### PR TITLE
Improve the CONTRIBUTING file and matching code changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,9 @@ New feature proposals and bug fix proposals should be submitted as
 or can be submitted directly if you have commit permission to the
 git-client-plugin repository.
 
-If you're using a pull request, fork the repository on GitHub, prepare
-your change on your forked copy, and submit a pull request.  Your pull
-request will be evaluated by the
-[Cloudbees Jenkins job](https://jenkins.ci.cloudbees.com/job/plugins/job/git-client-plugin/)
-and you should receive e-mail with the results of the evaluation.
+Pull requests are evaluated by the
+[Cloudbees Jenkins job](https://jenkins.ci.cloudbees.com/job/plugins/job/git-client-plugin/).
+You should receive e-mail with the results of the evaluation.
 
 Before submitting your change, please assure that you've added a test
 which verifies your change.  There have been many developers involved
@@ -27,9 +25,12 @@ when you submit.
 Before submitting your change, please review the findbugs output to
 assure that you haven't introduced new findbugs warnings.
 
-Code formatting in the git client plugin varies between files.  Recent
-additions have generally used the Netbeans "Format" right-click action
-to maintain consistency for new additions.  Try to maintain reasonable
-consistency with the existing files where feasible.  Please don't
-perform wholesale reformatting of a file without discussing with the
-current maintainers.
+# Code Style Guidelines
+
+## Indentation
+
+* Code formatting in the git client plugin varies between files.  Recent additions have generally used the Netbeans "Format" right-click action to maintain consistency for new additions.  Try to maintain reasonable consistency with the existing files.  Please don't perform wholesale reformatting of a file without discussing with the current maintainers.
+
+## Maven POM file layout
+
+* The `pom.xml` file shall use the sequencing of elements as defined by the `mvn tidy:pom` command (after any indenting fix-up).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,4 @@ assure that you haven't introduced new findbugs warnings.
 ## Maven POM file layout
 
 * The `pom.xml` file shall use the sequencing of elements as defined by the `mvn tidy:pom` command (after any indenting fix-up).
+* All `<plugin>` entries shall have an explicit version defined unless inherited from the parent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,8 @@ assure that you haven't introduced new findbugs warnings.
 
 ## Indentation
 
-* Code formatting in the git client plugin varies between files.  Recent additions have generally used the Netbeans "Format" right-click action to maintain consistency for new additions.  Try to maintain reasonable consistency with the existing files.  Please don't perform wholesale reformatting of a file without discussing with the current maintainers.
+* Code formatting in the git client plugin varies between files.  Recent additions have generally used the Netbeans "Format" right-click action to maintain consistency for new additions.  Try to maintain reasonable consistency with the existing files.
+* Please don't perform wholesale reformatting of a file without discussing with the current maintainers.
 
 ## Maven POM file layout
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
     <maven-site-plugin.version>3.4</maven-site-plugin.version>
     <!-- End of updated versions required for "mvn site" -->
-    <maven-javadoc-plugin.version>2.10.1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
     <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
     <jgit.version>3.7.1.201504261725-r</jgit.version>
   </properties>
@@ -184,6 +184,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${maven-javadoc-plugin.version}</version>
         <configuration>
           <excludePackageNames>org.apache.commons.httpclient.contrib.ssl</excludePackageNames>
           <fixTags>param,return,throws,link</fixTags>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
@@ -10,10 +12,10 @@
   <artifactId>git-client</artifactId>
   <version>1.19.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
+
   <name>Jenkins GIT client plugin</name>
   <description>Utility plugin for Git support in Jenkins</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Git+Client+Plugin</url>
-
   <licenses>
     <license>
       <name>The MIT License (MIT)</name>
@@ -58,6 +60,24 @@
     <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
     <jgit.version>3.7.1.201504261725-r</jgit.version>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>jgit-repository</id>
+      <name>Eclipse JGit Repository</name>
+      <url>https://repo.eclipse.org/content/groups/releases/</url>
+    </repository>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>
@@ -140,25 +160,6 @@
     </dependency>
   </dependencies>
 
-  <repositories>
-    <repository>
-      <id>jgit-repository</id>
-      <name>Eclipse JGit Repository</name>
-      <url>https://repo.eclipse.org/content/groups/releases/</url>
-    </repository>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
     <plugins>
       <plugin>
@@ -224,5 +225,4 @@
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
@@ -75,6 +75,7 @@ public interface CloneCommand extends GitCommand {
      * When shallow cloning, allow for a depth to be set in cases where you need more than the immediate last commit.
      * Has no effect if shallow is set to false (default)
      *
+     * @param depth number of revisions to be included in shallow clone
      * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
      */
     CloneCommand depth(Integer depth);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
@@ -50,6 +50,7 @@ public interface FetchCommand extends GitCommand {
      * When shallow cloning, allow for a depth to be set in cases where you need more than the immediate last commit.
      * Has no effect if shallow is set to false (default)
      *
+     * @param depth number of revisions to be included in shallow clone
      * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
      */
     FetchCommand depth(Integer depth);


### PR DESCRIPTION
@stephenc commented on the power of a good CONTRIBUTING file to guide people as they submit pull requests.  This is my attempt to make some progress toward having a CONTRIBUTING file in the git client plugin which clearly expresses the guidelines for the plugin.

I think guidelines should only be added to the CONTRIBUTING file when the plugin source code actually complies with the guidelines.  Thus, this initial effort states very few guidelines.

I'd like a @reviewbybees to see if others think that is a reasonable approach for the git client plugin