### PR TITLE
do not call echo from absolute path

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1533,7 +1533,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         File ssh = File.createTempFile("pass", ".sh");
         PrintWriter w = new PrintWriter(ssh);
         w.println("#!/bin/sh");
-        w.println("/bin/echo \"" + Secret.toString(sshUser.getPassphrase()) + "\"");
+        w.println("echo \"" + Secret.toString(sshUser.getPassphrase()) + "\"");
         w.close();
         ssh.setExecutable(true);
         return ssh;
@@ -1711,7 +1711,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         EnvVars environment = new EnvVars(env);
         if (!env.containsKey("SSH_ASKPASS")) {
             // GIT_ASKPASS supersed SSH_ASKPASS when set, so don't mask SSH passphrase when set
-            environment.put("GIT_ASKPASS", launcher.isUnix() ? "/bin/echo" : "echo");
+            environment.put("GIT_ASKPASS", "echo");
         }
         String command = gitExe + " " + StringUtils.join(args.toCommandArray(), " ");
         try {


### PR DESCRIPTION
`git-client-plugin` calls `echo` with an absolute path from `/bin/echo` on *-nix operating systems which causes an error on any system where `echo` may not be located there for whatever reason.

I am running jenkins on [NixOS](http://nixos.org) which does not adhere to [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) meaning `echo` is not located in `/bin/echo`. 

This PR changes the code such that echo is always called without absolute path so it is executed from `$PATH`.

 I can't think of any good reason why executing it from an absolute path should be favourable and with this change it will work fine if `echo` is located elsewhere.

This fixes [JENKINS-36255](https://issues.jenkins-ci.org/browse/JENKINS-36255)