### PR TITLE
[JENKINS-19994] jgit close files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -84,4 +84,17 @@ public interface ChangelogCommand extends GitCommand {
      * Limit the number of changelog entry up to N.
      */
     ChangelogCommand max(int n);
+
+    /**
+     * Abort this ChangelogCommand without executing it, close any
+     * open resources.  The JGit implementation of changelog
+     * calculation opens the git repository and will close it when the
+     * changelog.execute() is processed.  However, there are cases
+     * (like GitSCM.computeChangeLog) which create a changelog and
+     * never call execute().
+     *
+     * Either execute() or abort() must be called for each
+     * ChangelogCommand instance or files will be left open.
+     */
+    void abort();
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -502,6 +502,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public void abort() {
+                /* No cleanup needed to abort the CliGitAPIImpl ChangelogCommand */
+            }
+
             public void execute() throws GitException, InterruptedException {
                 ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "whatchanged", "--no-abbrev", "-M", "--pretty=raw");
                 if (n!=null)

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -683,10 +683,22 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            private void closeResources() {
+                walk.dispose();
+                or.release();
+                repo.close();
+            }
+
+            public void abort() {
+                closeResources();
+            }
+
             /** Execute the changelog command.  Assumed that this is
              * only performed once per instance of this object.
              * Resources opened by this ChangelogCommand object are
-             * closed at exit from the execute method.
+             * closed at exit from the execute method.  Either execute
+             * or abort must be called for each ChangelogCommand or
+             * files will remain open.
              */
             public void execute() throws GitException, InterruptedException {
                 PrintWriter pw = new PrintWriter(out,false);
@@ -701,10 +713,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 } catch (IOException e) {
                     throw new GitException(e);
                 } finally {
+                    closeResources();
                     pw.flush();
-                    walk.dispose();
-                    or.release();
-                    repo.close();
                 }
             }
         };


### PR DESCRIPTION
The JGit implementation leaves files open in the git repository.  That prevents deletion of the workspace as described in JENKINS-19994 and elsewhere.

In order to close the open files from the existing use cases for ChangelogCommand, the ChangelogCommand had to be extended to include an abort() method.  Either the abort() method or the execute() method must be called for each ChangelogCommand in order to close files opened by JGit.
