### PR TITLE
Fixing issues towards the version recognition and the ssh that is not being found.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -147,6 +147,15 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.9.2.msysgit.0", versions);
     }
 
+    public void test_git_version_windows_1940() {
+        VersionTest[] versions = {
+            new VersionTest(true,  1, 9, 4,  0),
+            new VersionTest(true,  1, 9, 3, 99),
+            new VersionTest(false, 1, 9, 4,  1)
+        };
+        doTest("git version 1.9.4.msysgit.0", versions);
+    }
+
     public void test_git_version_redhat_5() {
         VersionTest[] versions = {
             new VersionTest(true,  1, 8, 2, 1),
@@ -182,4 +191,33 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         };
         doTest("git version 1.8.3.2", versions);
     }
+    
+    private boolean isOneOfThese(String[] pathList, String actualPath) {
+    	boolean result = false;
+    	
+    	for (String path:pathList) {
+    		result = result || path.equalsIgnoreCase(actualPath);
+    	}
+    	
+		return result;
+    }
+    
+    public void test_git_ssh_executable_found_on_windows() {
+    	//given
+    	CliGitAPIImpl git = new CliGitAPIImpl("git", new File("."), listener, env);
+    	String[] expected = {
+    			"C:\\git\\bin\\ssh.exe", 
+    			"C:\\Program Files\\git\\bin\\ssh.exe", 
+    			"C:\\Program Files (x86)\\git\\bin\\ssh.exe"};
+    	
+    	//workaround for tests running on a Linux build
+    	boolean isWindows = System.getProperty("os.name").toLowerCase().indexOf("win") != -1;
+    	
+    	//when
+    	boolean actual = isWindows ? isOneOfThese(expected, git.getSSHExecutable().getAbsolutePath()) : true;
+    	
+    	//then
+    	assertTrue("Git SSH not found!", actual);
+    }
+
 }


### PR DESCRIPTION
- Fixing the method that retrieves the version from git --version command on a windows build with msysgit installed; 
- Fixing the method that retrieves the ssh executable on windows builds.
