### PR TITLE
Master findbugs fix npe warnings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -806,7 +806,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             // In these cases, origin is null and it's best to just exit early.
             return;
         } catch (Exception e) {
-            throw new GitException("Could determine remote.origin.url", e);
+            throw new GitException("Could not determine remote." + remote + ".url", e);
         }
 
         if ( origin.getScheme() == null ||


### PR DESCRIPTION
The findbugs annotation @CheckForNull correctly causes findbugs reports for
references to the return value of that method.  If that method returns null, a null
pointer exception will be generated without these safeguards.

The safeguards generally throw a GitException with a message rather than 
throwing a null pointer exception
