### PR TITLE
Make SubmoduleUpdateCommand an interface

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -669,6 +669,25 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     public SubmoduleUpdateCommand submoduleUpdate() {
         return new SubmoduleUpdateCommand() {
+            boolean recursive       = false;
+            boolean remoteTracking  = false;
+            String  ref             = null;
+
+            public SubmoduleUpdateCommand recursive(boolean recursive) {
+                this.recursive = recursive;
+                return this;
+            }
+
+            public SubmoduleUpdateCommand remoteTracking(boolean remoteTracking) {
+                this.remoteTracking = remoteTracking;
+                return this;
+            }
+
+            public SubmoduleUpdateCommand ref(String ref) {
+                this.ref = ref;
+                return this;
+            }
+
             /**
              * @throws GitException if executing the Git command fails
              * @throws InterruptedException if called methods throw same exception

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1396,6 +1396,25 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     public SubmoduleUpdateCommand submoduleUpdate() {
         return new SubmoduleUpdateCommand() {
+            boolean recursive      = false;
+            boolean remoteTracking = false;
+            String  ref            = null;
+
+            public SubmoduleUpdateCommand recursive(boolean recursive) {
+                this.recursive = recursive;
+                return this;
+            }
+
+            public SubmoduleUpdateCommand remoteTracking(boolean remoteTracking) {
+                this.remoteTracking = remoteTracking;
+                return this;
+            }
+
+            public SubmoduleUpdateCommand ref(String ref) {
+                this.ref = ref;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 Repository repo = null;
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
@@ -1,19 +1,12 @@
 package org.jenkinsci.plugins.gitclient;
 
-public abstract class SubmoduleUpdateCommand implements GitCommand {
-    protected boolean recursive      = false;
-    protected boolean remoteTracking = false;
-    protected String  ref            = null;
-
+public interface SubmoduleUpdateCommand extends GitCommand {
     /**
      * If set true, submodule update will be recursive.  Default is
      * non-recursive.
      * @param recursive if true, will recursively update submodules (requires git>=1.6.5)
      */
-    public SubmoduleUpdateCommand recursive(boolean recursive) {
-        this.recursive = recursive;
-        return this;
-    }
+    SubmoduleUpdateCommand recursive(boolean recursive);
 
     /**
      * If set true and if the git version supports it, update the
@@ -23,13 +16,7 @@ public abstract class SubmoduleUpdateCommand implements GitCommand {
      * SHA1 (compatible with previous versions of git)
      * @param remoteTracking if true, will update the submodule to the tip of the branch requested (requires git>=1.8.2)
      */
-    public SubmoduleUpdateCommand remoteTracking(boolean remoteTracking) {
-        this.remoteTracking = remoteTracking;
-        return this;
-    }
+    SubmoduleUpdateCommand remoteTracking(boolean remoteTracking);
 
-    public SubmoduleUpdateCommand ref(String ref) {
-        this.ref = ref;
-        return this;
-    }
+    SubmoduleUpdateCommand ref(String ref);
 }


### PR DESCRIPTION
Apparently, updating to git-plugin 2.1.1 from 2.0.4 causes the SubmoduleUpdate command stuff to not work with the following:

Resetting working tree
FATAL: org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand is not an interface
java.lang.IllegalArgumentException: org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand is not an interface
    at java.lang.reflect.Proxy.getProxyClass(Proxy.java:362)
    at java.lang.reflect.Proxy.newProxyInstance(Proxy.java:581)
    at org.jenkinsci.plugins.gitclient.RemoteGitImpl.command(RemoteGitImpl.java:112)
    at org.jenkinsci.plugins.gitclient.RemoteGitImpl.submoduleUpdate(RemoteGitImpl.java:442)
    at hudson.plugins.git.extensions.impl.SubmoduleOption.onCheckoutCompleted(SubmoduleOption.java:95)
    at hudson.plugins.git.GitSCM.checkout(GitSCM.java:908)
    at hudson.model.AbstractProject.checkout(AbstractProject.java:1411)
    at hudson.model.AbstractBuild$AbstractBuildExecution.defaultCheckout(AbstractBuild.java:671)
    at jenkins.scm.SCMCheckoutStrategy.checkout(SCMCheckoutStrategy.java:88)
    at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:580)
    at hudson.model.Run.execute(Run.java:1670)
    at hudson.matrix.MatrixBuild.run(MatrixBuild.java:304)
    at hudson.model.ResourceController.execute(ResourceController.java:88)
    at hudson.model.Executor.run(Executor.java:231)
    at hudson.model.OneOffExecutor.run(OneOffExecutor.java:43)

This commit makes the SubmoduleUpdateCommand an interface instead of an abstract class so that it will work correctly in the RemoteGitImpl mode.  NOTE -- Because of this change, a rebuild of git-plugin is necessary.
