### PR TITLE
[JENKINS-32160] Set StrictHostKeyChecking=no even if no credentials are provided

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1340,28 +1340,27 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                                                 Integer timeout) throws GitException, InterruptedException {
 
         File key = null;
-        String user = null;
         File ssh = null;
         File pass = null;
         File store = null;
         EnvVars env = environment;
         boolean deleteWorkDir = false;
         try {
-            env = new EnvVars(env);
-            if (credentials instanceof SSHUserPrivateKey) {
-                SSHUserPrivateKey sshUser = (SSHUserPrivateKey) credentials;
-                listener.getLogger().println("using GIT_SSH to set credentials " + sshUser.getDescription());
-                key = createSshKeyFile(key, sshUser);
-                user = sshUser.getUsername();
-                if (launcher.isUnix()) {
-                    pass =  createUnixSshAskpass(sshUser);
-                } else {
-                    pass =  createWindowsSshAskpass(sshUser);
-                }
-                env.put("SSH_ASKPASS", pass.getAbsolutePath());
-            }
-
             if ("".equals(url.getScheme()) || "ssh".equals(url.getScheme())) {
+                String user = null;
+                env = new EnvVars(env);
+                if (credentials instanceof SSHUserPrivateKey) {
+                    SSHUserPrivateKey sshUser = (SSHUserPrivateKey) credentials;
+                    listener.getLogger().println("using GIT_SSH to set credentials " + sshUser.getDescription());
+                    key = createSshKeyFile(key, sshUser);
+                    user = sshUser.getUsername();
+                    if (launcher.isUnix()) {
+                        pass =  createUnixSshAskpass(sshUser);
+                    } else {
+                        pass =  createWindowsSshAskpass(sshUser);
+                    }
+                    env.put("SSH_ASKPASS", pass.getAbsolutePath());
+                }
                 if (launcher.isUnix()) {
                     ssh = createUnixGitSSH(key, user);
                 } else {


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-32160

This solves a confusing situation where the user configures a job with a
ssh repository, but doesn't provide ssh credentials.

In this case, the plugin doesn't provide StrictHostKeyChecking=no to the
GIT_SSH configuration, and the build likely fails with "Host key verification
failed." unless the build slave has been pre-configured with the host key.

Then, the user tries to fix this known hosts issue, rather than providing
a ssh key which is the real fix.

@reviewbybees 
