### PR TITLE
Added RebaseCommand

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -593,6 +593,33 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /**
+     * rebase.
+     *
+     * @return a {@link org.jenkinsci.plugins.gitclient.RebaseCommand} object.
+     */
+    public RebaseCommand rebase() {
+        return new RebaseCommand() {
+            private String upstream;
+
+            public RebaseCommand setUpstream(String upstream) {
+                this.upstream = upstream;
+                return this;
+            }
+
+            public void execute() throws GitException, InterruptedException {
+                try {
+                    ArgumentListBuilder args = new ArgumentListBuilder();
+                    args.add("rebase");
+                    args.add(upstream);
+                    launchCommand(args);
+                } catch (GitException e) {
+                    throw new GitException("Could not rebase " + upstream, e);
+                }
+            }
+        };
+    }
+
+    /**
      * init_.
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.InitCommand} object.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -613,6 +613,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     args.add(upstream);
                     launchCommand(args);
                 } catch (GitException e) {
+                    launchCommand("rebase", "--abort");
                     throw new GitException("Could not rebase " + upstream, e);
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -19,7 +19,6 @@ import org.eclipse.jgit.transport.URIish;
 
 import javax.annotation.CheckForNull;
 import java.io.IOException;
-import java.io.NotSerializableException;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.util.List;
@@ -401,6 +400,13 @@ public interface GitClient {
      * @return a {@link org.jenkinsci.plugins.gitclient.MergeCommand} object.
      */
     MergeCommand merge();
+
+    /**
+     * rebase.
+     *
+     * @return a {@link org.jenkinsci.plugins.gitclient.RebaseCommand} object.
+     */
+    RebaseCommand rebase();
 
     /**
      * init_.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1589,7 +1589,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     RebaseResult rebaseResult = git.rebase().setUpstream(upstream).call();
                     if (!rebaseResult.getStatus().isSuccessful()) {
                         git.reset().setMode(HARD).call();
-                        git.checkout().setName(head);
+                        git.checkout().setName(head).call();
                         throw new GitException("Failed to rebase " + upstream);
                     }
                 } catch (IOException e){

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -119,6 +119,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.eclipse.jgit.api.RebaseCommand.Operation;
 import org.eclipse.jgit.api.RebaseResult;
 
 /**
@@ -1585,15 +1586,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 try {
                     repo = getRepository();
                     Git git = git(repo);
-                    String head = repo.resolve("HEAD").name();
                     RebaseResult rebaseResult = git.rebase().setUpstream(upstream).call();
                     if (!rebaseResult.getStatus().isSuccessful()) {
-                        git.reset().setMode(HARD).call();
-                        git.checkout().setName(head).call();
+                        git.rebase().setOperation(Operation.ABORT).call();
                         throw new GitException("Failed to rebase " + upstream);
                     }
-                } catch (IOException e){
-                    throw new GitException("Failed to rebase " + upstream, e);
                 } catch (GitAPIException e) {
                     throw new GitException("Failed to rebase " + upstream, e);
                 } finally {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RebaseCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RebaseCommand.java
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.gitclient;
+
+/**
+ * RebaseCommand interface.
+ */
+public interface RebaseCommand extends GitCommand {
+
+    /**
+     * setUpstream.
+     *
+     * @param upstream a {@link java.lang.String} object.
+     * @return a {@link org.jenkinsci.plugins.gitclient.RebaseCommand} object.
+     */
+    RebaseCommand setUpstream(String upstream);
+}

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -366,6 +366,15 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     }
 
     /**
+     * rebase.
+     *
+     * @return a {@link org.jenkinsci.plugins.gitclient.RebaseCommand} object.
+     */
+    public RebaseCommand rebase() {
+       return command(RebaseCommand.class);
+    }
+
+    /**
      * init_.
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.InitCommand} object.

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2550,6 +2550,8 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.rebase().setUpstream("master").execute();
 
         assertThat("Should've rebased feature1 onto master", w.git.revList("feature1").contains(w.git.revParse("master")));
+        assertEquals("HEAD should be on the rebased branch", w.git.revParse("HEAD").name(), w.git.revParse("feature1").name());
+        assertThat("Rebased file should be present in the worktree",w.git.getWorkTree().child("feature_file").exists());
     }
 
     public void test_rebase_fails_with_conflict() throws Exception {
@@ -2581,6 +2583,7 @@ public abstract class GitAPITestCase extends TestCase {
             fail();
         }
         catch (GitException e) {
+            assertEquals("HEAD should've been reset to the feature branch.", w.git.revParse("HEAD").name(), w.git.revParse("feature1").name());
             // expected
         }
     }


### PR DESCRIPTION
## Background

We're replacing all Git CLI calls in our plugin with those of the Git Client, since we'd like to make use of the Credentials API, but it's missing the ability to rebase.
Related issue: [JENKINS-30839](https://issues.jenkins-ci.org/browse/JENKINS-30839)

## Implementation

I added a RebaseCommand and added it to all the GitClient implementations. The implementations are pretty bare-bones and only allow for setting the target.

## Testing

I added two test cases that test the rebase with and without a conflict. I also tested our own plugin, using a snapshot version of the git client, all the tests pass and the rebase works just fine.
