### PR TITLE
Use Java 6 compatible equals method instead of Java 7 specific method

### DIFF
--- a/src/main/java/hudson/plugins/git/Revision.java
+++ b/src/main/java/hudson/plugins/git/Revision.java
@@ -156,6 +156,9 @@ public class Revision implements java.io.Serializable, Cloneable {
             return false;
         }
         Revision other = (Revision) obj;
-        return java.util.Objects.equals(sha1, other.sha1);
+        if (other.sha1 != null) {
+            return other.sha1.equals(sha1);
+        }
+        return sha1 == null;
     }
 }

--- a/src/test/java/hudson/plugins/git/RevisionTest.java
+++ b/src/test/java/hudson/plugins/git/RevisionTest.java
@@ -41,6 +41,7 @@ public class RevisionTest {
     public void testEquals() {
         assertEquals(revision1, revision1);
         assertNotEquals(revision1, null);
+        assertNotEquals(null, revision1);
         assertNotEquals(revision1, objectId);
         assertEquals(revision1, revision2);
 


### PR DESCRIPTION
No need to make the git client plugin fail to compile on Java 6 just
for the convenience of a single new class in Java 7.  The Java 7
java.util.Objects class is a nicety, not a necessity.

@ndeloof - any objection to me fixing my mistake by removing the
dependency on Java 7 which I introduced earlier this month?