### PR TITLE
git-server 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-server</artifactId>
-      <version>1.3</version>
+      <version>1.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Seems to be necessary to update this dependency since `git-server` 1.3 depends on `git` which of course depends on `git-client`, so there is a circular dependency that `PluginManager` rightly rejects. `git-server` 1.4 does not have this dependency on `git`.
