### PR TITLE
JENKINS-20879 - make sure $SSH_ASKPASS is not ignored

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1530,6 +1530,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         File ssh = File.createTempFile("ssh", ".sh");
         PrintWriter w = new PrintWriter(ssh);
         w.println("#!/bin/sh");
+        // ${SSH_ASKPASS} might be ignored if ${DISPLAY} is not set
+        w.println("[ -z \"${DISPLAY}\" ] && export DISPLAY=:123.456");
         w.println("ssh -i \"" + key.getAbsolutePath() + "\" -o StrictHostKeyChecking=no \"$@\"");
         w.close();
         ssh.setExecutable(true);


### PR DESCRIPTION
I'm also having the errors described in JENKINS-20879 when trying to poll a git repository using a passphrase-protected SSH private key (with the GitCli implementation - as already mentionned in the Jira report, JGit already works fine).  
Looking at the implementation, I understand that the passphrase is provided to git/ssh via a shell script and the `$SSH_ASKPASS` trick.  But according to the ssh manpage, this can only work if `$DISPLAY` is set, because this mechanism is usually dedicated to graphical environments.

     SSH_ASKPASS           If ssh needs a passphrase, it will read the passphrase from the current terminal if it was run from a
                           terminal.  If ssh does not have a terminal associated with it but DISPLAY and SSH_ASKPASS are set, it
                           will execute the program specified by SSH_ASKPASS and open an X11 window to read the passphrase.
                           This is particularly useful when calling ssh from a .xsession or related script.  (Note that on some
                           machines it may be necessary to redirect the input from /dev/null to make this work.)

So, the idea of this PR is pretty simple: ensure some `$DISPLAY` variable is exported in the SSH wrapper script (the `$GIT_SSH` one), so that `$SSH_ASKPASS` actually works. I'm assuming it won't have too much other side effect on the `git` command behavior.