### PR TITLE
Improve Git polling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -326,12 +326,12 @@ public class CliGitAPIImpl implements GitClient {
     	StringWriter writer = new StringWriter();
 
     	if (from != null){
-    		writer.write(launchCommand("show", "--no-abbrev", "--format=raw", "-M", "--raw",
+    		writer.write(launchCommand("log", "--full-history", "--no-abbrev", "--format=raw", "-M", "-m", "--raw",
                     from.name() + ".." + to.name()));
-    		writer.write("\\n");
+        } else {
+    		writer.write(launchCommand("log", "--full-history", "--no-abbrev", "--format=raw", "-M", "-m", "--raw",
+                    "-1", to.name()));
     	}
-    	
-    	writer.write(launchCommand("whatchanged", "--no-abbrev", "-M", "-m", "--pretty=raw", "-1", to.name()));
 
         String result = writer.toString();
         List<String> revShow = new ArrayList<String>();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.gitclient;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import hudson.Launcher;
 import hudson.model.TaskListener;
@@ -15,6 +16,7 @@ import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
 
 import java.io.*;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -316,6 +318,64 @@ public abstract class GitAPITestCase extends TestCase {
         git.push("origin", "master");
         String remoteSha1 = launchCommand(remote, "git rev-parse master").substring(0, 40);
         assertEquals(sha1, remoteSha1);
+    }
+
+    public void test_show_revision_for_merge() throws Exception {
+        launchCommand("git init");
+        launchCommand("git fetch https://github.com/jenkinsci/git-client-plugin.git");
+        ObjectId from = ObjectId.fromString("45e76942914664ee19f31d90e6f2edbfe0d13a46");
+        ObjectId to = ObjectId.fromString("b53374617e85537ec46f86911b5efe3e4e2fa54b");
+
+        List<String> revisionDetails = git.showRevision(from, to);
+
+        Collection<String> commits = Collections2.filter(revisionDetails, new Predicate<String>() {
+            public boolean apply(String detail) {
+                return detail.startsWith("commit ");
+            }
+        });
+        assertEquals(3, commits.size());
+        assertTrue(commits.contains("commit 4f2964e476776cf59be3e033310f9177bedbf6a8"));
+        // Merge commit is duplicated as have to capture changes that may have been made as part of merge
+        assertTrue(commits.contains("commit b53374617e85537ec46f86911b5efe3e4e2fa54b (from 4f2964e476776cf59be3e033310f9177bedbf6a8)"));
+        assertTrue(commits.contains("commit b53374617e85537ec46f86911b5efe3e4e2fa54b (from 45e76942914664ee19f31d90e6f2edbfe0d13a46)"));
+
+        Collection<String> diffs = Collections2.filter(revisionDetails, new Predicate<String>() {
+            public boolean apply(String detail) {
+                return detail.startsWith(":");
+            }
+        });
+        Collection<String> paths = Collections2.transform(diffs, new Function<String, String>() {
+            public String apply(String diff) {
+                return diff.substring(diff.indexOf('\t')+1);
+            }
+        });
+
+        assertTrue(paths.contains(".gitignore"));
+        // Some irrelevant changes will be listed due to merge commit
+        assertTrue(paths.contains("pom.xml"));
+        assertTrue(paths.contains("src/main/java/hudson/plugins/git/GitAPI.java"));
+        assertTrue(paths.contains("src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java"));
+        assertTrue(paths.contains("src/main/java/org/jenkinsci/plugins/gitclient/Git.java"));
+        assertTrue(paths.contains("src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java"));
+        assertTrue(paths.contains("src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java"));
+        assertTrue(paths.contains("src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java"));
+        assertTrue(paths.contains("src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java"));
+        // Previous implementation included other commits, and listed irrelevant changes
+        assertFalse(paths.contains("README.md"));
+    }
+
+    public void test_show_revision_for_single_commit() throws Exception {
+        launchCommand("git init");
+        launchCommand("git fetch https://github.com/jenkinsci/git-client-plugin.git");
+        ObjectId to = ObjectId.fromString("51de9eda47ca8dcf03b2af58dfff7355585f0d0c");
+        List<String> revisionDetails = git.showRevision(null, to);
+        Collection<String> commits = Collections2.filter(revisionDetails, new Predicate<String>() {
+            public boolean apply(String detail) {
+                return detail.startsWith("commit ");
+            }
+        });
+        assertEquals(1, commits.size());
+        assertTrue(commits.contains("commit 51de9eda47ca8dcf03b2af58dfff7355585f0d0c"));
     }
 
     private String launchCommand(String args) throws IOException, InterruptedException {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
@@ -39,6 +39,8 @@ public class JGitAPIImplTest extends GitAPITestCase {
         suite.addTest(TestSuite.createTest(JGitAPIImplTest.class, "test_hasGitRepo_without_git_directory"));
         suite.addTest(TestSuite.createTest(JGitAPIImplTest.class, "test_hasGitRepo_with_invalid_git_repo"));
         suite.addTest(TestSuite.createTest(JGitAPIImplTest.class, "test_hasGitRepo_with_valid_git_repo"));
+        //suite.addTest(TestSuite.createTest(JGitAPIImplTest.class, "test_show_revision_for_merge"));
+        //suite.addTest(TestSuite.createTest(JGitAPIImplTest.class, "test_show_revision_for_single_commit"));
 
         return suite;
     }


### PR DESCRIPTION
Using "git show from..to" is not selecting the correct commits to calculate the changes.  This can be demonstrated by looking at the output of "git show git-client-1.0.3..git-client-1.0.4" on the "git-client-plugin" -- it includes the initial commit.

This has two effects.  The first is the polling was very slow in some cases, and the size of the output was large and the polling exhausted heap space.

I changed the implementation so that "git log" is used to determine the changes.  This appears to select the correct changes, and has a dramatically shorter execution time.

I built a copy of the plugin, and installed it on the Jenkins installation displaying problems.  Before this change, we had a job that would take 20 minutes, and then run out of heap space (it has infrequent builds compared to the rest of the repository).

> Started on 19-Mar-2013 17:05:07
> Using strategy: Default
> [poll] Last Built Revision: Revision 2b7fbea455c3905d5607b92966b61585d2a0504e (origin/blackpepper)
> Fetching changes from the remote Git repositories
> Polling for changes in
> FATAL: remote file operation failed: C:\Jenkins\workspace\log-auto at hudson.remoting.Channel@7e33df34:titan-desktop-2
> hudson.util.IOException2: remote file operation failed: C:\Jenkins\workspace\log-auto at hudson.remoting.Channel@7e33df34:titan-desktop-2
>   at hudson.FilePath.act(FilePath.java:848)
>   at hudson.FilePath.act(FilePath.java:834)
>   at hudson.plugins.git.GitSCM.compareRemoteRevisionWithImpl(GitSCM.java:706)
>   at hudson.plugins.git.GitSCM.compareRemoteRevisionWith(GitSCM.java:628)
>   at hudson.scm.SCM._compareRemoteRevisionWith(SCM.java:356)
>   at hudson.scm.SCM.poll(SCM.java:373)
>   at hudson.model.AbstractProject._poll(AbstractProject.java:1402)
>   at hudson.model.AbstractProject.poll(AbstractProject.java:1335)
>   at hudson.triggers.SCMTrigger$Runner.runPolling(SCMTrigger.java:420)
>   at hudson.triggers.SCMTrigger$Runner.run(SCMTrigger.java:449)
>   at hudson.util.SequentialExecutionQueue$QueueEntry.run(SequentialExecutionQueue.java:118)
>   at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:441)
>   at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
>   at java.util.concurrent.FutureTask.run(FutureTask.java:138)
>   at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
>   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
>   at java.lang.Thread.run(Thread.java:662)
> Caused by: java.io.IOException: Remote call on titan-desktop-2 failed
>   at hudson.remoting.Channel.call(Channel.java:681)
>   at hudson.FilePath.act(FilePath.java:841)
>   ... 16 more
> Caused by: java.lang.OutOfMemoryError: Java heap space
> Done. Took 20 min
> No changes

Subsequently, the polling log looks like:

> Started on 20-Mar-2013 09:49:13
> Using strategy: Default
> [poll] Last Built Revision: Revision 2b7fbea455c3905d5607b92966b61585d2a0504e (origin/blackpepper)
> Fetching changes from the remote Git repositories
> Fetching upstream changes from origin
> Polling for changes in
> Done. Took 18 sec
