### PR TITLE
Silencing the list of remote branches so it doesn't spam the console log

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -18,6 +18,7 @@ import org.eclipse.jgit.transport.RemoteConfig;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.text.MessageFormat;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -831,10 +832,19 @@ public class CliGitAPIImpl implements GitClient {
             for(Ref candidate : refs.values()) {
                 if(candidate.getName().startsWith(Constants.R_REMOTES)) {
                     Branch buildBranch = new Branch(candidate);
-                    listener.getLogger().println("Seen branch in repository " + buildBranch.getName());
+                    if (!GitClient.quietRemoteBranches) {
+                        listener.getLogger().println("Seen branch in repository " + buildBranch.getName());
+                    }
                     branches.add(buildBranch);
                 }
             }
+
+            if (branches.size() == 1) {
+                listener.getLogger().println("Seen 1 remote branch");
+            } else {
+                listener.getLogger().println(MessageFormat.format("Seen {0} remote branches", branches.size()));
+            }
+
             return branches;
         } finally {
             db.close();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -20,6 +20,9 @@ public interface GitClient {
 
     boolean verbose = Boolean.getBoolean(IGitAPI.class.getName() + ".verbose");
 
+    // If true, do not print the list of remote branches.
+    boolean quietRemoteBranches = Boolean.getBoolean(GitClient.class.getName() + ".quietRemoteBranches");
+
     /**
      * Expose the JGit repository this GitClient is using.
      * Don't forget to call {@link org.eclipse.jgit.lib.Repository#close()}, to avoid JENKINS-12188.


### PR DESCRIPTION
@ndeloof for review

Large git repositories with many developers can have hundreds of branches (multiple branches per developer), which makes it spammy to print them all out when fetching remote repositories.  This change just prints out the total number of branches, unless the user requests verbose output.
