### PR TITLE
Two improvements

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1217,13 +1217,13 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 } catch (GitException e) {
                     listener.getLogger().println("Could not remove the credential section from the git configuration");
                 }
-                if (deleteWorkDir) {
-                    try {
-                        Util.deleteContentsRecursive(workDir);
-                        FileUtils.deleteDirectory( workDir );
-                    } catch (IOException ioe) {
-                        listener.getLogger().println("Couldn't delete dir " + workDir.getAbsolutePath() + " : " + ioe);
-                    }
+            }
+            if (deleteWorkDir) {
+                try {
+                    Util.deleteContentsRecursive(workDir);
+                    FileUtils.deleteDirectory( workDir );
+                } catch (IOException ioe) {
+                    listener.getLogger().println("Couldn't delete dir " + workDir.getAbsolutePath() + " : " + ioe);
                 }
             }
         }


### PR DESCRIPTION
1) When getting the head revision, first expand the given parameters by executing environments.exapnd() on them. that would output the git ls-remote command better.

2) Temp directory not always gets deleted even if we define them to be deleted. I think there was a problem with the condition. It got accidentally dependent on whethere "store" variable is null or not.
