### PR TITLE
More complete "clean" behavior.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -588,7 +588,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     public void clean() throws GitException, InterruptedException {
         reset(true);
-        launchCommand("clean", "-fdx");
+        launchCommand("clean", "-ffdx");
     }
 
     /** {@inheritDoc} */
@@ -907,7 +907,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     	if (recursive) {
             args.add("--recursive");
     	}
-    	args.add("git clean -fdx");
+    	args.add("git clean -ffdx");
 
     	launchCommand(args);
     }


### PR DESCRIPTION
Specifically, remove untracked directories even if they're managed as
part of another git repository. See the documentation for the -d switch
in "git help clean" for a full description.

This _seems_ like the right behavior to me. I can't think of a time
when it would make sense to not delete an untracked directory just because
it happens to be a git repo.

I haven't tested this. Haven't tried to compile. Haven't run unit tests.
Etc.

I was experiencing a problem where part of my build process downloads a
library from the internet. The library contains a .git file with a .gitdir
directive. This caused "git clean -fdx" to error-out during the next build
attempt when run as part of the "Clean after checkout" Git SCM additional
behavior, because it refused to delete the library.

You might be able to reproduce the problem by creating a simple project
in Jenkins. The test project will need to be checked out via Jenkins' Git
source code management plugin. As part of your build steps, add this:
    mkdir some_test_dir
    echo 'gitdir: /foo/bar' > some_test_dir/.git
Then add the "Clean after checkout" additional behavior under Source
Code Management.

Related bug reports:
https://issues.jenkins-ci.org/browse/JENKINS-21369
https://issues.jenkins-ci.org/browse/JENKINS-23694