### PR TITLE
The original GitException from a failed merge was good enough, no need to rethrow it

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -565,30 +565,26 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public void execute() throws GitException, InterruptedException {
                 ArgumentListBuilder args = new ArgumentListBuilder();
                 args.add("merge");
-                try {
-                    if(squash) {
-                        args.add("--squash");
-                    }
-
-                    if(!commit){
-                        args.add("--no-commit");
-                    }
-
-                    if (comment != null && !comment.isEmpty()) {
-                        args.add("-m");
-                        args.add(comment);
-                    }
-
-                    if (strategy != null && !strategy.isEmpty() && !strategy.equals(MergeCommand.Strategy.DEFAULT.toString())) {
-                        args.add("-s");
-                        args.add(strategy);
-                    }
-                    args.add(fastForwardMode);
-                    args.add(rev.name());
-                    launchCommand(args);
-                } catch (GitException e) {
-                    throw new GitException("Could not merge " + rev, e);
+                if(squash) {
+                    args.add("--squash");
                 }
+
+                if(!commit){
+                    args.add("--no-commit");
+                }
+
+                if (comment != null && !comment.isEmpty()) {
+                    args.add("-m");
+                    args.add(comment);
+                }
+
+                if (strategy != null && !strategy.isEmpty() && !strategy.equals(MergeCommand.Strategy.DEFAULT.toString())) {
+                    args.add("-s");
+                    args.add(strategy);
+                }
+                args.add(fastForwardMode);
+                args.add(rev.name());
+                launchCommand(args);
             }
         };
     }


### PR DESCRIPTION
Noticed while testing https://github.com/jenkinsci/github-branch-source-plugin/pull/60.

```
hudson.plugins.git.GitException: Could not merge AnyObjectId[99608938c2e9f12e73c4aba94b81a4dbdaffb937]
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$3.execute(CliGitAPIImpl.java:590)
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMSource$MergeWith.decorateRevisionToBuild(GitHubSCMSource.java:664)
	at hudson.plugins.git.GitSCM.determineRevisionToBuild(GitSCM.java:991)
	at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1080)
	at …
Caused by: hudson.plugins.git.GitException: Command "git merge 99608938c2e9f12e73c4aba94b81a4dbdaffb937" returned status code 1:
stdout: Auto-merging Jenkinsfile
CONFLICT (content): Merge conflict in Jenkinsfile
Automatic merge failed; fix conflicts and then commit the result.

stderr: 
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1719)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1695)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1691)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommand(CliGitAPIImpl.java:1321)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$3.execute(CliGitAPIImpl.java:588)
	... 9 more
```

simplified to

```
hudson.plugins.git.GitException: Command "git merge 99608938c2e9f12e73c4aba94b81a4dbdaffb937" returned status code 1:
stdout: Auto-merging Jenkinsfile
CONFLICT (content): Merge conflict in Jenkinsfile
Automatic merge failed; fix conflicts and then commit the result.

stderr: 
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1715)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1691)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1687)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommand(CliGitAPIImpl.java:1317)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$3.execute(CliGitAPIImpl.java:587)
	at org.jenkinsci.plugins.github_branch_source.GitHubSCMSource$MergeWith.decorateRevisionToBuild(GitHubSCMSource.java:664)
	at hudson.plugins.git.GitSCM.determineRevisionToBuild(GitSCM.java:991)
	at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1080)
	at …
```

@reviewbybees