### PR TITLE
Fix javadoc warnings from addCredentials references

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -68,7 +68,7 @@ public interface GitClient {
      * Adds credentials to be used when there are not url specific credentials defined.
      *
      * @param credentials the credentials to use.
-     * @see {@link #addCredentials(String, com.cloudbees.plugins.credentials.common.StandardCredentials)}
+     * @see #addCredentials(String, com.cloudbees.plugins.credentials.common.StandardCredentials)
      * @since 1.2.0
      */
     void addDefaultCredentials(StandardCredentials credentials);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/trilead/SmartCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/trilead/SmartCredentialsProvider.java
@@ -55,7 +55,7 @@ public class SmartCredentialsProvider extends CredentialsProvider {
      * Adds credentials to be used when there are not url specific credentials defined.
      *
      * @param credentials the credentials to use.
-     * @see {@link #addCredentials(String, com.cloudbees.plugins.credentials.common.StandardCredentials)}
+     * @see #addCredentials(String, com.cloudbees.plugins.credentials.common.StandardCredentials)
      * @since 1.2.0
      */
     public synchronized void addDefaultCredentials(StandardCredentials credentials) {


### PR DESCRIPTION
The @link references are not needed, since @see already implies that the referenced API will be a hyperlink
