### PR TITLE
Fix possible missing .git/info path for sparse checkout feature

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -94,6 +94,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private static final long serialVersionUID = 1;
+    static final String SPARSE_CHECKOUT_FILE_DIR = ".git/info";
     static final String SPARSE_CHECKOUT_FILE_PATH = ".git/info/sparse-checkout";
     transient Launcher launcher;
     TaskListener listener;
@@ -1338,6 +1339,13 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     paths = Lists.newArrayList("/*");
                 } else if(! coreSparseCheckoutConfigEnable) { // activating sparse checkout
                     launchCommand( "config", "core.sparsecheckout", "true" );
+                }
+
+                File sparseCheckoutDir = new File(workspace, SPARSE_CHECKOUT_FILE_DIR);
+                if(! sparseCheckoutDir.exists()) {
+                    if(! sparseCheckoutDir.mkdir()) {
+                        throw new GitException("Impossible to create sparse checkout dir " + sparseCheckoutDir.getAbsolutePath());
+                    }
                 }
 
                 File sparseCheckoutFile = new File(workspace, SPARSE_CHECKOUT_FILE_PATH);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1207,7 +1207,8 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.commit("commit");
 
         // Clone it
-        WorkingArea workingArea = clone(w.repoPath());
+        WorkingArea workingArea = new WorkingArea();
+        workingArea.git.clone_().url(w.repoPath()).execute();
 
         workingArea.git.checkout().ref("origin/master").branch("master").deleteBranchIfExist(true).sparseCheckoutPaths(Lists.newArrayList("dir1")).execute();
         assertTrue(workingArea.exists("dir1"));


### PR DESCRIPTION
In order to avoid a missing path depending on the cloning method and git templates
