### PR TITLE
Fix windows test failure in test_show_revision_for_merge

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -711,7 +711,7 @@ public abstract class GitAPITestCase extends TestCase {
         });
         Collection<String> paths = Collections2.transform(diffs, new Function<String, String>() {
             public String apply(String diff) {
-                return diff.substring(diff.indexOf('\t')+1);
+                return diff.substring(diff.indexOf('\t')+1).trim(); // Windows diff output ^M removed by trim()
             }
         });
 


### PR DESCRIPTION
The test_show_revision_for_merge fails on Windows with the JGit implementation.  It succeeds on Windows with the CLI implementation and it succeeds on Linux with both implementations.

This change removes a trailing ^M character from the file name which is collected from diff output during test execution.  The JGit diff output includes the ^M character in the file name, while the other three configurations do not.

Since the diff output comparison is internal to the test, I assume that it is better to fix the test infrastructure than to attempt a change to the JGit diff output on Windows.
