### PR TITLE
Support multi-line commit messages for tags in the CLI implementation.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1025,8 +1025,10 @@ public class CliGitAPIImpl implements GitClient {
     }
 
     public String getTagMessage(String tagName) throws GitException {
-        String out = launchCommand("tag", "-l", tagName, "-n");
-        return out.substring(tagName.length()).trim();
+        // 10000 lines of tag message "ought to be enough for anybody"
+        String out = launchCommand("tag", "-l", tagName, "-n10000");
+        // Strip the leading four spaces which git prefixes multi-line messages with
+        return out.substring(tagName.length()).replaceAll("(?m)(^    )", "").trim();
     }
 
     public ObjectId getHeadRev(String remoteRepoUrl, String branch) throws GitException {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -264,6 +264,17 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals("this-is-a-test", git.getTagMessage("test"));
     }
 
+    public void test_get_tag_message_multi_line() throws Exception {
+        launchCommand("git init");
+        launchCommand("git commit --allow-empty -m init");
+        launchCommand("git", "tag", "test", "-m", "test 123!\n* multi-line tag message\n padded ");
+
+        // Leading four spaces from each line should be stripped,
+        // but not the explicit single space before "padded",
+        // and the final errant space at the end should be trimmed
+        assertEquals("test 123!\n* multi-line tag message\n padded", git.getTagMessage("test"));
+    }
+
     public void test_get_HEAD_revision() throws Exception {
         // TODO replace with an embedded JGit server so that test run offline ?
         String sha1 = launchCommand("git ls-remote --heads https://github.com/jenkinsci/git-client-plugin.git refs/heads/master").substring(0,40);
@@ -320,6 +331,10 @@ public abstract class GitAPITestCase extends TestCase {
 
     private String launchCommand(String args) throws IOException, InterruptedException {
         return launchCommand(repo, args);
+    }
+
+    private String launchCommand(String... args) throws IOException, InterruptedException {
+        return doLaunchCommand(repo, args);
     }
 
     private String launchCommand(File workdir, String args) throws IOException, InterruptedException {


### PR DESCRIPTION
Added support for returning the content of git tag commit messages which span multiple lines.

Added unit tests and verified both JGit and CLI work as expected.
