### PR TITLE
Sync jenkins dependency with git plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,6 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Git+Client+Plugin</url>
 
   <properties>
-    <maven.compiler.source>1.5</maven.compiler.source>
-    <maven.compiler.target>1.5</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>


### PR DESCRIPTION
My first attempt to write a credentials test failed because Jenkins 1.480 would crash the trivial test at runtime.  When I switched to Jenkins 1.509, the test passed.  Since the git-plugin is already based on 1.509 and the primary consumer of git-client-plugin is the git-plugin, I think we should update the base Jenkins version of the git-client-plugin from 1.480 to 1.509.

The second change removes the JDK 1.5 property, since Jenkins now requires at least JDK 1.6 for Jenkins core.

Are there critical reasons why we should not update the Jenkins core dependency from 1.480 to 1.509?
