### PR TITLE
git.clean() is more clean

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -668,7 +668,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     public void clean() throws GitException, InterruptedException {
         reset(true);
-        launchCommand("clean", "-fdx");
+        launchCommand("clean", "-fdxf");
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
git clean needs *two* -f's to delete directories that have a .git

From `git help clean`:

> If an untracked directory is managed by a different Git repository, it is not removed by default. Use -f option twice if you really want to remove such a directory.