### PR TITLE
(WIP) git-client: teach submoduleUpdate how to pass credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -867,6 +867,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return new SubmoduleUpdateCommand() {
             boolean recursive                      = false;
             boolean remoteTracking                 = false;
+            boolean parentCredentials              = false;
             String  ref                            = null;
             Map<String, String> submodBranch   = new HashMap<String, String>();
             public Integer timeout;
@@ -878,6 +879,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             public SubmoduleUpdateCommand remoteTracking(boolean remoteTracking) {
                 this.remoteTracking = remoteTracking;
+                return this;
+            }
+
+            public SubmoduleUpdateCommand parentCredentials(boolean parentCredentials) {
+                this.parentCredentials = parentCredentials;
                 return this;
             }
 
@@ -959,6 +965,18 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     }
 
                     StandardCredentials cred = credentials.get(urIish.toPrivateString());
+                    if (parentCredentials) {
+                        String parentUrl = getRemoteUrl(getDefaultRemote());
+                        URIish parentUri = null;
+                        try {
+                            parentUri = new URIish(parentUrl);
+                        } catch (URISyntaxException e) {
+                            listener.error("Invalid URI for " + parentUrl);
+                            throw new GitException("Invalid URI for " + parentUrl);
+                        }
+                        cred = credentials.get(parentUri.toPrivateString());
+
+                    }
                     if (cred == null) cred = defaultCredentials;
 
                     perModuleArgs.add(sUrl);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -52,6 +52,7 @@ import org.eclipse.jgit.api.AddNoteCommand;
 import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.CreateBranchCommand.SetupUpstreamMode;
 import org.eclipse.jgit.api.FetchCommand;
+import org.eclipse.jgit.api.SubmoduleUpdateCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ListBranchCommand;
 import org.eclipse.jgit.api.LsRemoteCommand;
@@ -2090,38 +2091,39 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
      */
-    public SubmoduleUpdateCommand submoduleUpdate() {
-        return new SubmoduleUpdateCommand() {
+    public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand submoduleUpdate() {
+        return new org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand() {
             boolean recursive      = false;
             boolean remoteTracking = false;
             String  ref            = null;
 
-            public SubmoduleUpdateCommand recursive(boolean recursive) {
+            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand recursive(boolean recursive) {
                 this.recursive = recursive;
                 return this;
             }
 
-            public SubmoduleUpdateCommand remoteTracking(boolean remoteTracking) {
+            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand remoteTracking(boolean remoteTracking) {
                 this.remoteTracking = remoteTracking;
                 return this;
             }
 
-            public SubmoduleUpdateCommand ref(String ref) {
+            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand ref(String ref) {
                 this.ref = ref;
                 return this;
             }
 
-            public SubmoduleUpdateCommand timeout(Integer timeout) {
+            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand timeout(Integer timeout) {
             	// noop in jgit
                 return this;
             }
 
-            public SubmoduleUpdateCommand useBranch(String submodule, String branchname) {
+            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand useBranch(String submodule, String branchname) {
                 return this;
             }
 
             public void execute() throws GitException, InterruptedException {
                 Repository repo = null;
+                SubmoduleUpdateCommand update = null;
 
                 if (remoteTracking) {
                     listener.getLogger().println("[ERROR] JGit doesn't support remoteTracking submodules yet.");
@@ -2134,7 +2136,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 try {
                     repo = getRepository();
-                    git(repo).submoduleUpdate().call();
+                    update = git(repo).submoduleUpdate();
+                    update.setCredentialsProvider(getProvider());
+                    update.call();
                     if (recursive) {
                         for (JGitAPIImpl sub : submodules()) {
                             sub.submoduleUpdate(recursive);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2107,6 +2107,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand parentCredentials(boolean parentCredentials) {
+                // No-op for JGit implementation
+                return this;
+            }
+
             public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand ref(String ref) {
                 this.ref = ref;
                 return this;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
@@ -26,6 +26,15 @@ public interface SubmoduleUpdateCommand extends GitCommand {
     SubmoduleUpdateCommand remoteTracking(boolean remoteTracking);
 
     /**
+     * If set true and if the git version supports it, use the parent
+     * repository credentials when performing a submodule update.
+     *
+     * @param parentCredentials if true, will use the credentials of the parent project instead of credentials associated with its own URL
+     * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
+     */
+    SubmoduleUpdateCommand parentCredentials(boolean parentCredentials);
+
+    /**
      * ref.
      *
      * @param ref a {@link java.lang.String} object.

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -297,6 +297,12 @@ public class CredentialsTest {
         ObjectId master = git.getHeadRev(gitRepoURL, "master");
         log().println("Checking out " + master + " from " + gitRepoURL);
         git.checkout().branch("master").ref(master.getName()).deleteBranchIfExist(true).execute();
+        if (submodules) {
+            log().println("Initializing submodules from " + gitRepoURL);
+            git.submoduleInit();
+            SubmoduleUpdateCommand subcmd = git.submoduleUpdate();
+            subcmd.execute();
+        }
         assertTrue("master: " + master + " not in repo", git.isCommitInRepo(master));
         assertEquals("Master != HEAD", master, git.getRepository().getRef("master").getObjectId());
         assertEquals("Wrong branch", "master", git.getRepository().getBranch());

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -60,6 +60,7 @@ public class CredentialsTest {
     private final File privateKey;
     private final String fileToCheck;
     private final Boolean submodules;
+    private final Boolean useParentCreds;
 
     private GitClient git;
     private File repo;
@@ -87,7 +88,7 @@ public class CredentialsTest {
         return StreamTaskListener.fromStdout().getLogger();
     }
 
-    public CredentialsTest(String gitImpl, String gitRepoUrl, String username, String password, File privateKey, String fileToCheck, Boolean submodules) {
+    public CredentialsTest(String gitImpl, String gitRepoUrl, String username, String password, File privateKey, String fileToCheck, Boolean submodules, Boolean useParentCreds) {
         this.gitImpl = gitImpl;
         this.gitRepoURL = gitRepoUrl;
         this.privateKey = privateKey;
@@ -95,6 +96,7 @@ public class CredentialsTest {
         this.password = password;
         this.fileToCheck = fileToCheck;
         this.submodules = submodules;
+        this.useParentCreds = useParentCreds;
         log().println("Repo: " + gitRepoUrl);
     }
 
@@ -225,6 +227,11 @@ public class CredentialsTest {
                         submodules = false;
                     }
 
+                    Boolean useParentCreds = (Boolean) entry.get("parentcreds");
+                    if (useParentCreds == null) {
+                        useParentCreds = false;
+                    }
+
                     String keyfile = (String) entry.get("keyfile");
                     File privateKey = null;
 
@@ -242,7 +249,7 @@ public class CredentialsTest {
 
                     /* Add URL if it matches the pattern */
                     if (URL_MUST_MATCH_PATTERN.matcher(repoURL).matches()) {
-                        Object[] repo = {implementation, repoURL, username, password, privateKey, fileToCheck, submodules};
+                        Object[] repo = {implementation, repoURL, username, password, privateKey, fileToCheck, submodules, useParentCreds};
                         repos.add(repo);
                     }
                 }
@@ -300,7 +307,7 @@ public class CredentialsTest {
         if (submodules) {
             log().println("Initializing submodules from " + gitRepoURL);
             git.submoduleInit();
-            SubmoduleUpdateCommand subcmd = git.submoduleUpdate();
+            SubmoduleUpdateCommand subcmd = git.submoduleUpdate().parentCredentials(useParentCreds);
             subcmd.execute();
         }
         assertTrue("master: " + master + " not in repo", git.isCommitInRepo(master));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -111,7 +111,7 @@ public class CredentialsTest {
         listener.getLogger().println(LOGGING_STARTED);
         git = Git.with(listener, new hudson.EnvVars()).in(repo).using(gitImpl).getClient();
         if (gitImpl.equals("git")) {
-            addExpectedLogSubstring("> git -c core.askpass=true fetch ");
+            addExpectedLogSubstring("> git fetch ");
             addExpectedLogSubstring("> git checkout -b master ");
         }
         /* FetchWithCredentials does not log expected message */


### PR DESCRIPTION
Teach the submoduleUpdate call to perform submodule URL lookup, and call
"submodule update" separately for each submodule. Lookup the
credentials, and call it using launchCommandWithCredentials. This
enables submodules to correctly get the SSH or HTTP setup necessary such
that the Jenkins credentials will be passed into each submodule.

We can't just call "git submodule update" since it may be possible
(however unlikely!) that each submodule wants to use a separate
credential. Thus, perform lookup using each URL and run through a
forloop to actually update each submodule instead of depending on the
git implementation to do this for us.

JENKINS-20941 - Credentials and Submodules

NOTE: this depends on a change in the git-plugin to enable setting up default credentials or adding credentials for the submodule URL. I have submitted the pull request to git-plugin which enables advanced extensions for adding credentials to arbitrary URLs or as the default credentials.

It would be possible to just run "git submodule update" as before if we assume that "default" credentials are good enough, and supporting per-submodule credentials is not good. I believe per-module credentials should be supported which is why I went with the given implementation.

This patch together with the git-plugin patch do work in my setup, but I haven't yet had time to add more tests for this feature. It passes all of the current tests.


HTTP
--
This series also includes a fix for HTTP authentication that *should* also enable us to remove the clone = init+fetch setup. I believe we have enough tests for that particular change in behavior.

The HTTP patch removes use of the git-credential storage and instead just uses a GIT_ASKPASS script that will output username and password when given the suitable prompt. For stdin matching "Username" it outputs username, for stdin matching "Password" it outputs the password. This is much cleaner, and should even allow git-clone to work as expected without need to create credentials store.

I should note that the default test for the CSV repostiories found in auth-data requires that the repository contains a README.md which my repositories do not, resulting in test failures for no good reason. This should probably be fixed.