### PR TITLE
fix credential store filepath

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -978,7 +978,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                     String urlWithCredentials = getGitCredentialsURL(url, credentials);
                     store = createGitCredentialsStore(urlWithCredentials);
-                    launchCommandIn(workDir, "config", "--local", "credential.helper", "store --file=\\\"" + store.getAbsolutePath() + "\\\"");
+                    launchCommandIn(workDir, "config", "--local", "credential.helper", "store --file=\"" + store.getAbsolutePath() + "\"");
                 }
             }
 


### PR DESCRIPTION
[JENKINS-21016]
I encountered related issue with Atlassian Stash 2.10.0 repository.

```
fatal: could not read Username for 'https://myrepo': No such device or address
```

I think git cannot read credential temp file in.git/config.
So I fixed this problem and tested on below environments.
- CentOS 6.4, git 1.8.5.2 and Jenkins 1.544
- Mac OS X 10.9, git 1.8.3.4 (Apple Git-47) and Jenkins 1.544

Please review it.
