### PR TITLE
update jgit to latest release 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
-      <version>2.2.0.201212191850-r</version>
+      <version>3.0.0.201306101825-r</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -10,7 +10,7 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.kohsuke.stapler.framework.io.WriterOutputStream;
@@ -1056,7 +1056,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     public Repository getRepository() throws GitException {
         try {
-            return new FileRepository(new File(workspace, Constants.DOT_GIT));
+            return FileRepositoryBuilder.create(new File(workspace, Constants.DOT_GIT));
         } catch (IOException e) {
             throw new GitException("Failed to open Git repository " + workspace, e);
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.jgit.diff.DiffEntry.ChangeType;
 import org.eclipse.jgit.diff.RenameDetector;
 import org.eclipse.jgit.errors.InvalidPatternException;
 import org.eclipse.jgit.fnmatch.FileNameMatcher;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectReader;
@@ -35,7 +36,6 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.revwalk.filter.MaxCountRevFilter;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
 import org.eclipse.jgit.storage.file.FileBasedConfig;
-import org.eclipse.jgit.storage.file.FileRepository;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.FetchConnection;
 import org.eclipse.jgit.transport.RefSpec;
@@ -283,7 +283,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     public ObjectId getHeadRev(String remoteRepoUrl, String branch) throws GitException {
         try {
-            FileRepository repo = openDummyRepository();
+            Repository repo = openDummyRepository();
             final Transport tn = Transport.open(repo, new URIish(remoteRepoUrl));
             tn.setCredentialsProvider(provider);
             final FetchConnection c = tn.openFetch();
@@ -310,7 +310,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * Creates a empty dummy {@link Repository} to keep JGit happy where it wants a valid {@link Repository} operation
      * for remote objects.
      */
-    private FileRepository openDummyRepository() throws IOException {
+    private Repository openDummyRepository() throws IOException {
         final File tempDir = Util.createTempDir();
         return new FileRepository(tempDir) {
             @Override

--- a/src/test/java/org/jenkinsci/plugins/gitclient/trilead/TrileadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/trilead/TrileadTest.java
@@ -10,8 +10,8 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import hudson.util.StreamTaskListener;
 import org.eclipse.jgit.errors.UnsupportedCredentialItem;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.TextProgressMonitor;
-import org.eclipse.jgit.storage.file.FileRepository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.CredentialItem;
 import org.eclipse.jgit.transport.CredentialsProvider;
@@ -73,7 +73,7 @@ public class TrileadTest extends HudsonTestCase {
                 "git", new FileOnMasterPrivateKeySource("/home/kohsuke/.ssh/id_rsa"), System.getenv("TRILEAD_PASSPHRASE"), null);
         // TODO: it's very common for URI to override the user name
 
-        FileRepository b = new FileRepositoryBuilder().setWorkTree(new File("/tmp/foo")).build();
+        Repository b = new FileRepositoryBuilder().setWorkTree(new File("/tmp/foo")).build();
         Transport t = Transport.open(b, new URIish("ssh://git@github.com/cloudbees/ami-builder"));
         t.setCredentialsProvider(new CredentialsProviderImpl(StreamTaskListener.fromStdout(),sshCred));
         t.setDryRun(true);
@@ -125,7 +125,7 @@ public class TrileadTest extends HudsonTestCase {
             }
         });
 
-        FileRepository b = new FileRepositoryBuilder().setWorkTree(new File("/tmp/foo")).build();
+        Repository b = new FileRepositoryBuilder().setWorkTree(new File("/tmp/foo")).build();
         Transport t = Transport.open(b, new URIish("ssh://localhost/cloudbees/ami-builder.git"));
         t.setDryRun(true);
 
@@ -140,7 +140,7 @@ public class TrileadTest extends HudsonTestCase {
      */
     public static void usernamePassword(String[] args) throws Exception {
         CredentialsProvider cp = new UsernamePasswordCredentialsProvider(args[0],args[1]);
-        FileRepository b = new FileRepositoryBuilder().setWorkTree(new File("/tmp/foo")).build();
+        Repository b = new FileRepositoryBuilder().setWorkTree(new File("/tmp/foo")).build();
         Transport t = Transport.open(b, new URIish("https://github.com/cloudbees/ami-builder.git"));
         t.setCredentialsProvider(cp);
         t.setDryRun(true);


### PR DESCRIPTION
This PR updates jgit to its latest version.

jgit 3.0 moved the 'FileRepository' to an internal package, therefore refactored most of the code to use a 'Repository' only. 
The only place I did not do it is in 'JGitAPIImpl.openDummyRepository()', as there is an overwrite of close method done. 
