### PR TITLE
New cherry pick sensitive changelog (between branches) command

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/AbstractLogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/AbstractLogCommand.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.gitclient;
+
+import java.io.Writer;
+
+public interface AbstractLogCommand<C extends AbstractLogCommand<?>> extends GitCommand {
+
+    /**
+     * Sets the {@link java.io.OutputStream} that receives the changelog.
+     *
+     * This takes {@link java.io.Writer} and not {@link java.io.OutputStream} because the changelog is a textual format,
+     * and therefore it is a stream of chars, not bytes. (If the latter, then we'd be unable to handle
+     * multiple encodings correctly)
+     *
+     * According to man git-commit, the "encoding" header specifies the encoding of the commit message,
+     * and git CLIs will try to translate encoding back to UTF-8. In any case, it is the implementation's
+     * responsibility to correctly handle the encoding
+     *
+     * @param w a {@link java.io.Writer} object.
+     * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
+     */
+    C to(Writer w);
+
+    /**
+     * Limit the number of changelog entries up to n.
+     *
+     * @param n a int.
+     * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
+     */
+    C max(int n);
+
+    /**
+     * Abort this ChangelogCommand without executing it, close any
+     * open resources.  The JGit implementation of changelog
+     * calculation opens the git repository and will close it when the
+     * changelog.execute() is processed.  However, there are cases
+     * (like GitSCM.computeChangeLog) which create a changelog and
+     * never call execute().
+     *
+     * Either execute() or abort() must be called for each
+     * ChangelogCommand instance or files will be left open.
+     */
+    void abort();
+	
+}

--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -47,7 +47,7 @@ import java.io.Writer;
  *
  * @author Kohsuke Kawaguchi
  */
-public interface ChangelogCommand extends GitCommand {
+public interface ChangelogCommand extends AbstractLogCommand<ChangelogCommand> {
     /**
      * Adds the revision to exclude from the log.
      * Equivalent of {@code ^rev} on the command line.
@@ -85,40 +85,4 @@ public interface ChangelogCommand extends GitCommand {
      */
     ChangelogCommand includes(ObjectId rev);
 
-    /**
-     * Sets the {@link java.io.OutputStream} that receives the changelog.
-     *
-     * This takes {@link java.io.Writer} and not {@link java.io.OutputStream} because the changelog is a textual format,
-     * and therefore it is a stream of chars, not bytes. (If the latter, then we'd be unable to handle
-     * multiple encodings correctly)
-     *
-     * According to man git-commit, the "encoding" header specifies the encoding of the commit message,
-     * and git CLIs will try to translate encoding back to UTF-8. In any case, it is the implementation's
-     * responsibility to correctly handle the encoding
-     *
-     * @param w a {@link java.io.Writer} object.
-     * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
-     */
-    ChangelogCommand to(Writer w);
-
-    /**
-     * Limit the number of changelog entries up to n.
-     *
-     * @param n a int.
-     * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
-     */
-    ChangelogCommand max(int n);
-
-    /**
-     * Abort this ChangelogCommand without executing it, close any
-     * open resources.  The JGit implementation of changelog
-     * calculation opens the git repository and will close it when the
-     * changelog.execute() is processed.  However, there are cases
-     * (like GitSCM.computeChangeLog) which create a changelog and
-     * never call execute().
-     *
-     * Either execute() or abort() must be called for each
-     * ChangelogCommand instance or files will be left open.
-     */
-    void abort();
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.gitclient;
 
+import java.util.Collections;
 import java.util.List;
 
 /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.gitclient;
 
-import java.util.Collections;
 import java.util.List;
 
 /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CherryPickCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CherryPickCommand.java
@@ -1,0 +1,13 @@
+package org.jenkinsci.plugins.gitclient;
+
+/**
+ * cherry pick.
+ * See https://git-scm.com/docs/git-cherry-pick
+ *
+ * @author Jan Zajic
+ */
+public interface CherryPickCommand extends GitCommand {
+
+	CherryPickCommand commit(String sha1);
+	
+}

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -919,7 +919,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 if (n!=null)
                     args.add("-n").add(n);                
                 args.add(revisionRange);                
-                if (out==null)  throw new IllegalStateException();
+                if (out==null)  throw new IllegalStateException("Output writer is null! Set with method LogCommand.to(Writer w)");
 
                 try {
                     WriterOutputStream w = new WriterOutputStream(out);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -627,15 +627,15 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     @Override
     public CherryPickCommand cherryPick() {
-    	 return new CherryPickCommand() {
-             private String commit;
+        return new CherryPickCommand() {
+            private String commit;
 
-             @Override
+            @Override
             public CherryPickCommand commit(String sha1) {
-            	this.commit = sha1;
-            	return this;
+                this.commit = sha1;
+                return this;
             }
-            
+
             public void execute() throws GitException, InterruptedException {
                  try {
                      ArgumentListBuilder args = new ArgumentListBuilder();
@@ -649,7 +649,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
              }
          };
     }
-    
+
     /**
      * init_.
      *
@@ -872,19 +872,19 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
         };
     }
-    
+
     /** {@inheritDoc} */
-	public LogCommand log() {
+    public LogCommand log() {
         return new LogCommand() {
 
             /** Equivalent to the git-log raw format but using ISO 8601 date format - also prevent to depend on git CLI future changes */
             public static final String RAW = "commit %H%ntree %T%nparent %P%nauthor %aN <%aE> %ai%ncommitter %cN <%cE> %ci%n%n%w(76,4,4)%s%n%n%b";
-            
+
             Integer n = null;
             Writer out = null;
             String revisionRange = null;
             boolean cherryPick = false;
-            
+
             public LogCommand to(Writer w) {
                 this.out = w;
                 return this;
@@ -894,33 +894,33 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 this.n = n;
                 return this;
             }
-            
-			public LogCommand revisionRange(String fromRevision, String toRevision, boolean cherryPick) {
-				if(cherryPick)
-				{
-					revisionRange = fromRevision + "..." + toRevision;
-					this.cherryPick = true;					
-				} else {
-					revisionRange = fromRevision + ".." + toRevision;
-					this.cherryPick = false;
-				}
-				return this;
-			}
-            
+
+            public LogCommand revisionRange(String fromRevision, String toRevision, boolean cherryPick) {
+                if(cherryPick)
+                {
+                    revisionRange = fromRevision + "..." + toRevision;
+                    this.cherryPick = true;
+                } else {
+                    revisionRange = fromRevision + ".." + toRevision;
+                    this.cherryPick = false;
+                }
+                return this;
+            }
+
             public void abort() {
                 /* No cleanup needed to abort the CliGitAPIImpl ChangelogCommand */
             }
-            
+
             public void execute() throws GitException, InterruptedException {
-            	ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "log", "--no-merges", "--no-abbrev", "-M");
-            	if(cherryPick)
-            		args.add("--right-only", "--cherry-pick");
+                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "log", "--no-merges", "--no-abbrev", "-M");
+                if(cherryPick)
+                    args.add("--right-only", "--cherry-pick");
                 args.add("--format="+RAW);
                 if (n!=null)
                     args.add("-n").add(n);                
                 args.add(revisionRange);                
                 if (out==null)  throw new IllegalStateException();
-                
+
                 try {
                     WriterOutputStream w = new WriterOutputStream(out);
                     try {
@@ -933,16 +933,16 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     throw new GitException("Error launching git whatchanged",e);
                 }
             }
-            
+
             @Override
             public String toString() {
-            	return "Cli LogCommand[n: "+n + "," +
+                return "Cli LogCommand[n: "+n + "," +
                 "revisionRange: "+
                 "cherryPick: "+cherryPick+"]";
             }
 
         };
-	}
+    }
 
     /** {@inheritDoc} */
     public List<String> showRevision(ObjectId from, ObjectId to) throws GitException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -806,21 +806,21 @@ public interface GitClient {
      * @throws java.lang.InterruptedException if interrupted.
      */
     void changelog(String revFrom, String revTo, Writer os) throws GitException, InterruptedException;
-    
+
     /**
      * Returns a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} to build up the git-log invocation.
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
      */
     ChangelogCommand changelog();
-    
+
     /**
     * Returns a {@link org.jenkinsci.plugins.gitclient.LogCommand} to build up the git-log invocation.
     *
     * @return a {@link org.jenkinsci.plugins.gitclient.LogCommand} object.
     */
     LogCommand log();
-    
+
     /**
      * Appends to an existing git-note on the current HEAD commit.
      *

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -806,14 +806,21 @@ public interface GitClient {
      * @throws java.lang.InterruptedException if interrupted.
      */
     void changelog(String revFrom, String revTo, Writer os) throws GitException, InterruptedException;
-
+    
     /**
      * Returns a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} to build up the git-log invocation.
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
      */
     ChangelogCommand changelog();
-
+    
+    /**
+    * Returns a {@link org.jenkinsci.plugins.gitclient.LogCommand} to build up the git-log invocation.
+    *
+    * @return a {@link org.jenkinsci.plugins.gitclient.LogCommand} object.
+    */
+    LogCommand log();
+    
     /**
      * Appends to an existing git-note on the current HEAD commit.
      *
@@ -906,4 +913,7 @@ public interface GitClient {
      * @throws java.lang.InterruptedException on thread interruption
      */
     List<Branch> getBranchesContaining(String revspec, boolean allBranches) throws GitException, InterruptedException;
+    
+    CherryPickCommand cherryPick();
+    
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -21,6 +21,7 @@ import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitLockFailedException;
 import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
+import hudson.util.ArgumentListBuilder;
 import hudson.util.IOUtils;
 
 import java.io.File;
@@ -49,6 +50,8 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.lang.time.FastDateFormat;
 import org.eclipse.jgit.api.AddNoteCommand;
+import org.eclipse.jgit.api.CherryPickResult;
+import org.eclipse.jgit.api.CherryPickResult.CherryPickStatus;
 import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.CreateBranchCommand.SetupUpstreamMode;
 import org.eclipse.jgit.api.FetchCommand;
@@ -1174,7 +1177,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
         };
     }
-
+    
+	public LogCommand log() {
+		throw new UnsupportedOperationException("Not implemented using JGIT, use cli git instead");		
+	}
+    
     /**
      * Formats {@link RevCommit}.
      */
@@ -1599,7 +1606,44 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
         };
     }
+    
+    /**
+     * cherry-pick.
+     *
+     * @return a {@link org.jenkinsci.plugins.gitclient.CherryPickCommand} object.
+     */
+    @Override
+    public CherryPickCommand cherryPick() {
+    	 return new CherryPickCommand() {
+             private String commit;
 
+             @Override
+            public CherryPickCommand commit(String sha1) {
+            	this.commit = sha1;
+            	return this;
+            }
+            
+            public void execute() throws GitException, InterruptedException {
+            	 Repository repo = null;
+                 try {
+                     repo = getRepository();
+                     Git git = git(repo);
+                     CherryPickResult cherryPickResult = git.cherryPick().include(repo.resolve(commit)).call();
+                     if (cherryPickResult.getStatus()!=CherryPickStatus.OK) {
+                    	 //TODO: how abort cherry pick in jgit??
+                         throw new GitException("Failed to cherry-pick " + commit);
+                     }
+                 } catch (GitAPIException e) {
+                     throw new GitException("Failed to cherry-pick " + commit, e);
+                 } catch(IOException e) {
+                	 throw new GitException("Failed to cherry-pick " + commit, e);
+                 } finally {
+                     if (repo != null) repo.close();
+                 }
+             }
+         };
+    }
+    
     /** {@inheritDoc} */
     public void deleteTag(String tagName) throws GitException {
         Repository repo = null;
@@ -2777,4 +2821,5 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         repo.close();
         return config;
     }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/LogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/LogCommand.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.gitclient;
+
+/**
+ * Command builder for generating changelog in the format {@code GitSCM} expects, using git log command with revision range specification.
+ * Supports excluding cherry picks from change log, which other command ChangelogCommand don't.
+ * May in future support aditional advanced git log parameters. 
+ * 
+ * see https://git-scm.com/docs/git-log
+ * 
+ */
+public interface LogCommand extends AbstractLogCommand<LogCommand> {
+
+	/**
+     * range from..to.
+     *
+     * @param cherryPick - --cherry-pick - Omit any commit that introduces the same change as another commit  on the “other side”.
+     * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
+     */
+	LogCommand revisionRange(String fromRevision, String toRevision, boolean cherryPick);
+	    
+}

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -374,6 +374,11 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
        return command(RebaseCommand.class);
     }
 
+	@Override
+	public CherryPickCommand cherryPick() {
+		return command(CherryPickCommand.class);
+	}
+    
     /**
      * init_.
      *
@@ -678,7 +683,11 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     public ChangelogCommand changelog() {
         return command(ChangelogCommand.class);
     }
-
+    
+	public LogCommand log() {
+		return command(LogCommand.class);
+	}
+    
     /** {@inheritDoc} */
     public void appendNote(String note, String namespace) throws GitException, InterruptedException {
         proxy.appendNote(note, namespace);
@@ -872,4 +881,5 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
             throws GitException, InterruptedException {
         return getGitAPI().getBranchesContaining(revspec, allBranches);
     }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -3027,7 +3027,67 @@ public abstract class GitAPITestCase extends TestCase {
         String sha1 = w.git.revParse("HEAD").name();
         check_changelog_sha1(sha1, "master");
     }
-
+    
+    @NotImplementedInJGit
+    public void test_log() throws Exception {
+        w = clone(localMirror());
+        String sha1Prev = w.git.revParse("HEAD").name();
+        w.touch("changelog-file", "changelog-file-content-" + sha1Prev);
+        w.git.add("changelog-file");
+        w.git.commit("changelog-commit-message");
+        String sha1 = w.git.revParse("HEAD").name();
+        check_log_sha1(sha1, "master");
+    }
+    
+    @NotImplementedInJGit
+    public void test_log_exclude_cherry_pick() throws Exception {
+        w = clone(localMirror());
+        
+        //create empty branch
+        w.git.branch("branch1");
+               
+        w.touch("changelog-file", "changelog-file-content-1");
+        w.git.add("changelog-file");
+        w.git.commit("changelog-commit-message");
+        String shaCommit1 = w.git.revParse("HEAD").name();
+                
+        w.touch("changelog-file-2", "changelog-file-content-2");
+        w.git.add("changelog-file-2");
+        w.git.commit("changelog-commit-message-2");
+        String shaCommit2 = w.git.revParse("HEAD").name();
+        
+        w.git.branch("branch2");
+        
+        w.git.checkout().ref("branch1").execute();
+        //execute cherry pick command
+        w.git.cherryPick().commit(shaCommit2).execute();
+        
+        LogCommand logCommand = w.git.log();
+        logCommand.revisionRange("branch1", "branch2", true);
+        check_log_sha1(shaCommit1, logCommand);
+    }
+    
+    private void check_log_sha1(final String sha1, final String branchName) throws InterruptedException
+    {
+        LogCommand changelogCommand = w.git.log();
+        changelogCommand.max(1);
+        StringWriter writer = new StringWriter();
+        changelogCommand.to(writer);
+        changelogCommand.execute();
+        String splitLog[] = writer.toString().split("[\\n\\r]", 3); // Extract first line of changelog
+        assertEquals("Wrong changelog line 1 on branch " + branchName, "commit " + sha1, splitLog[0]);
+    }
+    
+    private void check_log_sha1(final String sha1, LogCommand changelogCommand) throws InterruptedException
+    {
+        changelogCommand.max(5);
+        StringWriter writer = new StringWriter();
+        changelogCommand.to(writer);
+        changelogCommand.execute();
+        String splitLog[] = writer.toString().split("[\\n\\r]", 3); // Extract first line of changelog
+        assertEquals("Wrong changelog line 1 using command " + changelogCommand + ", chagelog:\n"+writer.toString(), "commit " + sha1, splitLog[0]);
+    }
+    
     public void test_show_revision_for_merge() throws Exception {
         w = clone(localMirror());
         ObjectId from = ObjectId.fromString("45e76942914664ee19f31d90e6f2edbfe0d13a46");


### PR DESCRIPTION
I implemented LogCommand (alternative to ChangelogCommand). Only cli impl! It calls git cli log command - https://git-scm.com/docs/git-log, with following pattern:
A..B if you don't set cherryPick parameter, or --cherry-pick --right-only A...B if you set it to true. 

It's very important for jenkins to use in our projects - it is only way to show correct changelog between our release branches, because we havily use cherry picking where preparing release candidates to build. Without this, jenkins show much false positives commits in build changelog. We currently very depends on this modified plugins in our jenkins installation, other plugins that build on top of changelog are important for us (for example jira plugin).

I prefer to add new command instead of modify existing one, not to broke current functionality and because i don't now how implement jgit alternative of that. If someone know (and need it), you welcome.

I also add CherryPickCommand - cli and jgit implementation, because i need to create unit tests that test LogCommand and thats only possible with support of CherryPickCommand. 

I also modify git plugin to exploit this feature, we used it in our env. I create pull request https://github.com/jenkinsci/git-plugin/pull/373 to git plugin, which can be merged only after this pull request to git client plugin (it depends on this new feature).
