### PR TITLE
[JENKINS-31464] Changed the logic that sets the proxy environmental variables.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1424,7 +1424,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     }
                     if(shouldProxy) {
                         env = new EnvVars(env);
-                        listener.getLogger().println("Setting http proxy: " + proxy.name + ":" + proxy.port);
                         String userInfo = null;
                         if (proxy.getUserName() != null) {
                             userInfo = proxy.getUserName();
@@ -1434,8 +1433,25 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         }
                         try {
                             URI http_proxy = new URI("http", userInfo, proxy.name, proxy.port, null, null, null);
-                            env.put("http_proxy", http_proxy.toString());
-                            env.put("https_proxy", http_proxy.toString());
+                            // First check that the http proxy environmental variable is not already set.
+                            if( env.get("http_proxy", "") == "" ) {
+                                listener.getLogger().println("Setting http_proxy to be " + http_proxy.toString());
+                                env.put("http_proxy", http_proxy.toString());
+                            } else {
+                                listener.getLogger().println("Leaving http_proxy set to " + env.get("http_proxy", ""));
+                            }
+
+                            // First check that the https proxy environmental variable is not already set.
+                            if( env.get("https_proxy", "") == "" ) {
+                                listener.getLogger().println("Setting https_proxy to be " + http_proxy.toString());
+                                env.put("https_proxy", http_proxy.toString());
+                            } else {
+                                listener.getLogger().println("Leaving https_proxy set to " + env.get("https_proxy", ""));
+                            }
+
+                            // If we don't need the logging then the next two lines is equivalent to the above.
+                            //env.put("http_proxy", env.get("http_proxy", http_proxy.toString()));
+                            //env.put("https_proxy", env.get("https_proxy", http_proxy.toString()));
                         } catch (URISyntaxException ex) {
                             throw new GitException("Failed to create http proxy uri", ex);
                         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1434,7 +1434,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         try {
                             URI http_proxy = new URI("http", userInfo, proxy.name, proxy.port, null, null, null);
                             // First check that the http proxy environmental variable is not already set.
-                            if( env.get("http_proxy", "") == "" ) {
+                            if( env.get("http_proxy", "").equals("") ) {
                                 listener.getLogger().println("Setting http_proxy to be " + http_proxy.toString());
                                 env.put("http_proxy", http_proxy.toString());
                             } else {
@@ -1442,7 +1442,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                             }
 
                             // First check that the https proxy environmental variable is not already set.
-                            if( env.get("https_proxy", "") == "" ) {
+                            if( env.get("https_proxy", "").equals("") ) {
                                 listener.getLogger().println("Setting https_proxy to be " + http_proxy.toString());
                                 env.put("https_proxy", http_proxy.toString());
                             } else {


### PR DESCRIPTION
Now if there is already an environmental variable set (like in the node configuration or at the os layer on build user login) the git-client-plugin will not set it to be what is found in the "proxy settings" section of the jenkins configuration. This should mean that for the most part there would be no change in behaviour. The only difference this would make is if someone has gone to the trouble of setting these parameters at the node level (or at the o/s layer by setting the enviornment variables for the build user). If someone has gone to the trouble of setting the parameters in either of these two ways then it's likely (but not guaranteed) that they would had set these parameters correctly.
