### PR TITLE
Implemented Squash option on MergeCommand. JENKINS-28833

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -507,6 +507,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public ObjectId rev;
             public String strategy;
             public String fastForwardMode;
+            public boolean squash;
 
             public MergeCommand setRevisionToMerge(ObjectId rev) {
                 this.rev = rev;
@@ -523,16 +524,26 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public MergeCommand setSquash(boolean squash) {
+                this.squash = squash;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 ArgumentListBuilder args = new ArgumentListBuilder();
                 args.add("merge");
                 try {
+                    if(squash) {
+                        args.add("--squash");
+                    }
+
                     if (strategy != null && !strategy.isEmpty() && !strategy.equals(MergeCommand.Strategy.DEFAULT.toString())) {
                         args.add("-s");
                         args.add(strategy);
                     }
                     args.add(fastForwardMode);
                     args.add(rev.name());
+
                     launchCommand(args);
                 } catch (GitException e) {
                     throw new GitException("Could not merge " + rev, e);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -543,7 +543,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     }
                     args.add(fastForwardMode);
                     args.add(rev.name());
-
                     launchCommand(args);
                 } catch (GitException e) {
                     throw new GitException("Could not merge " + rev, e);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1454,6 +1454,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             ObjectId rev;
             MergeStrategy strategy;
             FastForwardMode fastForwardMode;
+            boolean squash;
 
             public MergeCommand setRevisionToMerge(ObjectId rev) {
                 this.rev = rev;
@@ -1490,6 +1491,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public MergeCommand setSquash(boolean squash){
+                this.squash = squash;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 Repository repo = null;
                 try {
@@ -1497,9 +1503,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     Git git = git(repo);
                     MergeResult mergeResult;
                     if (strategy != null)
-                        mergeResult = git.merge().setStrategy(strategy).setFastForward(fastForwardMode).include(rev).call();
+                        mergeResult = git.merge().setStrategy(strategy).setFastForward(fastForwardMode).setSquash(squash).include(rev).call();
                     else
-                        mergeResult = git.merge().setFastForward(fastForwardMode).include(rev).call();
+                        mergeResult = git.merge().setFastForward(fastForwardMode).setSquash(squash).include(rev).call();
                     if (!mergeResult.getMergeStatus().isSuccessful()) {
                         git.reset().setMode(HARD).call();
                         throw new GitException("Failed to merge " + rev);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
@@ -54,4 +54,12 @@ public interface MergeCommand extends GitCommand {
             return "--"+name().toLowerCase().replace("_","-");
         }
     }
+
+    /**
+     * setSquash
+     *
+     * @param squash - whether to squash commits or not
+     * @return a {@link org.jenkinsci.plugins.gitclient.MergeCommand} object.
+     */
+    MergeCommand setSquash(boolean squash);
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2302,6 +2302,60 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals("Merge commit failed. branch2 should be a parent of HEAD but it isn't.",revList.get(0).name(), branch2.name());
     }
 
+    public void test_merge_squash() throws Exception{
+        w.init();
+        w.commitEmpty("init");
+        w.git.branch("branch1");
+
+        //First commit to branch1
+        w.git.checkout("branch1");
+        w.touch("file1", "content1");
+        w.git.add("file1");
+        w.git.commit("commit1");
+
+        //Second commit to branch1
+        w.touch("file2", "content2");
+        w.git.add("file2");
+        w.git.commit("commit2");
+
+        //Merge branch1 with master, squashing both commits
+        w.git.checkout("master");
+        w.git.merge().setSquash(true).setRevisionToMerge(w.git.getHeadRev(w.repoPath(), "branch1")).execute();
+
+        //Compare commit counts of before and after commiting the merge, should be  one due to the squashing of commits.
+        final int commitCountBefore = w.git.revList("HEAD").size();
+        w.git.commit("commitMerge");
+        final int commitCountAfter = w.git.revList("HEAD").size();
+
+        assertEquals("Squash merge failed. Should have merged only one commit.", 1, commitCountAfter - commitCountBefore);
+    }
+
+    public void test_merge_no_squash() throws Exception{
+        w.init();
+        w.commitEmpty("init");
+
+        //First commit to branch1
+        w.git.branch("branch1");
+        w.git.checkout("branch1");
+        w.touch("file1", "content1");
+        w.git.add("file1");
+        w.git.commit("commit1");
+
+        //Second commit to branch1
+        w.touch("file2", "content2");
+        w.git.add("file2");
+        w.git.commit("commit2");
+
+        //Merge branch1 with master, without squashing commits.
+        //Compare commit counts of before and after commiting the merge, should be  one due to the squashing of commits.
+        w.git.checkout("master");
+        final int commitCountBefore = w.git.revList("HEAD").size();
+        w.git.merge().setSquash(false).setRevisionToMerge(w.git.getHeadRev(w.repoPath(), "branch1")).execute();
+        final int commitCountAfter = w.git.revList("HEAD").size();
+
+        assertEquals("Squashless merge failed. Should have merged two commits.", 2, commitCountAfter - commitCountBefore);
+    }
+
     @Deprecated
     public void test_merge_refspec() throws Exception {
         w.init();


### PR DESCRIPTION
<h3>Background</h3>
We are looking to use the Credentials API in our [pretested-integration-plugin](https://wiki.jenkins-ci.org/display/JENKINS/Pretested+Integration+Plugin). However, before we can get started on that, we'll need to add some missing functionalities to the [git-client-plugin](https://github.com/jenkinsci/git-client-plugin). The ability to squash commits when merging being one of them. (Related issue: [JENKINS-28833](https://issues.jenkins-ci.org/browse/JENKINS-28833))

<h3>Implementation</h3>
The implementation was pretty straightforward. `MergeCommand` now requires a `setSquash(boolean squash)` implementation which both `JGitAPIImpl` and `CliGitAPIImpl` received.

<h3>Testing</h3>
Tests were written to test both a squashed and unsquashed merge. We also took it for a spin with our own plugin and all its tests pass using the new squash merge.