### PR TITLE
[JENKINS-21016] Remove credential section as helper is a property within the credential section.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -992,9 +992,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             if (store != null) {
                 store.delete();
                 try {
-                    launchCommandIn(workDir, "config", "--local", "--remove-section", "credential.helper");
+                    launchCommandIn(workDir, "config", "--local", "--remove-section", "credential");
                 } catch (GitException e) {
-                    listener.getLogger().println("Could not remove the credential.helper section from the git configuration");
+                    listener.getLogger().println("Could not remove the credential section from the git configuration");
                 }
             }
         }


### PR DESCRIPTION
[JENKINS-21016] correct remove-section.  The section is called credential rather than credential.helper e.g.:

C:\Users\test>git config --local --list
credential.helper=store --file="c:\creden.txt"

C:\Users\test>git config --local --remove-section credential.helper
fatal: No such section!

C:\Users\test>git config --local --remove-section credential

C:\Users\test>git config --local --list
