### PR TITLE
Provide a more detailed error message when an SSLException occurs on checkout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -57,6 +57,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.net.ssl.SSLException;
 
 import static org.apache.commons.httpclient.params.HttpMethodParams.USER_AGENT;
 
@@ -1619,6 +1620,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 throw new GitException("Failed to connect to " + u.toString()
                     + (cred != null ? " using credentials " + cred.getDescription() : "" )
                     + " (status = "+status+")");
+        } catch (SSLException e) {
+            throw new GitException(e.getLocalizedMessage());
         } catch (IOException e) {
             throw new GitException("Failed to connect to " + u.toString()
                     + (cred != null ? " using credentials " + cred.getDescription() : "" ));


### PR DESCRIPTION
When you checkout a repository with a ssl secured and there is a problem with the truststore etc. the displayed error message is not enough to determine that there is a problem with the certificates:

Error message now:
Failed to connect to https://domain.com/git/repository.git using credentials Gitblit user account

Error message after change (e.g. when there is no certificate in truststore):
sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
