### PR TITLE
[FEATURE] Introduced reception of GIT_MERGE_FLAG

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -388,7 +388,15 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     public void merge(ObjectId rev) throws GitException, InterruptedException {
         try {
-            launchCommand("merge", rev.name());
+            String mergeFlag= environment.get("GIT_MERGE_FLAG");
+            listener.getLogger().println("Git-client-plugin: Received merge flag: "+ mergeFlag);
+            if ( mergeFlag==null || mergeFlag.equals("") ) {
+                listener.getLogger().println("Git-client-plugin: Merge flag invalid. Performing flagless merge.");
+                launchCommand("merge", rev.name());
+            } else {
+                listener.getLogger().println("Git-client-plugin: Passing merge flag to Git.");
+                launchCommand("merge", mergeFlag , rev.name());
+            }
         } catch (GitException e) {
             throw new GitException("Could not merge " + rev, e);
         }


### PR DESCRIPTION
This patch reads the the env. variable GIT_MERGE_FLAG
and passes its contained string to the git merge command
(null and "" being ignored)
A further patch to validate the flag is strongly recommended
for security reasons. I leave this to the project maintainers.
