### PR TITLE
as long as submodules are not supported, return false

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -605,7 +605,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     public boolean hasGitModules() throws GitException {
-        throw new UnsupportedOperationException("not implemented yet");
+//      throw new UnsupportedOperationException("not implemented yet");
+        // as long as we don't support submodules, we should just return false, because this method is called
+        return false;
     }
 
     public boolean hasGitRepo() throws GitException {


### PR DESCRIPTION
I did not open an issues, because this happens with the not yet published JGit support only.

As long as we don't support submodules with jgit (although I think jgit itself does) we should act on every repo as there would be no submodules.

btw. submodules are supported with jgit 3.0: http://download.eclipse.org/jgit/docs/jgit-3.0.0.201306101825-r/apidocs/index.html?org/eclipse/jgit/submodule/package-summary.html

Reproduce:
1. new maven project
2. configure git repo to checkout https://github.com/imod/dummy-tester/ (this repo has no submodules)
3. configure git-plugin to use jgit
4. trigger build

Started by user admin
[EnvInject] - Loading node environment variables.
Building on master in workspace /Users/Shared/Jenkins/Home/jobs/dummy-tester/workspace
Checkout:workspace / /Users/Shared/Jenkins/Home/jobs/dummy-tester/workspace - hudson.remoting.LocalChannel@7c46f6f0
Using strategy: Default
Cloning the remote Git repository
[WARNING] JGit doesn't support reference repository. This flag is ignored.
remote: Counting objects
remote: Compressing objects
Receiving objects
Resolving deltas
Updating references
Commencing build of Revision 21e56851816d83de61538df5292bcc848aea7c5e (origin/master)
Checking out Revision 21e56851816d83de61538df5292bcc848aea7c5e (origin/master)
FATAL: not implemented yet
java.lang.UnsupportedOperationException: not implemented yet
    at org.jenkinsci.plugins.gitclient.JGitAPIImpl.hasGitModules(JGitAPIImpl.java:608)
    at hudson.plugins.git.GitSCM$4.invoke(GitSCM.java:1239)
    at hudson.plugins.git.GitSCM$4.invoke(GitSCM.java:1213)
    at hudson.FilePath.act(FilePath.java:906)
    at hudson.FilePath.act(FilePath.java:879)
    at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1213)
    at hudson.model.AbstractProject.checkout(AbstractProject.java:1387)
    at hudson.model.AbstractBuild$AbstractBuildExecution.defaultCheckout(AbstractBuild.java:676)
    at jenkins.scm.SCMCheckoutStrategy.checkout(SCMCheckoutStrategy.java:88)
    at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:581)
    at hudson.model.Run.execute(Run.java:1593)
    at hudson.maven.MavenModuleSetBuild.run(MavenModuleSetBuild.java:491)
    at hudson.model.ResourceController.execute(ResourceController.java:88)
    at hudson.model.Executor.run(Executor.java:247)
