### PR TITLE
git-client: add support for --force option to submodule update

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -908,6 +908,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return new SubmoduleUpdateCommand() {
             boolean recursive                      = false;
             boolean remoteTracking                 = false;
+            boolean force                          = false;
             String  ref                            = null;
             Map<String, String> submodBranch   = new HashMap<String, String>();
             public Integer timeout;
@@ -919,6 +920,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             public SubmoduleUpdateCommand remoteTracking(boolean remoteTracking) {
                 this.remoteTracking = remoteTracking;
+                return this;
+            }
+
+            public SubmoduleUpdateCommand force(boolean force) {
+                this.force = force;
                 return this;
             }
 
@@ -946,6 +952,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 args.add("submodule", "update");
                 if (recursive) {
                     args.add("--init", "--recursive");
+                }
+                if (force) {
+                    args.add("--force");
                 }
                 if (remoteTracking && isAtLeastVersion(1,8,2,0)) {
                     args.add("--remote");

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2135,11 +2135,17 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     public SubmoduleUpdateCommand submoduleUpdate() {
         return new SubmoduleUpdateCommand() {
             boolean recursive      = false;
+            boolean force          = false;
             boolean remoteTracking = false;
             String  ref            = null;
 
             public SubmoduleUpdateCommand recursive(boolean recursive) {
                 this.recursive = recursive;
+                return this;
+            }
+
+            public SubmoduleUpdateCommand force(boolean force){
+                this.force = force;
                 return this;
             }
 
@@ -2167,6 +2173,10 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (remoteTracking) {
                     listener.getLogger().println("[ERROR] JGit doesn't support remoteTracking submodules yet.");
+                    throw new UnsupportedOperationException("not implemented yet");
+                }
+                if (force) {
+                    listener.getLogger().println("[ERROR] JGit doesn't support force updating submodules yet.");
                     throw new UnsupportedOperationException("not implemented yet");
                 }
                 if ((ref != null) && !ref.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
@@ -14,6 +14,15 @@ public interface SubmoduleUpdateCommand extends GitCommand {
     SubmoduleUpdateCommand recursive(boolean recursive);
 
     /**
+     * If set true, submodule update will be forced even if the commit is
+     * alraedy cecked out.  Default is non-forced.
+     *
+     * @param force if true, will force update of submodules (requires git&gt;=1.6.5)
+     * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
+     */
+    SubmoduleUpdateCommand force(boolean force);
+
+    /**
      * If set true and if the git version supports it, update the
      * submodules to the tip of the branch rather than to a specific
      * SHA1.  Refer to git documentation for details.  First available


### PR DESCRIPTION
The purpose of this is to extend the CLI wrapper to allow --force option which enables recovery from some specific failures when the network has intermittent issues. Particularly, if the submodule update command happens to fail due to network issue, a re-run of the command will not re-checkout the files, as the way git CLI implemenation works it will see that the submodule is already at the desired commit. The Git mailing list said the best way to handle this is to use --force, but I don't think it should be default behavior considering that behavior change which can result.

Signed-off-by: Jacob Keller jacob.keller@gmail.com
