### PR TITLE
Correct spelling of the test_fetch method in GitAPITestCase

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -85,7 +85,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue("unexpected status " + status, status.contains("working directory clean"));
     }
 
-    public void test_fecth() throws Exception {
+    public void test_fetch() throws Exception {
         launchCommand("git init");
         launchCommand("git remote add origin " + System.getProperty("user.dir")); // local git-plugin clone
         git.fetch("origin", null);


### PR DESCRIPTION
A minor spelling error in the name of the method which tests "git fetch".
