### PR TITLE
[JENKINS-30486] Added --no-commit option to MergeCommand

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -529,6 +529,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public String strategy;
             public String fastForwardMode;
             public boolean squash;
+            public boolean commit = true;
 
             public MergeCommand setRevisionToMerge(ObjectId rev) {
                 this.rev = rev;
@@ -555,12 +556,21 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public MergeCommand setCommit(boolean commit) {
+                this.commit = commit;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 ArgumentListBuilder args = new ArgumentListBuilder();
                 args.add("merge");
                 try {
                     if(squash) {
                         args.add("--squash");
+                    }
+
+                    if(!commit){
+                        args.add("--no-commit");
                     }
 
                     if (comment != null && !comment.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1467,6 +1467,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             MergeStrategy strategy;
             FastForwardMode fastForwardMode;
             boolean squash;
+            boolean commit = true;
             String comment;
 
             public MergeCommand setRevisionToMerge(ObjectId rev) {
@@ -1514,6 +1515,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public MergeCommand setCommit(boolean commit) {
+                this.commit = commit;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 Repository repo = null;
                 try {
@@ -1521,9 +1527,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     Git git = git(repo);
                     MergeResult mergeResult;
                     if (strategy != null)
-                        mergeResult = git.merge().setMessage(comment).setStrategy(strategy).setFastForward(fastForwardMode).setSquash(squash).include(rev).call();
+                        mergeResult = git.merge().setMessage(comment).setStrategy(strategy).setFastForward(fastForwardMode).setSquash(squash).setCommit(commit).include(rev).call();
                     else
-                        mergeResult = git.merge().setMessage(comment).setFastForward(fastForwardMode).setSquash(squash).include(rev).call();
+                        mergeResult = git.merge().setMessage(comment).setFastForward(fastForwardMode).setSquash(squash).setCommit(commit).include(rev).call();
                     if (!mergeResult.getMergeStatus().isSuccessful()) {
                         git.reset().setMode(HARD).call();
                         throw new GitException("Failed to merge " + rev);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
@@ -70,4 +70,12 @@ public interface MergeCommand extends GitCommand {
      * @return a {@link org.jenkinsci.plugins.gitclient.MergeCommand} object.
      */
     MergeCommand setSquash(boolean squash);
+
+    /**
+     * setCommit
+     *
+     * @param commit - whether or not to commit the result after a successful merge.
+     * @return a {@link org.jenkinsci.plugins.gitclient.MergeCommand} object.
+     */
+    MergeCommand setCommit(boolean commit);
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2396,6 +2396,48 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals("Squashless merge failed. Should have merged two commits.", 2, commitCountAfter - commitCountBefore);
     }
 
+    public void test_merge_no_commit() throws Exception{
+        w.init();
+        w.commitEmpty("init");
+
+        //Create branch1 and commit a file
+        w.git.branch("branch1");
+        w.git.checkout("branch1");
+        w.touch("file1", "content1");
+        w.git.add("file1");
+        w.git.commit("commit1");
+
+        //Merge branch1 with master, without committing the merge.
+        //Compare commit counts of before and after the merge, should be zero due to the lack of autocommit.
+        w.git.checkout("master");
+        final int commitCountBefore = w.git.revList("HEAD").size();
+        w.git.merge().setCommit(false).setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF).setRevisionToMerge(w.git.getHeadRev(w.repoPath(), "branch1")).execute();
+        final int commitCountAfter = w.git.revList("HEAD").size();
+
+        assertEquals("No Commit merge failed. Shouldn't have committed any changes.", 0, commitCountAfter - commitCountBefore);
+    }
+
+    public void test_merge_commit() throws Exception{
+        w.init();
+        w.commitEmpty("init");
+
+        //Create branch1 and commit a file
+        w.git.branch("branch1");
+        w.git.checkout("branch1");
+        w.touch("file1", "content1");
+        w.git.add("file1");
+        w.git.commit("commit1");
+
+        //Merge branch1 with master, without committing the merge.
+        //Compare commit counts of before and after the merge, should be two due to the commit of the file and the commit of the merge.
+        w.git.checkout("master");
+        final int commitCountBefore = w.git.revList("HEAD").size();
+        w.git.merge().setCommit(true).setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF).setRevisionToMerge(w.git.getHeadRev(w.repoPath(), "branch1")).execute();
+        final int commitCountAfter = w.git.revList("HEAD").size();
+
+        assertEquals("Commit merge failed. Should have committed the merge.", 2, commitCountAfter - commitCountBefore);
+    }
+
     public void test_merge_with_message() throws Exception {
         w.init();
         w.commitEmpty("init");


### PR DESCRIPTION
### Background
We are planning to use the Credentials API in our Pretested Integration plugin, but we're lacking certain features in the Git Client plugin. The ability to merge without committing being one of them.
Related issue: [JENKINS-30486](https://issues.jenkins-ci.org/browse/JENKINS-30486)

### Implementation
The MergeCommand interface now requires a setCommit(boolean commit) implementation which both JGitAPIImpl and CliGitAPIImpl received. Commit defaults to true as to not change the plugin's default behaviour.

### Testing
Two test cases were added to GitAPITestCase to test both a committed and non-commited merge. We also tested our own plugin, using the no-commit option, and all our tests pass as well.
