### PR TITLE
[JENKINS-25389] Added tags option to Push command

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1469,8 +1469,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
-            public PushCommand tags() {
-                this.tags = true;
+            public PushCommand tags(boolean tags) {
+                this.tags = tags;
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1383,8 +1383,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
-            public PushCommand tags() {
-                this.tags = true;
+            public PushCommand tags(boolean tags) {
+                this.tags = tags;
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/PushCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/PushCommand.java
@@ -16,7 +16,7 @@ public interface PushCommand extends GitCommand {
 
     PushCommand force();
 
-    PushCommand tags();
+    PushCommand tags(boolean tags);
 
     PushCommand timeout(Integer timeout);
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -880,6 +880,68 @@ public abstract class GitAPITestCase extends TestCase {
         }
     }
 
+    public void test_push_tags() throws Exception {
+        /* Create a working repo containing a commit */
+        w.init();
+        w.touch("file1", "file1 content " + java.util.UUID.randomUUID().toString());
+        w.git.add("file1");
+        w.git.commit("commit1");
+        ObjectId commit1 = w.head();
+
+        /* Clone working repo into a bare repo */
+        WorkingArea bare = new WorkingArea();
+        bare.init(true);
+        w.git.setRemoteUrl("origin", bare.repoPath());
+        Set<Branch> remoteBranchesEmpty = w.git.getRemoteBranches();
+        assertEquals("Unexpected branch count", 0, remoteBranchesEmpty.size());
+        w.git.push("origin", "master");
+        ObjectId bareCommit1 = bare.git.getHeadRev(bare.repoPath(), "master");
+        assertEquals("bare != working", commit1, bareCommit1);
+        assertEquals(commit1, bare.git.getHeadRev(bare.repoPath(), "refs/heads/master"));
+
+        /* Add tag to working repo and without pushing it to the bare repo */
+        w.tag("tag1");
+        assertTrue("tag1 wasn't created", w.git.tagExists("tag1"));
+        w.git.push().to(new URIish(bare.repoPath())).tags(false).execute();
+        assertFalse("tag1 wasn't pushed", bare.cmd("git tag").contains("tag1"));
+
+        /* Add another tag to working repo and push tags to the bare repo */
+        w.touch("file2", "file2 content " + java.util.UUID.randomUUID().toString());
+        w.git.add("file2");
+        w.git.commit("commit2");
+        w.tag("tag2");
+        assertTrue("tag2 wasn't created", w.git.tagExists("tag2"));
+        w.git.push().to(new URIish(bare.repoPath())).tags(true).execute();
+        assertTrue("tag1 wasn't pushed", bare.cmd("git tag").contains("tag1"));
+        assertTrue("tag2 wasn't pushed", bare.cmd("git tag").contains("tag2"));
+    }
+
+    public void test_push_tags_default_behaviour() throws Exception {
+        /* Create a working repo containing a commit */
+        w.init();
+        w.touch("file1", "file1 content " + java.util.UUID.randomUUID().toString());
+        w.git.add("file1");
+        w.git.commit("commit1");
+        ObjectId commit1 = w.head();
+
+        /* Clone working repo into a bare repo */
+        WorkingArea bare = new WorkingArea();
+        bare.init(true);
+        w.git.setRemoteUrl("origin", bare.repoPath());
+        Set<Branch> remoteBranchesEmpty = w.git.getRemoteBranches();
+        assertEquals("Unexpected branch count", 0, remoteBranchesEmpty.size());
+        w.git.push("origin", "master");
+        ObjectId bareCommit1 = bare.git.getHeadRev(bare.repoPath(), "master");
+        assertEquals("bare != working", commit1, bareCommit1);
+        assertEquals(commit1, bare.git.getHeadRev(bare.repoPath(), "refs/heads/master"));
+
+        /* Add tag to working repo and without pushing it to the bare repo */
+        w.tag("tag1");
+        assertTrue("tag1 wasn't created", w.git.tagExists("tag1"));
+        w.git.push().to(new URIish(bare.repoPath())).execute();
+        assertFalse("tag1 wasn't pushed", bare.cmd("git tag").contains("tag1"));
+    }
+
     @Bug(19591)
     public void test_fetch_needs_preceding_prune() throws Exception {
         /* Create a working repo containing a commit */


### PR DESCRIPTION
New Pull-Request, after the #149 keeps waiting for the Jenkins build.
I also created a JIRA issue, but this is only the first part, after the git-client-plugin is extended, the git-plugin needs also some modifications to resolve the issue.

Once again, thanks for your feedback on the last ticket, I changed the tags() method to accept a boolean. 
Also thanks for telling me where to find examples for the test cases, I tried adding two tests, but had a slight problem:

```
assertTrue("tag1 wasn't pushed", bare.git.tagExists("tag1"));
assertTrue("tag2 wasn't pushed", bare.git.tagExists("tag2"));
```

This works for CliGitAPIImpl, but not for JGitAPIImp, I changed it to

```
assertTrue("tag1 wasn't pushed", bare.cmd("git tag").contains("tag1"));
assertTrue("tag2 wasn't pushed", bare.cmd("git tag").contains("tag2"));
```

This works for both, but I'm unsure why tagExists fails for JGit.
