### PR TITLE
[JENKINS-26197] Implement trivial prune strategy for JGit.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1065,8 +1065,9 @@ public abstract class GitAPITestCase extends TestCase {
      * branches than command line git prunes during fetch.  This test
      * should be used to evaluate future versions of JGit to see if
      * pruning behavior more closely emulates command line git.
+     * 
+     * This has been fixed using a workaround.
      */
-    @NotImplementedInJGit
     public void test_fetch_with_prune() throws Exception {
         WorkingArea bare = new WorkingArea();
         bare.init(true);


### PR DESCRIPTION
Delete any remote branches matching the destination of the given refspecs. Then do the fetch and let it recreate the references.