### PR TITLE
JENKINS-31108 Disable push from shallow clone using CGit<1.9.0 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1075,6 +1075,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return !"false".equals(line.trim());
     }
 
+    public boolean isShallowRepository() {
+        return new File(workspace, pathJoin(".git", "shallow")).exists();
+    }
+
     private String pathJoin( String a, String b ) {
         return new File(a, b).toString();
     }
@@ -1726,6 +1730,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (tags) {
                     args.add("--tags");
+                }
+
+                if (!isAtLeastVersion(1,9,0,0) && isShallowRepository()) {
+                    throw new GitException("Can't push from shallow repository using git client older than 1.9.0");
                 }
 
                 StandardCredentials cred = credentials.get(remote.toPrivateString());


### PR DESCRIPTION
Versions of CLI Git < 1.9.0 have limitations when pushing from shallow
clone, which have been lifted in newer versions.
See http://stackoverflow.com/q/6900103 for more details.

After merging this commit GitException will be thrown when trying to
push from a shallow clone with CLI Git < 1.9.0.