### PR TITLE
update tests for git-client-plugin

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1825,6 +1825,18 @@ public abstract class GitAPITestCase extends TestCase {
         );
     }
 
+    public void test_submodule_update() throws Exception {
+        w.init();
+        // Re-use the same submodule test branch
+        w.launchCommand("git","fetch",localMirror(),"tests/getSubmodules:t");
+        w.git.checkout("t");
+        w.git.submoduleInit();
+        w.git.submoduleUpdate().execute();
+
+        assertTrue("modules/firewall does not exist", w.exists("modules/firewall"));
+        assertTrue("modules/ntp does not exist", w.exists("modules/ntp"));
+    }
+
     @NotImplementedInJGit
     public void test_trackingSubmoduleBranches() throws Exception {
         if (! ((CliGitAPIImpl)w.git).isAtLeastVersion(1,8,2,0)) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -4,6 +4,8 @@ import static java.util.Collections.unmodifiableList;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.startsWith;
+import static org.jenkinsci.plugins.gitclient.StringSharesPrefix.sharesPrefix;
 import static org.junit.Assert.assertNotEquals;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -2927,10 +2929,10 @@ public abstract class GitAPITestCase extends TestCase {
         w.touch("a");
         w.git.add("a");
         w.git.commit("second");
-        assertEquals(w.cmd("git describe").trim(), w.git.describe("HEAD"));
+        assertThat(w.cmd("git describe").trim(), sharesPrefix(w.git.describe("HEAD")));
 
         w.tag("-m test2 t2");
-        assertEquals(w.cmd("git describe").trim(), w.git.describe("HEAD"));
+        assertThat(w.cmd("git describe").trim(), sharesPrefix(w.git.describe("HEAD")));
     }
 
     public void test_getAllLogEntries() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushSimpleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushSimpleTest.java
@@ -17,12 +17,6 @@ public class PushSimpleTest extends PushTest {
     }
 
     @Test
-    public void pushNoRefSpec() throws IOException, GitException, InterruptedException, URISyntaxException {
-        checkoutBranchAndCommitFile();
-        workingGitClient.push().to(bareURI).execute(); // no ref() argument
-    }
-
-    @Test
     public void pushNonFastForwardThrows() throws IOException, GitException, InterruptedException, URISyntaxException {
         checkoutOldBranchAndCommitFile(); // Old branch can't be pushed without force()
         thrown.expect(GitException.class);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/StringSharesPrefix.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/StringSharesPrefix.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.gitclient;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.core.SubstringMatcher;
+
+/**
+ * Tests if the argument shares a prefix.
+ */
+public class StringSharesPrefix extends SubstringMatcher {
+    public StringSharesPrefix(String substring) { super(substring); }
+
+    @Override
+    protected boolean evalSubstringOf(String s) {
+        return s.startsWith(substring) ||
+               substring.startsWith(s);
+    }
+
+    @Override
+    protected String relationship() {
+            return "sharing prefix with";
+    }
+
+    /**
+     * <p>
+     * Creates a matcher that matches if th examined {@link String} shares a
+     * common prefix with the specified {@link String}.
+     * </p>
+     * For example:
+     * <pre>assertThat("myString", sharesPrefix("myStringOfNote"))</pre>
+     *
+     * @param prefix
+     *      the substring that the returned matcher will expect to share a
+     *      prefix of any examined string
+     */
+    public static Matcher<String> sharesPrefix(String prefix) { return new StringSharesPrefix(prefix); }
+}


### PR DESCRIPTION
Add an additional test for submodule init/update based on the same test remote as a previous submodule test.

Fix git describe test to not rely on core.abbrev remaining identical to size of JGit implementation. Although they should remain unique, it is possible for user to customize CLI implementation to a higher or lower value than the default 7, and thus this test fails on JGit since it would not be identical.