### PR TITLE
Fix HTTP-based credentials issues during form validation.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -967,6 +967,17 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                     String urlWithCredentials = getGitCredentialsURL(url, credentials);
                     store = createGitCredentialsStore(urlWithCredentials);
+
+                    // Create a temporary workspace directory in the event that no
+                    // workspace has been created.  Call git init to allow for
+                    // credentials to be stored here during execution for HTTP-based
+                    // form validation.
+                    // See https://issues.jenkins-ci.org/browse/JENKINS-21016
+                    if (workDir == null) {
+                        workDir = store.getParentFile();
+                        launchCommandIn(workDir, "init");
+                    }
+
                     String fileStore = launcher.isUnix() ? store.getAbsolutePath() : "\\\"" + store.getAbsolutePath() + "\\\"";
                     launchCommandIn(workDir, "config", "--local", "credential.helper", "store --file=" + fileStore);
                 }


### PR DESCRIPTION
Fix form validation for HTTP-based Git repos by creating a temporary workspace using the same directory used to store the credentials.
