### PR TITLE
Add shallow submodule init support.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -138,6 +138,12 @@ public class GitAPI extends CliGitAPIImpl {
     */
 
     /*
+    public void submoduleUpdate(boolean recursive, boolean shallow, String reference) throws GitException {
+        if (Git.USE_CLI) super.submoduleUpdate(recursive, shallow, reference); else  jgit.submoduleUpdate(recursive, shallow, reference);
+    }
+    */
+
+    /*
     public List<String> showRevision(ObjectId from, ObjectId to) throws GitException {
         return Git.USE_CLI ? super.showRevision(from, to) :  jgit.showRevision(from, to);
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -575,10 +575,24 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     public void submoduleUpdate(boolean recursive, String reference) throws GitException, InterruptedException {
+        submoduleUpdate(recursive, false, null);
+    }
+
+    /**
+     * Reset submodules
+     *
+     * @param shallow if true, will shallow update (requres git>=1.8.4)
+     *
+     * @throws GitException if executing the git command fails
+     */
+    public void submoduleUpdate(boolean recursive, boolean shallow, String reference) throws GitException, InterruptedException {
     	ArgumentListBuilder args = new ArgumentListBuilder();
     	args.add("submodule", "update");
     	if (recursive) {
             args.add("--init", "--recursive");
+        }
+        if (shallow) {
+            args.add("--depth=1");
         }
         if (reference != null && !reference.equals("")) {
             File referencePath = new File(reference);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -312,6 +312,8 @@ public interface GitClient {
 
     void submoduleUpdate(boolean recursive, String reference)  throws GitException, InterruptedException;
 
+    void submoduleUpdate(boolean recursive, boolean shallow, String reference)  throws GitException, InterruptedException;
+
     void submoduleClean(boolean recursive)  throws GitException, InterruptedException;
 
     void submoduleInit()  throws GitException, InterruptedException;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1255,6 +1255,10 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         throw new UnsupportedOperationException("not implemented yet");
     }
 
+    public void submoduleUpdate(boolean recursive, boolean shallow, String reference) throws GitException {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
 
 
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -416,6 +416,10 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
         proxy.submoduleUpdate(recursive, reference);
     }
 
+    public void submoduleUpdate(boolean recursive, boolean shallow, String reference) throws GitException, InterruptedException {
+        proxy.submoduleUpdate(recursive, shallow, reference);
+    }
+
     public void submoduleClean(boolean recursive) throws GitException, InterruptedException {
         proxy.submoduleClean(recursive);
     }


### PR DESCRIPTION
As you know, recent git (since 1.8.x) supports shallow submodule cloning.
This patch is just to add API method.
I'll send pull requests to git-plugin after this patch was approved.
