### PR TITLE
IllegalStateException from Connection.openSession

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -671,6 +671,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             throw new GitException(e);
         } catch (URISyntaxException e) {
             throw new GitException(e);
+        } catch (IllegalStateException e) {
+            // "Cannot open session, connection is not authenticated." from com.trilead.ssh2.Connection.openSession
+            throw new GitException(e);
         }
         return null;
     }


### PR DESCRIPTION
Need to rethrow as `GitException`. Otherwise if you are using JGit and you select bad (or no) credentials for a remote repo, the _ERROR_ link expands to a monster nasty stack trace. With this patch, a simple one-line error is shown as expected.
