### PR TITLE
Search _netrc file (Windows variant) in home directory.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1453,7 +1453,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     private Credentials getCredentialsFromNetrc(String host) {
         File home = new File(System.getProperty("user.home"));
         File netrc = new File(home, ".netrc");
-        if (!netrc.exists()) netrc = new File("_netrc"); // windows variant
+        if (!netrc.exists()) netrc = new File(home, "_netrc"); // windows variant
         if (!netrc.exists()) return null;
 
         BufferedReader r = null;


### PR DESCRIPTION
This patch searches the _netrc file, commonly used under Windows, in the
user.home directory, instead of the current working directory.

This patch would fix JENKINS-20688
