### PR TITLE
Making repository lock failure retryable

### DIFF
--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -63,7 +63,7 @@ public interface IGitAPI extends GitClient {
     List<ObjectId> revListBranch(String branchId) throws GitException, InterruptedException;
     List<Tag> getTagsOnCommit(String revName) throws GitException, IOException, InterruptedException;
     void changelog(String revFrom, String revTo, OutputStream fos) throws GitException, InterruptedException;
-    void checkoutBranch(String branch, String commitish) throws GitException, InterruptedException;
+    void checkoutBranch(String branch, String commitish) throws IOException, GitException, InterruptedException;
     ObjectId mergeBase(ObjectId sha1, ObjectId sha12) throws InterruptedException;
     List<String> showRevision(Revision r) throws GitException, InterruptedException;
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -875,7 +875,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         launchCommand("checkout", "-b", branch, ref);
     }
 
-    public void checkoutBranch(String branch, String ref) throws GitException, InterruptedException {
+    public void checkoutBranch(String branch, String ref) throws IOException, GitException, InterruptedException {
         try {
             // First, checkout to detached HEAD, so we can delete the branch.
             checkout(ref);
@@ -891,7 +891,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 checkout(ref, branch);
             }
         } catch (GitException e) {
-            throw new GitException("Could not checkout " + branch + " with start point " + ref, e);
+            // Throw IOException so the retry will be able to catch it
+            throw new IOException("Could not checkout " + branch + " with start point " + ref, e);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -139,7 +139,7 @@ public interface GitClient {
      * For compatibility reasons, the order of the parameter is different from {@link #checkout(String, String)}.
      * @since 1.0.6
      */
-    void checkoutBranch(String branch, String ref) throws GitException, InterruptedException;
+    void checkoutBranch(String branch, String ref) throws IOException, GitException, InterruptedException;
 
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.jgit.api.MergeResult;
 import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.ShowNoteCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.JGitInternalException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffEntry.ChangeType;
 import org.eclipse.jgit.diff.RenameDetector;
@@ -177,7 +178,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
     }
 
-    public void checkoutBranch(String branch, String ref) throws GitException {
+    public void checkoutBranch(String branch, String ref) throws IOException, GitException {
         try {
             RefUpdate refUpdate = db().updateRef(R_HEADS + branch);
             refUpdate.setNewObjectId(db().resolve(ref));
@@ -194,6 +195,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             checkout(ref);
         } catch (IOException e) {
             throw new GitException("Could not checkout " + branch + " with start point " + ref, e);
+        } catch (JGitInternalException e) {
+            // Throw IOException so the retry will be able to catch it
+            throw new IOException(e.getMessage());
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -261,7 +261,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
         proxy.checkout(ref, branch);
     }
 
-    public void checkoutBranch(String branch, String ref) throws GitException, InterruptedException {
+    public void checkoutBranch(String branch, String ref) throws IOException, GitException, InterruptedException {
         proxy.checkoutBranch(branch, ref);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -733,4 +733,18 @@ public abstract class GitAPITestCase extends TestCase {
         }
         return Util.join(names,",");
     }
+
+    public void test_checkoutBranchFailure() throws Exception {
+        w = clone(localMirror());
+        File lock = new File(w.repo, ".git/index.lock");
+        try {
+            FileUtils.touch(lock);
+            w.git.checkoutBranch("somebranch", "master");
+            fail();
+        } catch (IOException e) {
+            // expected
+        } finally {
+            lock.delete();
+        }
+    }
 }


### PR DESCRIPTION
In a shared workspace environment, git checkout occasionally fails because another concurrent build has lock on the git repository(.git/index.lock).
(e.g http://jenkins-ci.361315.n4.nabble.com/Git-index-lock-problem-on-a-common-directory-td4488918.html)
This change resolves this problem by throwing IOException on lock failure to make operation retryable.
