### PR TITLE
Correct 2 javadoc warnings in Apache EasySSLProtocolSocketFactory

### DIFF
--- a/src/main/java/org/apache/commons/httpclient/contrib/ssl/EasySSLProtocolSocketFactory.java
+++ b/src/main/java/org/apache/commons/httpclient/contrib/ssl/EasySSLProtocolSocketFactory.java
@@ -159,8 +159,8 @@ public class EasySSLProtocolSocketFactory implements SecureProtocolSocketFactory
      *
      * @param host the host name/IP
      * @param port the port on the host
-     * @param clientHost the local host name/IP to bind the socket to
-     * @param clientPort the port on the local machine
+     * @param localAddress the local address to bind the socket to
+     * @param localPort the port on the local machine
      * @param params {@link HttpConnectionParams Http connection parameters}
      *
      * @return Socket a new socket


### PR DESCRIPTION
If you're intentionally keeping the EasySSL implementation consistent with upstream, then it is probably best to reject this pull request.
