### PR TITLE
Only attempt to create Git credentials when a workspace dir is present.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -962,7 +962,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             if ("http".equalsIgnoreCase(url.getScheme()) || "https".equalsIgnoreCase(url.getScheme())) {
                 checkCredentials(url, credentials);
 
-                if (credentials != null) {
+                if (credentials != null && workDir != null) {
                     listener.getLogger().println("using .gitcredentials to set credentials");
 
                     String urlWithCredentials = getGitCredentialsURL(url, credentials);
@@ -979,7 +979,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             if (pass != null) pass.delete();
             if (key != null) key.delete();
             if (ssh != null) ssh.delete();
-            if (store != null) {
+            if (store != null && workDir != null) {
                 store.delete();
                 try {
                     launchCommandIn(workDir, "config", "--local", "--remove-section", "credential");


### PR DESCRIPTION
This command is used during form validation and launching a Git command.  The problem
is that for HTTP-based URLs during the form validation, there's no workspace directory.
As a result, the credentials store is attempted to created in the directory in which
Jenkins was started (i.e. /), causing accesses to .git/config, which are done when
storing credential files, to fail.

See: https://issues.jenkins-ci.org/browse/JENKINS-21016
