### PR TITLE
fixed JENKINS-21116

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1116,7 +1116,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             args.add(refspec);
         }
 
-        StandardCredentials cred = credentials.get(url);
+        StandardCredentials cred = credentials.get(url.toPrivateString());
         if (cred == null) cred = defaultCredentials;
         launchCommandWithCredentials(args, workspace, cred, url);
         // Ignore output for now as there's many different formats


### PR DESCRIPTION
The problem is, that credentials is a `Map<String, StandardCredentials>` and in `push(URIish url, String refspec)`, url is an `URIish`. So the map lookup isn't working.

Not sure why the compiler does not complain about that. Maybe an compiler configuration thing...
