### PR TITLE
[FIXED JENKINS-18519] Add submodule reference parameter

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -130,6 +130,12 @@ public class GitAPI extends CliGitAPIImpl {
     */
 
     /*
+    public void submoduleUpdate(boolean recursive, String reference) throws GitException {
+        if (Git.USE_CLI) super.submoduleUpdate(recursive, String reference); else  jgit.submoduleUpdate(recursive, String reference);
+    }
+    */
+
+    /*
     public List<String> showRevision(ObjectId from, ObjectId to) throws GitException {
         return Git.USE_CLI ? super.showRevision(from, to) :  jgit.showRevision(from, to);
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -456,10 +456,23 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @throws GitException if executing the Git command fails
      */
     public void submoduleUpdate(boolean recursive) throws GitException, InterruptedException {
+        submoduleUpdate(recursive, null);
+    }
+
+    public void submoduleUpdate(boolean recursive, String reference) throws GitException, InterruptedException {
     	ArgumentListBuilder args = new ArgumentListBuilder();
     	args.add("submodule", "update");
     	if (recursive) {
             args.add("--init", "--recursive");
+        }
+        if (reference != null && !reference.equals("")) {
+            File referencePath = new File(reference);
+            if (!referencePath.exists())
+                listener.error("Reference path does not exist: " + reference);
+            else if (!referencePath.isDirectory())
+                listener.error("Reference path is not a directory: " + reference);
+            else
+                args.add("--reference", reference);
         }
 
         launchCommand(args);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -297,6 +297,8 @@ public interface GitClient {
 
     void submoduleUpdate(boolean recursive)  throws GitException, InterruptedException;
 
+    void submoduleUpdate(boolean recursive, String reference)  throws GitException, InterruptedException;
+
     void submoduleClean(boolean recursive)  throws GitException, InterruptedException;
 
     void submoduleInit()  throws GitException, InterruptedException;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -973,6 +973,10 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
     }
 
+    public void submoduleUpdate(boolean recursive, String reference) throws GitException {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
 
 
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -384,6 +384,10 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
         proxy.submoduleUpdate(recursive);
     }
 
+    public void submoduleUpdate(boolean recursive, String reference) throws GitException, InterruptedException {
+        proxy.submoduleUpdate(recursive, reference);
+    }
+
     public void submoduleClean(boolean recursive) throws GitException, InterruptedException {
         proxy.submoduleClean(recursive);
     }


### PR DESCRIPTION
Method `submoduleUpdate` should accept `reference` the same way as `clone` does.

```
git submodule update --init --recursive --reference $reference
```

Addresses https://issues.jenkins-ci.org/browse/JENKINS-18519
