### PR TITLE
Allow clean to remove abandoned submodules

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -514,7 +514,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     public void clean() throws GitException, InterruptedException {
         reset(true);
-        launchCommand("clean", "-fdx");
+        launchCommand("clean", "-ffdx");
     }
 
     public ObjectId revParse(String revName) throws GitException, InterruptedException {
@@ -800,7 +800,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     	if (recursive) {
             args.add("--recursive");
     	}
-    	args.add("git clean -fdx");
+        args.add("git clean -ffdx");
 
     	launchCommand(args);
     }


### PR DESCRIPTION
"git clean -fdx" will not remove submodule folders that are no longer
relevant. This commit adds an additional -f argument so that unused
submodule folders are also removed.