### PR TITLE
fix workDir argument. change public to private

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -927,11 +927,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return launchCommand(new ArgumentListBuilder(args));
     }
 
-    public String launchCommandIn(File workDir, String... args) throws GitException, InterruptedException {
-        return launchCommandIn(new ArgumentListBuilder(args), workspace);
-    }
-
-
     private String launchCommandWithCredentials(ArgumentListBuilder args, File workDir,
                                                 StandardCredentials credentials,
                                                 @NonNull String url) throws GitException, InterruptedException {
@@ -1074,6 +1069,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         w.close();
         ssh.setExecutable(true);
         return ssh;
+    }
+
+    private String launchCommandIn(File workDir, String... args) throws GitException, InterruptedException {
+        return launchCommandIn(new ArgumentListBuilder(args), workDir);
     }
 
     private String launchCommandIn(ArgumentListBuilder args, File workDir) throws GitException, InterruptedException {


### PR DESCRIPTION
workDir argument is not used, and I thought this method should be private.

Please review this commit.
