### PR TITLE
Update guava to 11.0.1 - match the version used by git-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>r09</version>
+      <version>11.0.1</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
The latest guava version (16.0) causes test failures, so cannot be
used yet.  This version is consistent with the version used by
git-plugin which may avoid silent incompatibilities between the two
plugins.
