### PR TITLE
Set remote URL in CliGit clone method, match JGit and command line

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -262,7 +262,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     public CloneCommand clone_() {
         return new CloneCommand() {
             String url;
-            String origin;
+            String origin = "origin";
             String reference;
             boolean shallow,shared;
 			Integer timeout;
@@ -357,6 +357,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         .shallow(shallow)
                         .timeout(timeout)
                         .execute();
+                setRemoteUrl(origin, url);
             }
 
         };

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -178,7 +178,6 @@ public abstract class GitAPITestCase extends TestCase {
          */
         void adaptCliGitClone(String repoName) throws IOException, InterruptedException {
             if (git instanceof CliGitAPIImpl) {
-                git.setRemoteUrl(repoName, localMirror());
                 git.checkout(repoName + "/master", "master");
             }
         }
@@ -397,8 +396,7 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_getRemoteURL_two_args() throws Exception {
         w.init();
         String originUrl = "https://github.com/bogus/bogus.git";
-        w.cmd("git remote add origin " + originUrl);
-        // w.git.setRemoteUrl("origin", originUrl);
+        w.git.setRemoteUrl("origin", originUrl);
         assertEquals("Wrong remote URL", originUrl, w.git.getRemoteUrl("origin"));
         assertEquals("Wrong null remote URL", originUrl, w.igit().getRemoteUrl("origin", null));
         assertEquals("Wrong blank remote URL", originUrl, w.igit().getRemoteUrl("origin", ""));


### PR DESCRIPTION
The CliGit clone_ method is implemented internally as fetch plus merge,
so that credentials can be used with command line git.  Unfortunately,
that means the results of CliGit clone_ are not the same as command line
git clone, and not the same as JGit clone.

This change sets the remote URL so that CliGit and JGit are the same in
that area.

This does not perform a checkout of the master branch after the clone,
since the typical consumers of a clone will perform their own checkout
of a specific SHA1.
