### PR TITLE
Fix JENKINS-30371 allow symlinks with jgit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,14 @@
       <version>${jgit.version}</version>
     </dependency>
     <dependency>
+      <!-- Include jgit java7 component so that jgit can support
+           symbolic links when running on Java 7 with a file system
+           which supports symbolic links. See JENKINS-30371 -->
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit.java7</artifactId>
+      <version>${jgit.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>${findbugs-maven-plugin.version}</version>
         <configuration>
+          <skip>${skipFindbugs}</skip>
           <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
           <failOnError>${maven.findbugs.failure.strict}</failOnError>
           <xmlOutput>true</xmlOutput>
@@ -234,4 +235,17 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>java-6</id>
+      <activation>
+        <jdk>1.6</jdk>
+      </activation>
+      <properties>
+        <!-- Findbugs requires Java 7. This allows default run
+             of findbugs on every compile, unless running Java 6 -->
+        <skipFindbugs>true</skipFindbugs>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2044,13 +2044,20 @@ public abstract class GitAPITestCase extends TestCase {
         assertFalse(w.git.hasGitModules());
     }
 
+    private boolean isJava6() {
+        if (System.getProperty("java.version").startsWith("1.6")) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * core.symlinks is set to false by msysgit on Windows and by JGit
      * 3.3.0 on all platforms.  It is not set on Linux.  Refer to
      * JENKINS-21168, JENKINS-22376, and JENKINS-22391 for details.
      */
     private void checkSymlinkSetting(WorkingArea area) throws IOException {
-        String expected = SystemUtils.IS_OS_WINDOWS || area.git instanceof JGitAPIImpl ? "false" : "";
+        String expected = SystemUtils.IS_OS_WINDOWS || (area.git instanceof JGitAPIImpl && isJava6()) ? "false" : "";
         String symlinkValue = null;
         try {
             symlinkValue = w.cmd(true, "git config core.symlinks").trim();


### PR DESCRIPTION
Including one more JGit jar from the JGit 3.7.1 package allows JGit to support symbolic links in some cases.

Users running Java 6 will not have symlink support because the JGit library won't be loaded.

Users running Windows with default settings will not have symlink support because Windows does not allow symbolic links by default.

Users running Linux or FreeBSD or HP-UX or AIX or other Unix-like environments should have symbolic link support so long as they are running Java 7 or newer.