### PR TITLE
Add test that working directory is as expected for test success

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -316,6 +316,7 @@ public abstract class GitAPITestCase extends TestCase {
 
     public void test_clone_reference_working_repo() throws IOException, InterruptedException
     {
+        assertTrue("SRC_DIR " + SRC_DIR + " has no .git subdir", (new File(SRC_DIR + File.separator + ".git").isDirectory()));
         w.git.clone_().url(localMirror()).repositoryName("origin").reference(SRC_DIR).execute();
         if (w.git instanceof CliGitAPIImpl) {
             w.git.setRemoteUrl("origin", localMirror());
@@ -659,6 +660,18 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals(sha1, w.git.revParse(sha1).name());
         assertEquals(sha1, w.git.revParse("HEAD").name());
         assertEquals(sha1, w.git.revParse("test").name());
+    }
+
+    public void test_revparse_throws_expected_exception() throws Exception {
+        w.init();
+        w.commit("init");
+        try {
+            w.git.revParse("unknown-rev-to-parse");
+            fail("Did not throw exception");
+        } catch (GitException ge) {
+            final String msg = ge.getMessage();
+            assertTrue("Wrong exception: " + msg, msg.contains("unknown-rev-to-parse"));
+        }
     }
 
     public void test_hasGitRepo_without_git_directory() throws Exception


### PR DESCRIPTION
Some of the GitAPITestCase tests need to copy a git repository.  This
test asserts that a git repository is available directly in the
expected location in the working directory of the build.

Also adds a test of a rev-parse exception case
