### PR TITLE
Throw GitLockFailedException on repository lock failure

### DIFF
--- a/src/main/java/hudson/plugins/git/GitLockFailedException.java
+++ b/src/main/java/hudson/plugins/git/GitLockFailedException.java
@@ -1,0 +1,21 @@
+package hudson.plugins.git;
+
+public class GitLockFailedException extends GitException {
+    private static final long serialVersionUID = 1L;
+
+    public GitLockFailedException() {
+        super();
+    }
+
+    public GitLockFailedException(String message) {
+        super(message);
+    }
+
+    public GitLockFailedException(Throwable cause) {
+        super(cause);
+    }
+
+    public GitLockFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -14,6 +14,7 @@ import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
 import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
@@ -1227,7 +1228,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 checkout(ref, branch);
             }
         } catch (GitException e) {
-            throw new GitException("Could not checkout " + branch + " with start point " + ref, e);
+            if (Pattern.compile("index\\.lock").matcher(e.getMessage()).find()) {
+                throw new GitLockFailedException("Could not lock repository. Please try again", e);
+            } else {
+                throw new GitException("Could not checkout " + branch + " with start point " + ref, e);
+            }
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -8,6 +8,7 @@ import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
 import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
 import hudson.util.IOUtils;
@@ -183,7 +184,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 throw new GitException("Could not checkout " + ref, e);
             } catch (JGitInternalException e) {
                 if (Pattern.matches("Cannot lock.+", e.getMessage())){
-                    throw new GitException("Could not checkout " + ref, e);
+                    throw new GitLockFailedException("Could not lock repository. Please try again", e);
                 } else {
                     throw e;
                 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -8,6 +8,7 @@ import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
 import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.IndexEntry;
 import hudson.util.StreamTaskListener;
@@ -1041,7 +1042,7 @@ public abstract class GitAPITestCase extends TestCase {
             FileUtils.touch(lock);
             w.git.checkoutBranch("somebranch", "master");
             fail();
-        } catch (GitException e) {
+        } catch (GitLockFailedException e) {
             // expected
         } finally {
             lock.delete();


### PR DESCRIPTION
Refs #17, #31, jenkinsci/git-plugin#177
This modification tries to throw GitLockFailedException when a concurrent build has a lock file on the repository, and should reflect @ndeloof 's [initial suggestion](https://github.com/jenkinsci/git-client-plugin/pull/17#commitcomment-3888726), which I could not get it at a first glance.

Sorry to bother you repeatedly. I'd happy to make modifications if problem still exists.
Thanks!
