### PR TITLE
squid:S00115, squid:S1155 - Constant names should comply with a namin…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -62,9 +62,9 @@ import java.util.regex.Pattern;
  */
 public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
-    private static final boolean acceptSelfSignedCertificates;
+    private static final boolean ACCEPT_SELF_SIGNED_CERTIFICATES;
     static {
-        acceptSelfSignedCertificates = Boolean.getBoolean(GitClient.class.getName() + ".untrustedSSL");
+        ACCEPT_SELF_SIGNED_CERTIFICATES = Boolean.getBoolean(GitClient.class.getName() + ".untrustedSSL");
     }
 
     private static final long serialVersionUID = 1;
@@ -163,7 +163,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         this.gitExe = gitExe;
         this.environment = environment;
 
-        launcher = new LocalLauncher(IGitAPI.verbose?listener:TaskListener.NULL);
+        launcher = new LocalLauncher(IGitAPI.VERBOSE ?listener:TaskListener.NULL);
     }
 
     /** {@inheritDoc} */
@@ -1074,7 +1074,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
         if (remotes.contains(_default_)) {
             return _default_;
-        } else if ( remotes.size() >= 1 ) {
+        } else if ( !remotes.isEmpty() ) {
             return remotes.get(0);
         } else {
             throw new GitException("No remotes found!");
@@ -1850,7 +1850,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             for(Ref candidate : refs.values()) {
                 if(candidate.getName().startsWith(Constants.R_REMOTES)) {
                     Branch buildBranch = new Branch(candidate);
-                    if (!GitClient.quietRemoteBranches) {
+                    if (!GitClient.QUIET_REMOTE_BRANCHES) {
                         listener.getLogger().println("Seen branch in repository " + buildBranch.getName());
                     }
                     branches.add(buildBranch);
@@ -2223,7 +2223,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         try {
             List<ObjectId> revs = revList(commit.name());
 
-            return revs.size() != 0;
+            return !revs.isEmpty();
         } catch (GitException e) {
             return false;
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -36,11 +36,11 @@ import java.util.Set;
 public interface GitClient {
 
     /** Constant <code>verbose=Boolean.getBoolean(IGitAPI.class.getName() + ".verbose")</code> */
-    boolean verbose = Boolean.getBoolean(IGitAPI.class.getName() + ".verbose");
+    boolean VERBOSE = Boolean.getBoolean(IGitAPI.class.getName() + ".verbose");
 
     // If true, do not print the list of remote branches.
     /** Constant <code>quietRemoteBranches=Boolean.getBoolean(GitClient.class.getName() + ".quietRemoteBranches")</code> */
-    boolean quietRemoteBranches = Boolean.getBoolean(GitClient.class.getName() + ".quietRemoteBranches");
+    boolean QUIET_REMOTE_BRANCHES = Boolean.getBoolean(GitClient.class.getName() + ".quietRemoteBranches");
 
     /**
      * The supported credential types.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00115, squid:S1155 - Constant names should comply with a naming convention, Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S00115
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat