### PR TITLE
Add bare option to GitAPITestCase init method, use to simplify test_push

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -88,6 +88,15 @@ public abstract class GitAPITestCase extends TestCase {
             return this;
         }
 
+        WorkingArea init(boolean bare) throws IOException, InterruptedException {
+            if (bare) {
+                cmd("git init --bare");
+            } else {
+                init();
+            }
+            return this;
+        }
+
         void add(String path) throws IOException, InterruptedException {
             cmd("git add " + path);
         }
@@ -727,8 +736,7 @@ public abstract class GitAPITestCase extends TestCase {
         ObjectId sha1 = w.head();
 
         WorkingArea r = new WorkingArea();
-        r.init();
-        r.cmd("git checkout -b tmp"); // can't push on active branch
+        r.init(true);
         w.cmd("git remote add origin " + r.repoPath());
 
         w.git.push("origin", "master");
@@ -860,7 +868,7 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_prune() throws Exception {
         // pretend that 'r' is a team repository and ws1 and ws2 are team members
         WorkingArea r = new WorkingArea();
-        r.cmd("git init --bare");
+        r.init(true);
 
         WorkingArea ws1 = new WorkingArea().init();
         WorkingArea ws2 = w.init();


### PR DESCRIPTION
The test_push fails on Red Hat Linux 6 because Git 1.7.1 version
behaves differently than more recent versions.  Git 1.7.1 reports "You
are on a branch yet to be born" when attempting to checkout a branch
from a freshly initialized git repository.  Checkout of a new branch
on an empty repository is quite a corner case, and there is little
motivation to fix that, since later git versions do not show the same
problem.

Switching test_push to push to a bare repository seems more likely as
a scenario for push testing anywway, since most writers agree that
pushing to a working repository has several problems.
