### PR TITLE
Update dependencies, except Google guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,19 +71,19 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
-      <version>1.3</version>
+      <version>1.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>2.0.1</version>
+      <version>2.0.3</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.5.1</version>
+      <version>1.6</version>
     </dependency>
 
     <dependency>
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.8</version>
+      <version>1.9</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Updating the Google guava dependency to the latest version (16.0) from
the current version (r9) is a multi-year step in versions and breaks
tests.
