### PR TITLE
implement repos.json to replace repos.csv

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
       <version>1.6</version>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -37,6 +37,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONArray;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 /**
  *
@@ -165,13 +169,13 @@ public class CredentialsTest {
     }
 
     @Parameterized.Parameters(name = "{2}-{1}-{0}")
-    public static Collection gitRepoUrls() throws MalformedURLException, FileNotFoundException, IOException, InterruptedException {
+    public static Collection gitRepoUrls() throws MalformedURLException, FileNotFoundException, IOException, InterruptedException, ParseException {
         List<Object[]> repos = new ArrayList<Object[]>();
         String[] implementations = isCredentialsSupported() ? new String[]{"git", "jgit"} : new String[]{"jgit"};
         for (String implementation : implementations) {
             /* Add master repository as authentication test with private
              * key of current user.  Try to test at least one
-             * authentication case, even if there is no repos.csv file in
+             * authentication case, even if there is no repos.json file in
              * the external directory.
              */
             if (defaultPrivateKey.exists()) {
@@ -182,28 +186,45 @@ public class CredentialsTest {
             }
 
             /* Add additional repositories if the ~/.ssh/auth-data directory
-             * contains a repos.csv file defining the repositories to test and the
-             * private key files to use for those tests.
+             * contains a repos.json file defining the repositories to test and the
+             * authentication data to use for those tests.
              */
-            File authDataDefinitions = new File(authDataDir, "repos.csv");
+            File authDataDefinitions = new File(authDataDir, "repos.json");
             if (authDataDefinitions.exists()) {
-                CSVReader reader = new CSVReader(new FileReader(authDataDefinitions));
-                List<String[]> myEntries = reader.readAll();
-                for (String[] entry : myEntries) {
-                    if (entry.length < 3) {
-                        System.out.println("Too few fields(" + entry.length + ") in " + entry[0]);
+                JSONParser parser = new JSONParser();
+                Object obj = parser.parse(new FileReader(authDataDefinitions));
+
+                JSONArray authEntries = (JSONArray)obj;
+
+                for (Object entryObj : authEntries) {
+                    JSONObject entry = (JSONObject)entryObj;
+                    String repoURL = (String) entry.get("url");
+                    String username = (String) entry.get("username");
+                    String password = (String) entry.get("password");
+                    String keyfile = (String) entry.get("keyfile");
+                    File privateKey = null;
+
+                    if (keyfile != null) {
+                        privateKey = privateKey = new File(authDataDir, keyfile);
+                        if (!privateKey.exists())
+                            privateKey = null;
+                    }
+
+                    if (repoURL == null) {
+                        System.out.println("No repository URL provided.");
                         continue;
                     }
-                    String repoURL = entry[0];
-                    String username = entry[1];
-                    File privateKey = new File(authDataDir, entry[2]);
-                    if (!privateKey.exists()) {
-                        privateKey = null;
+
+                    if (username == null) {
+                        System.out.println("No username provided for " + repoURL);
+                        continue;
                     }
-                    String password = null;
-                    if (entry.length > 3) {
-                        password = entry[3];
+
+                    if (privateKey == null && password == null) {
+                        System.out.println("No authentication information found for " + repoURL);
+                        continue;
                     }
+
                     Object[] repo = {implementation, repoURL, username, password, privateKey};
                     repos.add(repo);
                 }


### PR DESCRIPTION
Obviously, a new repos.json file will be required as compared to the current repos.csv.

This format is much more manageable, and extendable. Possibly we want to change the whole way we handle items in it instead of returning an object and using the items to populate a constructor, we should maybe pass the entire thing as a Map. However, I didn't bother with that just yet.

I did add two new features that are optional to the list, submodule checkout support, and file testing, to not hardcode the README.md

Hopefully this is a solid addition that can be pulled without much fuss, as these changes will be helpful in testing the related issues with the submodule and HTTP changes.