### PR TITLE
Fix failure in test_push_tags

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -929,7 +929,7 @@ public abstract class GitAPITestCase extends TestCase {
         /* Add tag to working repo and without pushing it to the bare repo */
         w.tag("tag1");
         assertTrue("tag1 wasn't created", w.git.tagExists("tag1"));
-        w.git.push().to(new URIish(bare.repoPath())).tags(false).execute();
+        w.git.push().ref("master").to(new URIish(bare.repoPath())).tags(false).execute();
         assertFalse("tag1 wasn't pushed", bare.cmd("git tag").contains("tag1"));
 
         /* Add tag to working repo without pushing it to the bare
@@ -938,7 +938,7 @@ public abstract class GitAPITestCase extends TestCase {
          */
         w.tag("tag3");
         assertTrue("tag3 wasn't created", w.git.tagExists("tag3"));
-        w.git.push().to(new URIish(bare.repoPath())).execute();
+        w.git.push().ref("master").to(new URIish(bare.repoPath())).execute();
         assertFalse("tag3 was pushed", bare.cmd("git tag").contains("tag3"));
 
         /* Add another tag to working repo and push tags to the bare repo */
@@ -947,7 +947,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.commit("commit2");
         w.tag("tag2");
         assertTrue("tag2 wasn't created", w.git.tagExists("tag2"));
-        w.git.push().to(new URIish(bare.repoPath())).tags(true).execute();
+        w.git.push().ref("master").to(new URIish(bare.repoPath())).tags(true).execute();
         assertTrue("tag1 wasn't pushed", bare.cmd("git tag").contains("tag1"));
         assertTrue("tag2 wasn't pushed", bare.cmd("git tag").contains("tag2"));
         assertTrue("tag3 wasn't pushed", bare.cmd("git tag").contains("tag3"));


### PR DESCRIPTION
Currently (with 1.16.1), when testing git-client-plugin, I am getting
the following error in test_push_tags:

--------------------------------------------------------
The current branch master has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream /tmp/hudson4099265862244982437test master
--------------------------------------------------------

The reason that this is happening is that test_push_tags() is using the
PushCommand() pattern, but is failing to specify a refspec.  Also, this
test case is creating a remote url, but is not setting up the master
branch to track that remote url.  So, without a refspec, the behaviour
depends on whether CLI or JGIT is used.

In CLI, it uses whatever push.default specifies.  In my case, it was set
to tracking/upstream.  With this setting, it requires that the upstream be
configured correctly, or it will error out with the above error message.  I
tested with all other values, and only the matching value passed the test.

In JGIT, it uses Transport.REFSPEC_PUSH_ALL.  This corresponds to
push.default = matching, which means that it works.

If you are wondering why this was not hit before, by default, push.default
is matching.  Also, all other instances of git.push() in the test harness
uses the 2 argument version, which requires the refspec().  Hence, no problem.

To make this test deterministic, specifying the refspec via
.ref("master"). fixes it for both configurations.