### PR TITLE
Changed abstract class CheckoutCommand to an interface

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
@@ -6,30 +6,13 @@ import java.util.List;
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public abstract class CheckoutCommand implements GitCommand {
+public interface CheckoutCommand extends GitCommand {
 
-    public String ref;
-    public String branch;
-    public boolean deleteBranch;
-    public List<String> sparseCheckoutPaths = Collections.emptyList();
+    CheckoutCommand ref(String ref);
 
-    public CheckoutCommand ref(String ref) {
-        this.ref = ref;
-        return this;
-    }
+    CheckoutCommand branch(String branch);
 
-    public CheckoutCommand branch(String branch) {
-        this.branch = branch;
-        return this;
-    }
+    CheckoutCommand deleteBranchIfExist(boolean deleteBranch);
 
-    public CheckoutCommand deleteBranchIfExist(boolean deleteBranch) {
-        this.deleteBranch = deleteBranch;
-        return this;
-    }
-
-    public CheckoutCommand sparseCheckoutPaths(List<String> sparseCheckoutPaths) {
-        this.sparseCheckoutPaths = sparseCheckoutPaths == null ? Collections.<String>emptyList() : sparseCheckoutPaths;
-        return this;
-    }
+    CheckoutCommand sparseCheckoutPaths(List<String> sparseCheckoutPaths);
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1311,6 +1311,31 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     public CheckoutCommand checkout() {
         return new CheckoutCommand() {
 
+            public String ref;
+            public String branch;
+            public boolean deleteBranch;
+            public List<String> sparseCheckoutPaths = Collections.emptyList();
+
+            public CheckoutCommand ref(String ref) {
+                this.ref = ref;
+                return this;
+            }
+
+            public CheckoutCommand branch(String branch) {
+                this.branch = branch;
+                return this;
+            }
+
+            public CheckoutCommand deleteBranchIfExist(boolean deleteBranch) {
+                this.deleteBranch = deleteBranch;
+                return this;
+            }
+
+            public CheckoutCommand sparseCheckoutPaths(List<String> sparseCheckoutPaths) {
+                this.sparseCheckoutPaths = sparseCheckoutPaths == null ? Collections.<String>emptyList() : sparseCheckoutPaths;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 try {
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -161,6 +161,31 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     public CheckoutCommand checkout() {
         return new CheckoutCommand() {
 
+            public String ref;
+            public String branch;
+            public boolean deleteBranch;
+            public List<String> sparseCheckoutPaths = Collections.emptyList();
+
+            public CheckoutCommand ref(String ref) {
+                this.ref = ref;
+                return this;
+            }
+
+            public CheckoutCommand branch(String branch) {
+                this.branch = branch;
+                return this;
+            }
+
+            public CheckoutCommand deleteBranchIfExist(boolean deleteBranch) {
+                this.deleteBranch = deleteBranch;
+                return this;
+            }
+
+            public CheckoutCommand sparseCheckoutPaths(List<String> sparseCheckoutPaths) {
+                this.sparseCheckoutPaths = sparseCheckoutPaths == null ? Collections.<String>emptyList() : sparseCheckoutPaths;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
 
                 if(! sparseCheckoutPaths.isEmpty()) {


### PR DESCRIPTION
Looks required in order to be proxyfied in git-plugin

org.jenkinsci.plugins.gitclient.CheckoutCommand is not an interface
    at java.lang.reflect.Proxy.getProxyClass0(Proxy.java:496)
    at java.lang.reflect.Proxy.newProxyInstance(Proxy.java:722)
    at org.jenkinsci.plugins.gitclient.RemoteGitImpl.command(RemoteGitImpl.java:112)
    at org.jenkinsci.plugins.gitclient.RemoteGitImpl.checkout(RemoteGitImpl.java:278)
    at hudson.plugins.git.GitSCM.checkout(GitSCM.java:889)
