### PR TITLE
Pass submodule reset as a single argument to foreach

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -635,10 +635,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         if (recursive) {
             args.add("--recursive");
         }
-        args.add("git reset");
-        if (hard) {
-            args.add("--hard");
-        }
+        args.add("git reset" + (hard ? " --hard" : ""));
 
         launchCommand(args);
     }


### PR DESCRIPTION
In Git 1.9 the submodule foreach command executes the passed command as <code>"$@"</code> or <code>eval "$1"</code>, not <code>eval "$@"</code> like in 1.8. Therefore the current <code>git reset --hard</code> will be interpreted as "git reset" --hard, resulting this error:
<code>
FATAL: Command "git submodule foreach --recursive git reset --hard" returned status code 1:
...
stderr: /usr/lib/git-core/git-submodule: 1409: git reset: not found
</code>
