### PR TITLE
[Fix JENKINS-23017] delete the tmp workdir also

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1183,6 +1183,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 if (deleteWorkDir) {
                     try {
                         Util.deleteContentsRecursive(workDir);
+                        FileUtils.deleteDirectory( workDir );
                     } catch (IOException ioe) {
                         listener.getLogger().println("Couldn't delete dir " + workDir.getAbsolutePath() + " : " + ioe);
                     }


### PR DESCRIPTION
In order to not leave unlimited directories created by the polling cycle
in the tmp directory which results in reaching the system limit for
subdirectory numbers we should also delete the workdir itself and not only its
contents.
