### PR TITLE
Enable test execution behind firewall

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/firewall"]
 	path = modules/firewall
-	url = git://github.com/puppetlabs/puppetlabs-firewall.git
+	url = https://github.com/puppetlabs/puppetlabs-firewall.git
 [submodule "modules/ntp"]
 	path = modules/ntp
-	url = git://github.com/puppetlabs/puppetlabs-ntp.git
+	url = https://github.com/puppetlabs/puppetlabs-ntp.git


### PR DESCRIPTION
This change is required to enable test execution behind
a proxy/firewall using parameters -DproxyHost=<host> -DproxyPort=<port>.

CliGitAPIImplTest.test_submodule_tags_not_fetched_into_parent() fails
also with proxy settings since git:// requires port 9418 to be open.
Using https:// solves this issue.

Mentioned test is the last failing test behind a firewall. If this is fixed all tests
can be properly executed behind a firewall using -DproxyHost=<host> -DproxyPort=<port>.
