### PR TITLE
Change to fetch head rev with refs/tags

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2333,6 +2333,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     public Map<String, ObjectId> getHeadRev(String url) throws GitException, InterruptedException {
         ArgumentListBuilder args = new ArgumentListBuilder("ls-remote");
         args.add("-h");
+        args.add("-t");
         args.add(url);
 
         StandardCredentials cred = credentials.get(url);


### PR DESCRIPTION
`CliGitAPIImpl#getHeadRev(String url)` doesn't fetch refs/tags so [git-plugin](https://github.com/jenkinsci/git-plugin) can't handle any tags (ref. [https://github.com/jenkinsci/git-plugin/blob/af01132e56f767f7ee944a3b64b17aa3a0c7f198/src/main/java/hudson/plugins/git/GitSCM.java#L583](https://github.com/jenkinsci/git-plugin/blob/af01132e56f767f7ee944a3b64b17aa3a0c7f198/src/main/java/hudson/plugins/git/GitSCM.java#L583), [https://issues.jenkins-ci.org/browse/JENKINS-14917](https://issues.jenkins-ci.org/browse/JENKINS-14917)).

From the above, I changed `CliGitAPIImpl#getHeadRev(String url)` to fetch head revision with refs/tags by appending `-t` option to `git ls-remote`.

However I can't predict effect of this change. It should be another new method?
