### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/src/main/java/hudson/plugins/git/IndexEntry.java
+++ b/src/main/java/hudson/plugins/git/IndexEntry.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
  * @author nigelmagnay
  */
 public class IndexEntry implements Serializable {
-    String mode, type, object, file;
+    private String mode, type, object, file;
 
     /**
      * Returns the mode of this entry as a String.

--- a/src/main/java/hudson/plugins/git/Revision.java
+++ b/src/main/java/hudson/plugins/git/Revision.java
@@ -22,8 +22,8 @@ import java.util.Collection;
 public class Revision implements java.io.Serializable, Cloneable {
     private static final long serialVersionUID = -7203898556389073882L;
 
-    ObjectId           sha1;
-    Collection<Branch> branches;
+    private ObjectId           sha1;
+    private Collection<Branch> branches;
 
     /**
      * Constructor for Revision.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -67,15 +67,15 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         acceptSelfSignedCertificates = Boolean.getBoolean(GitClient.class.getName() + ".untrustedSSL");
     }
 
-    private static final long serialVersionUID = 1;
-    static final String SPARSE_CHECKOUT_FILE_DIR = ".git/info";
-    static final String SPARSE_CHECKOUT_FILE_PATH = ".git/info/sparse-checkout";
     static final String TIMEOUT_LOG_PREFIX = " # timeout=";
+    private static final long serialVersionUID = 1;
+    private static final String SPARSE_CHECKOUT_FILE_DIR = ".git/info";
+    private static final String SPARSE_CHECKOUT_FILE_PATH = ".git/info/sparse-checkout";
     private static final String INDEX_LOCK_FILE_PATH = ".git" + File.separator + "index.lock";
-    transient Launcher launcher;
-    TaskListener listener;
-    String gitExe;
-    EnvVars environment;
+    private transient Launcher launcher;
+    private TaskListener listener;
+    private String gitExe;
+    private EnvVars environment;
     private Map<String, StandardCredentials> credentials = new HashMap<String, StandardCredentials>();
     private StandardCredentials defaultCredentials;
 
@@ -379,14 +379,14 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     public CloneCommand clone_() {
         return new CloneCommand() {
-            String url;
-            String origin = "origin";
-            String reference;
-            boolean shallow,shared;
-            Integer timeout;
-            boolean tags = true;
-            List<RefSpec> refspecs;
-            Integer depth = 1;
+            private String url;
+            private String origin = "origin";
+            private String reference;
+            private boolean shallow,shared;
+            private Integer timeout;
+            private boolean tags = true;
+            private List<RefSpec> refspecs;
+            private Integer depth = 1;
 
             public CloneCommand url(String url) {
                 this.url = url;
@@ -782,10 +782,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             /** Equivalent to the git-log raw format but using ISO 8601 date format - also prevent to depend on git CLI future changes */
             public static final String RAW = "commit %H%ntree %T%nparent %P%nauthor %aN <%aE> %ai%ncommitter %cN <%cE> %ci%n%n%w(76,4,4)%s%n%n%b";
-            final List<String> revs = new ArrayList<String>();
+            private final List<String> revs = new ArrayList<String>();
 
-            Integer n = null;
-            Writer out = null;
+            private Integer n = null;
+            private Writer out = null;
 
             public ChangelogCommand excludes(String rev) {
                 revs.add(sanitize('^'+rev));
@@ -906,10 +906,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     public SubmoduleUpdateCommand submoduleUpdate() {
         return new SubmoduleUpdateCommand() {
-            boolean recursive                      = false;
-            boolean remoteTracking                 = false;
-            String  ref                            = null;
-            Map<String, String> submodBranch   = new HashMap<String, String>();
+            private boolean recursive                      = false;
+            private boolean remoteTracking                 = false;
+            private String  ref                            = null;
+            private Map<String, String> submodBranch   = new HashMap<String, String>();
             public Integer timeout;
 
             public SubmoduleUpdateCommand recursive(boolean recursive) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1085,11 +1085,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     public ChangelogCommand changelog() {
         return new ChangelogCommand() {
-            Repository repo = getRepository();
-            ObjectReader or = repo.newObjectReader();
-            RevWalk walk = new RevWalk(or);
-            Writer out;
-            boolean hasIncludedRev = false;
+            private Repository repo = getRepository();
+            private ObjectReader or = repo.newObjectReader();
+            private RevWalk walk = new RevWalk(or);
+            private Writer out;
+            private boolean hasIncludedRev = false;
 
             public ChangelogCommand excludes(String rev) {
                 try {
@@ -1313,13 +1313,13 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     public CloneCommand clone_() {
 
         return new CloneCommand() {
-            String url;
-            String remote = Constants.DEFAULT_REMOTE_NAME;
-            String reference;
-            Integer timeout;
-            boolean shared;
-            boolean tags = true;
-            List<RefSpec> refspecs;
+            private String url;
+            private String remote = Constants.DEFAULT_REMOTE_NAME;
+            private String reference;
+            private Integer timeout;
+            private boolean shared;
+            private boolean tags = true;
+            private List<RefSpec> refspecs;
 
             public CloneCommand url(String url) {
                 this.url = url;
@@ -1471,12 +1471,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     public MergeCommand merge() {
         return new MergeCommand() {
 
-            ObjectId rev;
-            MergeStrategy strategy;
-            FastForwardMode fastForwardMode;
-            boolean squash;
-            boolean commit = true;
-            String comment;
+            private ObjectId rev;
+            private MergeStrategy strategy;
+            private FastForwardMode fastForwardMode;
+            private boolean squash;
+            private boolean commit = true;
+            private String comment;
 
             public MergeCommand setRevisionToMerge(ObjectId rev) {
                 this.rev = rev;
@@ -2134,9 +2134,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     public SubmoduleUpdateCommand submoduleUpdate() {
         return new SubmoduleUpdateCommand() {
-            boolean recursive      = false;
-            boolean remoteTracking = false;
-            String  ref            = null;
+            private boolean recursive      = false;
+            private boolean remoteTracking = false;
+            private String  ref            = null;
 
             public SubmoduleUpdateCommand recursive(boolean recursive) {
                 this.recursive = recursive;
@@ -2550,15 +2550,15 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
              * Tracks the depth of each tag as we find them.
              */
             class Candidate {
-                final RevCommit commit;
-                final Ref tag;
-                final RevFlag flag;
+                private final RevCommit commit;
+                private final Ref tag;
+                private final RevFlag flag;
 
                 /**
                  * This field number of commits that are reachable from the tip but
                  * not reachable from the tag.
                  */
-                int depth;
+                private int depth;
 
                 Candidate(RevCommit commit, Ref tag) {
                     this.commit = commit;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat
