### PR TITLE
JENKINS-24728  Add ability to specify shallow clone depth

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -244,6 +244,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public boolean shallow;
             public Integer timeout;
             public boolean tags = true;
+            public Integer depth = 1;
 
             public FetchCommand from(URIish remote, List<RefSpec> refspecs) {
                 this.url = remote;
@@ -271,6 +272,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             	return this;
             }
 
+            public FetchCommand depth(Integer depth) {
+                this.depth = depth;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 listener.getLogger().println(
                         "Fetching upstream changes from " + url);
@@ -292,7 +298,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (prune) args.add("--prune");
 
-                if (shallow) args.add("--depth=1");
+                if (shallow) {
+                    if (depth == null){
+                        depth = 1;
+                    }
+                    args.add("--depth=" + depth);
+                }
 
                 warnIfWindowsTemporaryDirNameHasSpaces();
 
@@ -371,6 +382,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             Integer timeout;
             boolean tags = true;
             List<RefSpec> refspecs;
+            Integer depth = 1;
 
             public CloneCommand url(String url) {
                 this.url = url;
@@ -410,6 +422,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public CloneCommand timeout(Integer timeout) {
             	this.timeout = timeout;
             	return this;
+            }
+
+            public CloneCommand depth(Integer depth) {
+                this.depth = depth;
+                return this;
             }
 
             public CloneCommand refspecs(List<RefSpec> refspecs) {
@@ -484,6 +501,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 }
                 fetch_().from(urIish, refspecs)
                         .shallow(shallow)
+                        .depth(depth)
                         .timeout(timeout)
                         .tags(tags)
                         .execute();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
@@ -70,4 +70,12 @@ public interface CloneCommand extends GitCommand {
     CloneCommand tags(boolean tags);
 
     CloneCommand refspecs(List<RefSpec> refspecs);
+
+    /**
+     * When shallow cloning, allow for a depth to be set in cases where you need more than the immediate last commit.
+     * Has no effect if shallow is set to false (default)
+     *
+     * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
+     */
+    CloneCommand depth(Integer depth);
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
@@ -45,4 +45,12 @@ public interface FetchCommand extends GitCommand {
     FetchCommand timeout(Integer timeout);
 
     FetchCommand tags(boolean tags);
+
+    /**
+     * When shallow cloning, allow for a depth to be set in cases where you need more than the immediate last commit.
+     * Has no effect if shallow is set to false (default)
+     *
+     * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
+     */
+    FetchCommand depth(Integer depth);
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -576,6 +576,10 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public org.jenkinsci.plugins.gitclient.FetchCommand depth(Integer depth) {
+                throw new UnsupportedOperationException("JGit don't (yet) support fetch --depth");
+            }
+
             public void execute() throws GitException, InterruptedException {
                 Repository repo = null;
                 FetchCommand fetch = null;
@@ -1351,6 +1355,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             public CloneCommand noCheckout() {
                 // this.noCheckout = true; ignored, we never do a checkout
+                return this;
+            }
+
+            public CloneCommand depth(Integer depth) {
+                listener.getLogger().println("[WARNING] JGit doesn't support shallow clone and therefore depth is meaningless. This flag is ignored");
                 return this;
             }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -486,6 +486,16 @@ public abstract class GitAPITestCase extends TestCase {
         assertFalse("Alternates file found: " + alternates, w.exists(alternates));
     }
 
+    public void test_clone_shallow_with_depth() throws IOException, InterruptedException
+    {
+        w.git.clone_().url(localMirror()).repositoryName("origin").shallow().depth(2).execute();
+        w.git.checkout("origin/master", "master");
+        check_remote_url("origin");
+        assertBranchesExist(w.git.getBranches(), "master");
+        final String alternates = ".git" + File.separator + "objects" + File.separator + "info" + File.separator + "alternates";
+        assertFalse("Alternates file found: " + alternates, w.exists(alternates));
+    }
+
     public void test_clone_shared() throws IOException, InterruptedException
     {
         w.git.clone_().url(localMirror()).repositoryName("origin").shared().execute();
@@ -1195,6 +1205,19 @@ public abstract class GitAPITestCase extends TestCase {
         w.init();
         w.git.setRemoteUrl("origin", localMirror());
         w.git.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).shallow(true).execute();
+        check_remote_url("origin");
+        assertBranchesExist(w.git.getRemoteBranches(), "origin/master");
+        final String alternates = ".git" + File.separator + "objects" + File.separator + "info" + File.separator + "alternates";
+        assertFalse("Alternates file found: " + alternates, w.exists(alternates));
+        final String shallow = ".git" + File.separator + "shallow";
+        assertTrue("Shallow file not found: " + shallow, w.exists(shallow));
+    }
+
+    @NotImplementedInJGit
+    public void test_fetch_shallow_depth() throws Exception {
+        w.init();
+        w.git.setRemoteUrl("origin", localMirror());
+        w.git.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).shallow(true).depth(2).execute();
         check_remote_url("origin");
         assertBranchesExist(w.git.getRemoteBranches(), "origin/master");
         final String alternates = ".git" + File.separator + "objects" + File.separator + "info" + File.separator + "alternates";


### PR DESCRIPTION
This is pre-work to make the base git-client plugin able to understand depth for shallow clones. There will be another pull request on the main git-plugin to take it from the UI.