### PR TITLE
Fix JGit test_show_revision_for_merge - line ending sanitization

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -711,7 +711,7 @@ public abstract class GitAPITestCase extends TestCase {
         });
         Collection<String> paths = Collections2.transform(diffs, new Function<String, String>() {
             public String apply(String diff) {
-                return diff.substring(diff.indexOf('\t')+1);
+                return diff.substring(diff.indexOf('\t')+1).trim(); // Windows diff output ^M removed by trim()
             }
         });
 


### PR DESCRIPTION
The test_show_revision_for_merge fails on the JGit implementation on
Windows, but runs successfully on Linux. The same test runs
successfully on both JGit and C Git on Windows and Linux.

The difference seems to be in line ending handling in the diff output
from JGit on Windows.  The output includes the \r character in
addition to the \n character.  Rather than attempt to modify the
output of JGit for Windows, this change adapts the test to that output
difference by removing the leading and trailing white space characters
from the file name in the transformed diff output that is created
during test execution.

This does not alter the behavior of the production code.
