### PR TITLE
Invalid credentials vs. bad hostnames are hard to differentiate right now.  Exposing the stack trace error to provide more context.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1621,7 +1621,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             throw new GitException(e.getLocalizedMessage());
         } catch (IOException e) {
             throw new GitException("Failed to connect to " + u.toString()
-                    + (cred != null ? " using credentials " + cred.getDescription() : "" ));
+                    + (cred != null ? " using credentials " + cred.getDescription() : "" )
+                    + " (exception: " + e + ")" );
         } catch (IllegalArgumentException e) {
             throw new GitException("Invalid URL " + u.toString());
         }


### PR DESCRIPTION
Invalid credentials vs. bad hostnames are hard to differentiate right now. Exposing the stack trace error to provide more context.
