### PR TITLE
ls-remote to lookup references in a remote repository

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -327,6 +327,23 @@ public interface GitClient {
     ObjectId getHeadRev(String remoteRepoUrl, String branch) throws GitException, InterruptedException;
 
     /**
+     * List references in a remote repository. Equivalent to <tt>git ls-remote [--heads] [--tags] <repository> [<refs>]</tt>.
+     *
+     * @param remoteRepoUrl
+     *      Remote repository URL.
+     * @param pattern
+     *      Only references matching the given pattern are displayed.
+     * @param headsOnly
+     *      Limit to only refs/heads.
+     * @param tagsOnly
+     *      Limit to only refs/tags.
+     *      headsOnly and tagsOnly are not mutually exclusive;
+     *      when both are true, references stored in refs/heads and refs/tags are displayed.
+     * @return a map of references name and its commit hash. Empty if none.
+     */
+    Map<String, ObjectId> getRemoteReferences(String remoteRepoUrl, String pattern, boolean headsOnly, boolean tagsOnly) throws GitException, InterruptedException;
+
+    /**
      * Retrieve commit object that is direct child for <tt>revName</tt> revision reference.
      * @param revName a commit sha1 or tag/branch refname
      * @throws GitException when no such commit / revName is found in repository.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ListBranchCommand;
+import org.eclipse.jgit.api.LsRemoteCommand;
 import org.eclipse.jgit.api.MergeResult;
 import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.ShowNoteCommand;
@@ -71,6 +72,7 @@ import java.io.Writer;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -611,6 +613,49 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             throw new GitException(e);
         }
         return heads;
+    }
+
+    public Map<String, ObjectId> getRemoteReferences(String url, String pattern, boolean headsOnly, boolean tagsOnly)
+            throws GitException, InterruptedException {
+        Map<String, ObjectId> references = new HashMap<String, ObjectId>();
+        String regexPattern = null;
+        if (pattern != null) {
+            regexPattern = createRefRegexFromGlob(pattern);
+        }
+        try {
+            Repository repo = openDummyRepository();
+            LsRemoteCommand lsRemote = new LsRemoteCommand(repo);
+            if (headsOnly) {
+                lsRemote.setHeads(headsOnly);
+            }
+            if (tagsOnly) {
+                lsRemote.setTags(tagsOnly);
+            }
+            lsRemote.setRemote(url);
+            lsRemote.setCredentialsProvider(getProvider());
+            Collection<Ref> refs = lsRemote.call();
+            try {
+                for (final Ref r : refs) {
+                    final String refName = r.getName();
+                    final ObjectId refObjectId =
+                            r.getPeeledObjectId() != null ? r.getPeeledObjectId() : r.getObjectId();
+                    if (regexPattern != null) {
+                        if (refName.matches(regexPattern)) {
+                            references.put(refName, refObjectId);
+                        }
+                    } else {
+                        references.put(refName, refObjectId);
+                    }
+                }
+            } finally {
+                repo.close();
+            }
+        } catch (GitAPIException e) {
+            throw new GitException(e);
+        } catch (IOException e) {
+            throw new GitException(e);
+        }
+        return references;
     }
 
     /* Adapted from http://stackoverflow.com/questions/1247772/is-there-an-equivalent-of-java-util-regex-for-glob-type-patterns */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -413,6 +413,10 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
         return proxy.getHeadRev(remoteRepoUrl, branch);
     }
 
+    public Map<String, ObjectId> getRemoteReferences(String remoteRepoUrl, String pattern, boolean headsOnly, boolean tagsOnly) throws GitException, InterruptedException {
+        return proxy.getRemoteReferences(remoteRepoUrl, pattern, headsOnly, tagsOnly);
+    }
+
     public ObjectId revParse(String revName) throws GitException, InterruptedException {
         return proxy.revParse(revName);
     }


### PR DESCRIPTION
List references, like heads or tags, in a remote repository
without depending on a locally cloned workspace.

The git-parameter plugin lists branches or tags on a local
cloned workspace, so it doesn't work on the first build or
if user wipes out workspace.

If user only wants a tag name with its commit id, there is
no need to clone the whole repository.
