### PR TITLE
Reduce output for successful GitAPITestCase calls

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -74,8 +74,7 @@ public abstract class GitAPITestCase extends TestCase {
             int st = new Launcher.LocalLauncher(listener).launch().pwd(repo).cmds(args).
                     envs(env).stdout(out).join();
             String s = out.toString();
-            assertEquals(s, 0, st);
-            System.out.println(s);
+            assertEquals(s, 0, st); /* Reports full output of failing commands */
             return s;
         }
 


### PR DESCRIPTION
Still displays the command which is being executed, but does not
display the results of the command, if the command was successful.
