### PR TITLE
let CliGitAPIImpl rely on FilePath+Launcher remote API while JGitAPIIml is remotable.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532.2</version>
+    <version>1.609.2</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -3,6 +3,7 @@ package hudson.plugins.git;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Launcher;
 import hudson.model.TaskListener;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
@@ -38,21 +39,6 @@ public class GitAPI extends CliGitAPIImpl {
      * @param repository a {@link hudson.FilePath} for the repository directory
      * @param listener a {@link hudson.model.TaskListener} which monitors the git work
      * @param environment the {@link hudson.EnvVars} environment for the build
-     * @throws java.io.IOException if any IO failure
-     * @throws java.lang.InterruptedException if interrupted
-     */
-    @Deprecated
-    public GitAPI(String gitExe, FilePath repository, TaskListener listener, EnvVars environment) throws IOException, InterruptedException {
-        this(gitExe, new File(repository.getRemote()), listener, environment);
-    }
-
-    /**
-     * Constructor for GitAPI.
-     *
-     * @param gitExe name of git executable (git or git.exe or jgit)
-     * @param repository a {@link hudson.FilePath} for the repository directory
-     * @param listener a {@link hudson.model.TaskListener} which monitors the git work
-     * @param environment the {@link hudson.EnvVars} environment for the build
      * @param reference SHA1 for checkout
      * @throws java.io.IOException if any IO failure
      * @throws java.lang.InterruptedException if interrupted.
@@ -62,6 +48,11 @@ public class GitAPI extends CliGitAPIImpl {
         this(gitExe, repository, listener, environment);
     }
 
+    @Deprecated
+    public GitAPI(String gitExe, FilePath repository, TaskListener listener, EnvVars environment) throws IOException, InterruptedException {
+        this(gitExe, repository, listener, environment, (Launcher) null);
+    }
+
     /**
      * Constructor for GitAPI.
      *
@@ -69,12 +60,12 @@ public class GitAPI extends CliGitAPIImpl {
      * @param repository a {@link hudson.FilePath} for the repository directory
      * @param listener a {@link hudson.model.TaskListener} which monitors the git work
      * @param environment the {@link hudson.EnvVars} environment for the build
+     * @param launcher the (@link Launcher} to use to run gitExe
      * @throws java.io.IOException if any IO failure
      * @throws java.lang.InterruptedException if interrupted.
      */
-    @Deprecated
-    public GitAPI(String gitExe, File repository, TaskListener listener, EnvVars environment) throws IOException, InterruptedException {
-        super(gitExe, repository, listener, environment);
+    public GitAPI(String gitExe, FilePath repository, TaskListener listener, EnvVars environment, Launcher launcher) throws IOException, InterruptedException {
+        super(gitExe, repository, listener, environment, launcher);
 
         // If USE_CLI is forced, don't delegate to JGit client
         this.jgit = Git.USE_CLI ? null : Git.with(listener, environment).in(repository).using("jgit").getClient();
@@ -83,7 +74,7 @@ public class GitAPI extends CliGitAPIImpl {
     // --- delegate implemented methods to JGit client
 
     /** {@inheritDoc} */
-    public void add(String filePattern) throws GitException, InterruptedException {
+    public void add(String filePattern) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.add(filePattern); else  jgit.add(filePattern);
     }
 
@@ -94,17 +85,17 @@ public class GitAPI extends CliGitAPIImpl {
     */
 
     /** {@inheritDoc} */
-    public String getRemoteUrl(String name) throws GitException, InterruptedException {
+    public String getRemoteUrl(String name) throws GitException, InterruptedException, IOException {
         return Git.USE_CLI ? super.getRemoteUrl(name) :  jgit.getRemoteUrl(name);
     }
 
     /** {@inheritDoc} */
-    public void push(String remoteName, String refspec) throws GitException, InterruptedException {
+    public void push(String remoteName, String refspec) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.push(remoteName, refspec); else  jgit.push(remoteName, refspec);
     }
 
     /** {@inheritDoc} */
-    public String getTagMessage(String tagName) throws GitException, InterruptedException {
+    public String getTagMessage(String tagName) throws GitException, InterruptedException, IOException {
         return Git.USE_CLI ? super.getTagMessage(tagName) :  jgit.getTagMessage(tagName);
     }
 
@@ -156,7 +147,7 @@ public class GitAPI extends CliGitAPIImpl {
     }
 
     /** {@inheritDoc} */
-    public void setRemoteUrl(String name, String url) throws GitException, InterruptedException {
+    public void setRemoteUrl(String name, String url) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.setRemoteUrl(name, url); else  jgit.setRemoteUrl(name, url);
     }
 
@@ -191,7 +182,7 @@ public class GitAPI extends CliGitAPIImpl {
     */
 
     /** {@inheritDoc} */
-    public Set<Branch> getBranches() throws GitException, InterruptedException {
+    public Set<Branch> getBranches() throws GitException, InterruptedException, IOException {
         return Git.USE_CLI ? super.getBranches() :  jgit.getBranches();
     }
 
@@ -208,32 +199,32 @@ public class GitAPI extends CliGitAPIImpl {
     */
 
     /** {@inheritDoc} */
-    public Set<Branch> getRemoteBranches() throws GitException, InterruptedException {
+    public Set<Branch> getRemoteBranches() throws GitException, InterruptedException, IOException {
         return Git.USE_CLI ? super.getRemoteBranches() :  jgit.getRemoteBranches();
     }
 
     /** {@inheritDoc} */
-    public void init() throws GitException, InterruptedException {
+    public void init() throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.init(); else  jgit.init();
     }
 
     /** {@inheritDoc} */
-    public void deleteBranch(String name) throws GitException, InterruptedException {
+    public void deleteBranch(String name) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.deleteBranch(name); else  jgit.deleteBranch(name);
     }
 
     /** {@inheritDoc} */
-    public void checkout(String ref, String branch) throws GitException, InterruptedException {
+    public void checkout(String ref, String branch) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.checkout(ref, branch); else  jgit.checkout(ref, branch);
     }
 
     /** {@inheritDoc} */
-    public boolean hasGitRepo() throws GitException, InterruptedException {
+    public boolean hasGitRepo() throws GitException, InterruptedException, IOException {
         return Git.USE_CLI ? super.hasGitRepo() :  jgit.hasGitRepo();
     }
 
     /** {@inheritDoc} */
-    public boolean isCommitInRepo(ObjectId commit) throws GitException, InterruptedException {
+    public boolean isCommitInRepo(ObjectId commit) throws GitException, InterruptedException, IOException {
         return Git.USE_CLI ? super.isCommitInRepo(commit) :  jgit.isCommitInRepo(commit);
     }
 
@@ -244,33 +235,27 @@ public class GitAPI extends CliGitAPIImpl {
     */
 
     /** {@inheritDoc} */
-    public void commit(String message) throws GitException, InterruptedException {
+    public void commit(String message) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.commit(message); else  jgit.commit(message);
     }
 
     /** {@inheritDoc} */
-    public void commit(String message, PersonIdent author, PersonIdent committer) throws GitException, InterruptedException {
+    public void commit(String message, PersonIdent author, PersonIdent committer) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.commit(message, author, committer); else  jgit.commit(message, author, committer);
     }
 
     /** {@inheritDoc} */
-    public void checkout(String ref) throws GitException, InterruptedException {
+    public void checkout(String ref) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.checkout(ref); else  jgit.checkout(ref);
     }
 
     /** {@inheritDoc} */
-    public void deleteTag(String tagName) throws GitException, InterruptedException {
+    public void deleteTag(String tagName) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.deleteTag(tagName); else  jgit.deleteTag(tagName);
     }
 
     /** {@inheritDoc} */
-    @NonNull
-    public Repository getRepository() throws GitException {
-        return Git.USE_CLI ? super.getRepository() :  jgit.getRepository();
-    }
-
-    /** {@inheritDoc} */
-    public void tag(String tagName, String comment) throws GitException, InterruptedException {
+    public void tag(String tagName, String comment) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.tag(tagName, comment); else  jgit.tag(tagName, comment);
     }
 
@@ -281,22 +266,22 @@ public class GitAPI extends CliGitAPIImpl {
     */
 
     /** {@inheritDoc} */
-    public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
+    public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.fetch(url, refspecs); else  jgit.fetch(url, refspecs);
     }
 
     /** {@inheritDoc} */
-    public void fetch(String remoteName, RefSpec... refspec) throws GitException, InterruptedException {
+    public void fetch(String remoteName, RefSpec... refspec) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.fetch(remoteName, refspec); else  jgit.fetch(remoteName, refspec);
     }
 
     /** {@inheritDoc} */
-    public void fetch(String remoteName, RefSpec refspec) throws GitException, InterruptedException {
+    public void fetch(String remoteName, RefSpec refspec) throws GitException, InterruptedException, IOException {
         fetch(remoteName, new RefSpec[] {refspec});
     }
 
     /** {@inheritDoc} */
-    public boolean tagExists(String tagName) throws GitException, InterruptedException {
+    public boolean tagExists(String tagName) throws GitException, InterruptedException, IOException {
         return Git.USE_CLI ? super.tagExists(tagName) :  jgit.tagExists(tagName);
     }
 
@@ -307,17 +292,17 @@ public class GitAPI extends CliGitAPIImpl {
     */
 
     /** {@inheritDoc} */
-    public void clean() throws GitException, InterruptedException {
+    public void clean() throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.clean(); else  jgit.clean();
     }
 
     /** {@inheritDoc} */
-    public ObjectId revParse(String revName) throws GitException, InterruptedException {
+    public ObjectId revParse(String revName) throws GitException, InterruptedException, IOException {
         return Git.USE_CLI ? super.revParse(revName) :  jgit.revParse(revName);
     }
 
     /** {@inheritDoc} */
-    public void branch(String name) throws GitException, InterruptedException {
+    public void branch(String name) throws GitException, InterruptedException, IOException {
         if (Git.USE_CLI) super.branch(name); else  jgit.branch(name);
     }
 }

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -27,7 +27,7 @@ public interface IGitAPI extends GitClient {
      * @throws java.lang.InterruptedException if interrupted.
      * @see GitClient#hasGitModules
      */
-    boolean hasGitModules( String treeIsh ) throws GitException, InterruptedException;
+    boolean hasGitModules( String treeIsh ) throws GitException, InterruptedException, IOException;
 
     /**
      * Returns URL of remote name in repository GIT_DIR.
@@ -38,7 +38,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    String getRemoteUrl(String name, String GIT_DIR) throws GitException, InterruptedException;
+    String getRemoteUrl(String name, String GIT_DIR) throws GitException, InterruptedException, IOException;
 
     /**
      * Set remote repository name and URL.
@@ -49,7 +49,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void setRemoteUrl(String name, String url, String GIT_DIR) throws GitException, InterruptedException;
+    void setRemoteUrl(String name, String url, String GIT_DIR) throws GitException, InterruptedException, IOException;
 
     /**
      * Returns name of default remote.
@@ -59,7 +59,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    String getDefaultRemote( String _default_ ) throws GitException, InterruptedException;
+    String getDefaultRemote( String _default_ ) throws GitException, InterruptedException, IOException;
 
     /**
      * Returns true if this repositry is bare.
@@ -68,7 +68,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    boolean isBareRepository() throws GitException, InterruptedException;
+    boolean isBareRepository() throws GitException, InterruptedException, IOException;
 
     /**
      * Detect whether a repository at the given path is bare or not.
@@ -78,7 +78,7 @@ public interface IGitAPI extends GitClient {
      * @throws java.lang.InterruptedException if interrupted
      * @return true if this repository is bare
      */
-    boolean isBareRepository(String GIT_DIR) throws GitException, InterruptedException;
+    boolean isBareRepository(String GIT_DIR) throws GitException, InterruptedException, IOException;
 
     /**
      * Synchronizes submodules' remote URL configuration setting to
@@ -88,7 +88,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void submoduleSync() throws GitException, InterruptedException;
+    void submoduleSync() throws GitException, InterruptedException, IOException;
 
     /**
      * Returns URL of the named submodule.
@@ -98,7 +98,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    String getSubmoduleUrl(String name) throws GitException, InterruptedException;
+    String getSubmoduleUrl(String name) throws GitException, InterruptedException, IOException;
 
     /**
      * Sets URL of the named submodule.
@@ -108,7 +108,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void setSubmoduleUrl(String name, String url) throws GitException, InterruptedException;
+    void setSubmoduleUrl(String name, String url) throws GitException, InterruptedException, IOException;
 
     /**
      * fixSubmoduleUrls.
@@ -118,9 +118,9 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void fixSubmoduleUrls( String remote, TaskListener listener ) throws GitException, InterruptedException;
+    void fixSubmoduleUrls( String remote, TaskListener listener ) throws GitException, InterruptedException, IOException;
 
-    void setupSubmoduleUrls( String remote, TaskListener listener ) throws GitException, InterruptedException;
+    void setupSubmoduleUrls( String remote, TaskListener listener ) throws GitException, InterruptedException, IOException;
 
     /**
      * Retrieve commits based on refspec from repository.
@@ -130,7 +130,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public void fetch(String repository, String refspec) throws GitException, InterruptedException;
+    public void fetch(String repository, String refspec) throws GitException, InterruptedException, IOException;
 
     /**
      * Retrieve commits from RemoteConfig.
@@ -138,7 +138,7 @@ public interface IGitAPI extends GitClient {
      * @param remoteRepository remote configuration from which refs will be retrieved
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void fetch(RemoteConfig remoteRepository) throws InterruptedException;
+    void fetch(RemoteConfig remoteRepository) throws InterruptedException, IOException;
 
     /**
      * Retrieve commits from default remote.
@@ -146,7 +146,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void fetch() throws GitException, InterruptedException;
+    void fetch() throws GitException, InterruptedException, IOException;
 
     /**
      * Reset the contents of the working directory of this
@@ -156,7 +156,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void reset(boolean hard) throws GitException, InterruptedException;
+    void reset(boolean hard) throws GitException, InterruptedException, IOException;
 
     /**
      * Reset the contents of the working directory of this
@@ -165,9 +165,9 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void reset() throws GitException, InterruptedException;
+    void reset() throws GitException, InterruptedException, IOException;
 
-    void push(RemoteConfig repository, String revspec) throws GitException, InterruptedException;
+    void push(RemoteConfig repository, String revspec) throws GitException, InterruptedException, IOException;
 
     /**
      * Merge commits from revspec into the current branch.
@@ -176,7 +176,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void merge(String revSpec) throws GitException, InterruptedException;
+    void merge(String revSpec) throws GitException, InterruptedException, IOException;
 
     /**
      * Clone repository from source to this repository.
@@ -185,7 +185,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void clone(RemoteConfig source) throws GitException, InterruptedException;
+    void clone(RemoteConfig source) throws GitException, InterruptedException, IOException;
 
     /**
      * Clone repository from {@link org.eclipse.jgit.transport.RemoteConfig} rc to this repository.
@@ -195,7 +195,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void clone(RemoteConfig rc, boolean useShallowClone) throws GitException, InterruptedException;
+    void clone(RemoteConfig rc, boolean useShallowClone) throws GitException, InterruptedException, IOException;
 
     /**
      * Find all the branches that include the given commit.
@@ -209,7 +209,7 @@ public interface IGitAPI extends GitClient {
      *             instead. This method does work only with local branches on
      *             one implementation and with all the branches - in the other
      */
-    List<Branch> getBranchesContaining(String revspec) throws GitException, InterruptedException;
+    List<Branch> getBranchesContaining(String revspec) throws GitException, InterruptedException, IOException;
 
     /**
      * This method has been implemented as non-recursive historically, but
@@ -223,7 +223,7 @@ public interface IGitAPI extends GitClient {
      * @deprecated
      *  Use {@link #lsTree(String, boolean)} to be explicit about the recursion behaviour.
      */
-    List<IndexEntry> lsTree(String treeIsh) throws GitException, InterruptedException;
+    List<IndexEntry> lsTree(String treeIsh) throws GitException, InterruptedException, IOException;
 
     /**
      * lsTree.
@@ -234,7 +234,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    List<IndexEntry> lsTree(String treeIsh, boolean recursive) throws GitException, InterruptedException;
+    List<IndexEntry> lsTree(String treeIsh, boolean recursive) throws GitException, InterruptedException, IOException;
 
     /**
      * revListBranch.
@@ -244,7 +244,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    List<ObjectId> revListBranch(String branchId) throws GitException, InterruptedException;
+    List<ObjectId> revListBranch(String branchId) throws GitException, InterruptedException, IOException;
 
     /**
      * getTagsOnCommit.
@@ -258,10 +258,10 @@ public interface IGitAPI extends GitClient {
     List<Tag> getTagsOnCommit(String revName) throws GitException, IOException, InterruptedException;
 
     /** {@inheritDoc} */
-    void changelog(String revFrom, String revTo, OutputStream fos) throws GitException, InterruptedException;
+    void changelog(String revFrom, String revTo, OutputStream fos) throws GitException, InterruptedException, IOException;
 
     /** {@inheritDoc} */
-    void checkoutBranch(String branch, String commitish) throws GitException, InterruptedException;
+    void checkoutBranch(String branch, String commitish) throws GitException, InterruptedException, IOException;
 
     /**
      * mergeBase.
@@ -271,7 +271,7 @@ public interface IGitAPI extends GitClient {
      * @return a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    ObjectId mergeBase(ObjectId sha1, ObjectId sha2) throws InterruptedException;
+    ObjectId mergeBase(ObjectId sha1, ObjectId sha2) throws InterruptedException, IOException;
 
     /**
      * showRevision.
@@ -281,7 +281,7 @@ public interface IGitAPI extends GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    List<String> showRevision(Revision r) throws GitException, InterruptedException;
+    List<String> showRevision(Revision r) throws GitException, InterruptedException, IOException;
 
     /**
      * This method makes no sense, in that it lists all log entries across all refs and yet it
@@ -293,5 +293,5 @@ public interface IGitAPI extends GitClient {
      * @throws java.lang.InterruptedException if interrupted.
      */
     @Restricted(NoExternalUse.class)
-    String getAllLogEntries(String branch) throws InterruptedException;
+    String getAllLogEntries(String branch) throws InterruptedException, IOException;
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
@@ -21,18 +21,9 @@ import java.io.Writer;
  * @author Kohsuke Kawaguchi
  */
 abstract class AbstractGitAPIImpl implements GitClient, Serializable {
-    /** {@inheritDoc} */
-    public <T> T withRepository(RepositoryCallback<T> callable) throws IOException, InterruptedException {
-        Repository repo = getRepository();
-        try {
-            return callable.invoke(repo, MasterComputer.localChannel);
-        } finally {
-            repo.close();
-        }
-    }
 
     /** {@inheritDoc} */
-    public void commit(String message, PersonIdent author, PersonIdent committer) throws GitException, InterruptedException {
+    public void commit(String message, PersonIdent author, PersonIdent committer) throws GitException, InterruptedException, IOException {
         setAuthor(author);
         setCommitter(committer);
         commit(message);
@@ -51,39 +42,39 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
     }
 
     /** {@inheritDoc} */
-    public void changelog(String revFrom, String revTo, OutputStream outputStream) throws GitException, InterruptedException {
+    public void changelog(String revFrom, String revTo, OutputStream outputStream) throws GitException, InterruptedException, IOException {
         changelog(revFrom, revTo, new OutputStreamWriter(outputStream));
     }
 
     /** {@inheritDoc} */
-    public void changelog(String revFrom, String revTo, Writer w) throws GitException, InterruptedException {
+    public void changelog(String revFrom, String revTo, Writer w) throws GitException, InterruptedException, IOException {
         changelog().excludes(revFrom).includes(revTo).to(w).execute();
     }
 
     /** {@inheritDoc} */
-    public void clone(String url, String origin, boolean useShallowClone, String reference) throws GitException, InterruptedException {
+    public void clone(String url, String origin, boolean useShallowClone, String reference) throws GitException, InterruptedException, IOException {
         CloneCommand c = clone_().url(url).repositoryName(origin).reference(reference);
         if (useShallowClone)    c.shallow();
         c.execute();
     }
 
     /** {@inheritDoc} */
-    public void checkout(String commit) throws GitException, InterruptedException {
+    public void checkout(String commit) throws GitException, InterruptedException, IOException {
         checkout().ref(commit).execute();
     }
 
     /** {@inheritDoc} */
-    public void checkout(String ref, String branch) throws GitException, InterruptedException {
+    public void checkout(String ref, String branch) throws GitException, InterruptedException, IOException {
         checkout().ref(ref).branch(branch).execute();
     }
 
     /** {@inheritDoc} */
-    public void checkoutBranch(String branch, String ref) throws GitException, InterruptedException {
+    public void checkoutBranch(String branch, String ref) throws GitException, InterruptedException, IOException {
         checkout().ref(ref).branch(branch).deleteBranchIfExist(true).execute();
     }
 
     /** {@inheritDoc} */
-    public void merge(ObjectId rev) throws GitException, InterruptedException {
+    public void merge(ObjectId rev) throws GitException, InterruptedException, IOException {
         merge().setRevisionToMerge(rev).execute();
     }
 
@@ -121,19 +112,19 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
 
 
     /** {@inheritDoc} */
-    public void submoduleUpdate(boolean recursive) throws GitException, InterruptedException {
+    public void submoduleUpdate(boolean recursive) throws GitException, InterruptedException, IOException {
         submoduleUpdate().recursive(recursive).execute();
     }
     /** {@inheritDoc} */
-    public void submoduleUpdate(boolean recursive, String reference) throws GitException, InterruptedException {
+    public void submoduleUpdate(boolean recursive, String reference) throws GitException, InterruptedException, IOException {
         submoduleUpdate().recursive(recursive).ref(reference).execute();
     }
     /** {@inheritDoc} */
-    public void submoduleUpdate(boolean recursive, boolean remoteTracking) throws GitException, InterruptedException {
+    public void submoduleUpdate(boolean recursive, boolean remoteTracking) throws GitException, InterruptedException, IOException {
         submoduleUpdate().recursive(recursive).remoteTracking(remoteTracking).execute();
     }
     /** {@inheritDoc} */
-    public void submoduleUpdate(boolean recursive, boolean remoteTracking, String reference) throws GitException, InterruptedException {
+    public void submoduleUpdate(boolean recursive, boolean remoteTracking, String reference) throws GitException, InterruptedException, IOException {
         submoduleUpdate().recursive(recursive).remoteTracking(remoteTracking).ref(reference).execute();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -110,20 +110,6 @@ public interface GitClient {
     void setCommitter(PersonIdent p) throws GitException;
 
     /**
-     * Expose the JGit repository this GitClient is using.
-     * Don't forget to call {@link org.eclipse.jgit.lib.Repository#close()}, to avoid JENKINS-12188.
-     *
-     * @deprecated as of 1.1
-     *      This method was deprecated to make {@link org.jenkinsci.plugins.gitclient.GitClient} remotable. When called on
-     *      a proxy object, this method throws {@link java.io.NotSerializableException}.
-     *      Use {@link #withRepository(RepositoryCallback)} to pass in the closure instead.
-     *      This prevents the repository leak (JENKINS-12188), too.
-     * @return a {@link org.eclipse.jgit.lib.Repository} object.
-     * @throws hudson.plugins.git.GitException if underlying git operation fails.
-     */
-    Repository getRepository() throws GitException;
-
-    /**
      * Runs the computation that requires local access to {@link org.eclipse.jgit.lib.Repository}.
      *
      * @param callable the repository callback used as closure to instance
@@ -132,7 +118,7 @@ public interface GitClient {
      * @throws java.io.IOException in case of IO error
      * @throws java.lang.InterruptedException if interrupted
      */
-    <T> T withRepository(RepositoryCallback<T> callable) throws IOException, InterruptedException;
+    <T> T withRepository(RepositoryCallback<T> callable) throws IOException, InterruptedException, IOException;
 
     /**
      * The working tree of this repository.
@@ -147,7 +133,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public void init() throws GitException, InterruptedException;
+    public void init() throws GitException, InterruptedException, IOException;
 
     /**
      * add.
@@ -156,7 +142,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void add(String filePattern) throws GitException, InterruptedException;
+    void add(String filePattern) throws GitException, InterruptedException, IOException;
 
     /**
      * commit.
@@ -165,7 +151,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void commit(String message) throws GitException, InterruptedException;
+    void commit(String message) throws GitException, InterruptedException, IOException;
 
     /**
      * commit.
@@ -179,7 +165,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void commit(String message, PersonIdent author, PersonIdent committer) throws GitException, InterruptedException;
+    void commit(String message, PersonIdent author, PersonIdent committer) throws GitException, InterruptedException, IOException;
 
     /**
      * hasGitRepo.
@@ -188,7 +174,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    boolean hasGitRepo() throws GitException, InterruptedException;
+    boolean hasGitRepo() throws GitException, InterruptedException, IOException;
 
     /**
      * isCommitInRepo.
@@ -198,7 +184,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    boolean isCommitInRepo(ObjectId commit) throws GitException, InterruptedException;
+    boolean isCommitInRepo(ObjectId commit) throws GitException, InterruptedException, IOException;
 
     /**
      * From a given repository, get a remote's URL
@@ -208,7 +194,7 @@ public interface GitClient {
      * @return a {@link java.lang.String} object.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    String getRemoteUrl(String name) throws GitException, InterruptedException;
+    String getRemoteUrl(String name) throws GitException, InterruptedException, IOException;
 
     /**
      * For a given repository, set a remote's URL
@@ -218,7 +204,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if executing the git command fails
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void setRemoteUrl(String name, String url) throws GitException, InterruptedException;
+    void setRemoteUrl(String name, String url) throws GitException, InterruptedException, IOException;
 
     /**
      * addRemoteUrl.
@@ -228,7 +214,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void addRemoteUrl(String name, String url) throws GitException, InterruptedException;
+    void addRemoteUrl(String name, String url) throws GitException, InterruptedException, IOException;
 
     /**
      * Checks out the specified commit/tag/branch into the workspace.
@@ -239,7 +225,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void checkout(String ref) throws GitException, InterruptedException;
+    void checkout(String ref) throws GitException, InterruptedException, IOException;
 
     /**
      * Creates a new branch that points to the specified ref.
@@ -253,7 +239,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void checkout(String ref, String branch) throws GitException, InterruptedException;
+    void checkout(String ref, String branch) throws GitException, InterruptedException, IOException;
 
     /**
      * checkout.
@@ -291,7 +277,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void checkoutBranch(@CheckForNull String branch, String ref) throws GitException, InterruptedException;
+    void checkoutBranch(@CheckForNull String branch, String ref) throws GitException, InterruptedException, IOException;
 
 
     /**
@@ -304,7 +290,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void clone(String url, String origin, boolean useShallowClone, String reference) throws GitException, InterruptedException;
+    void clone(String url, String origin, boolean useShallowClone, String reference) throws GitException, InterruptedException, IOException;
 
     /**
      * Returns a {@link org.jenkinsci.plugins.gitclient.CloneCommand} to build up the git-log invocation.
@@ -323,7 +309,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException;
+    void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException, IOException;
 
     /**
      * fetch.
@@ -334,7 +320,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void fetch(String remoteName, RefSpec... refspec) throws GitException, InterruptedException;
+    void fetch(String remoteName, RefSpec... refspec) throws GitException, InterruptedException, IOException;
 
     /**
      * fetch.
@@ -345,7 +331,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void fetch(String remoteName, RefSpec refspec) throws GitException, InterruptedException;
+    void fetch(String remoteName, RefSpec refspec) throws GitException, InterruptedException, IOException;
 
     /**
      * fetch_.
@@ -363,7 +349,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void push(String remoteName, String refspec) throws GitException, InterruptedException;
+    void push(String remoteName, String refspec) throws GitException, InterruptedException, IOException;
 
     /**
      * push.
@@ -374,7 +360,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void push(URIish url, String refspec) throws GitException, InterruptedException;
+    void push(URIish url, String refspec) throws GitException, InterruptedException, IOException;
 
     /**
      * push.
@@ -392,7 +378,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void merge(ObjectId rev) throws GitException, InterruptedException;
+    void merge(ObjectId rev) throws GitException, InterruptedException, IOException;
 
     /**
      * merge.
@@ -422,7 +408,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void prune(RemoteConfig repository) throws GitException, InterruptedException;
+    void prune(RemoteConfig repository) throws GitException, InterruptedException, IOException;
 
     /**
      * Fully revert working copy to a clean state, i.e. run both
@@ -433,7 +419,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void clean() throws GitException, InterruptedException;
+    void clean() throws GitException, InterruptedException, IOException;
 
 
 
@@ -446,7 +432,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void branch(String name) throws GitException, InterruptedException;
+    void branch(String name) throws GitException, InterruptedException, IOException;
 
     /**
      * (force) delete a branch.
@@ -455,7 +441,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void deleteBranch(String name) throws GitException, InterruptedException;
+    void deleteBranch(String name) throws GitException, InterruptedException, IOException;
 
     /**
      * getBranches.
@@ -464,7 +450,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    Set<Branch> getBranches() throws GitException, InterruptedException;
+    Set<Branch> getBranches() throws GitException, InterruptedException, IOException;
 
     /**
      * getRemoteBranches.
@@ -473,7 +459,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    Set<Branch> getRemoteBranches() throws GitException, InterruptedException;
+    Set<Branch> getRemoteBranches() throws GitException, InterruptedException, IOException;
 
 
     // --- manage tags
@@ -486,7 +472,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void tag(String tagName, String comment) throws GitException, InterruptedException;
+    void tag(String tagName, String comment) throws GitException, InterruptedException, IOException;
 
     /**
      * tagExists.
@@ -496,7 +482,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    boolean tagExists(String tagName) throws GitException, InterruptedException;
+    boolean tagExists(String tagName) throws GitException, InterruptedException, IOException;
 
     /**
      * getTagMessage.
@@ -506,7 +492,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    String getTagMessage(String tagName) throws GitException, InterruptedException;
+    String getTagMessage(String tagName) throws GitException, InterruptedException, IOException;
 
     /**
      * deleteTag.
@@ -515,7 +501,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void deleteTag(String tagName) throws GitException, InterruptedException;
+    void deleteTag(String tagName) throws GitException, InterruptedException, IOException;
 
     /**
      * getTagNames.
@@ -525,7 +511,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    Set<String> getTagNames(String tagPattern) throws GitException, InterruptedException;
+    Set<String> getTagNames(String tagPattern) throws GitException, InterruptedException, IOException;
     /**
      * getRemoteTagNames.
      *
@@ -534,7 +520,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    Set<String> getRemoteTagNames(String tagPattern) throws GitException, InterruptedException;
+    Set<String> getRemoteTagNames(String tagPattern) throws GitException, InterruptedException, IOException;
 
 
     // --- manage refs
@@ -546,7 +532,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void ref(String refName) throws GitException, InterruptedException;
+    void ref(String refName) throws GitException, InterruptedException, IOException;
 
     /**
      * Check if a ref exists. Equivalent to comparing the return code of <tt>git show-ref</tt> to zero.
@@ -556,7 +542,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    boolean refExists(String refName) throws GitException, InterruptedException;
+    boolean refExists(String refName) throws GitException, InterruptedException, IOException;
 
     /**
      * Deletes a ref. Has no effect if the ref does not exist, equivalent to <tt>git update-ref -d</tt>.
@@ -565,7 +551,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void deleteRef(String refName) throws GitException, InterruptedException;
+    void deleteRef(String refName) throws GitException, InterruptedException, IOException;
 
     /**
      * List refs with the given prefix. Equivalent to <tt>git for-each-ref --format="%(refname)"</tt>.
@@ -575,7 +561,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    Set<String> getRefNames(String refPrefix) throws GitException, InterruptedException;
+    Set<String> getRefNames(String refPrefix) throws GitException, InterruptedException, IOException;
 
     // --- lookup revision
 
@@ -587,7 +573,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    Map<String, ObjectId> getHeadRev(String url) throws GitException, InterruptedException;
+    Map<String, ObjectId> getHeadRev(String url) throws GitException, InterruptedException, IOException;
 
     /**
      * getHeadRev.
@@ -598,7 +584,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    ObjectId getHeadRev(String remoteRepoUrl, String branch) throws GitException, InterruptedException;
+    ObjectId getHeadRev(String remoteRepoUrl, String branch) throws GitException, InterruptedException, IOException;
 
     /**
      * List references in a remote repository. Equivalent to <tt>git ls-remote [--heads] [--tags] &lt;repository&gt; [&lt;refs&gt;]</tt>.
@@ -617,7 +603,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    Map<String, ObjectId> getRemoteReferences(String remoteRepoUrl, String pattern, boolean headsOnly, boolean tagsOnly) throws GitException, InterruptedException;
+    Map<String, ObjectId> getRemoteReferences(String remoteRepoUrl, String pattern, boolean headsOnly, boolean tagsOnly) throws GitException, InterruptedException, IOException;
 
     /**
      * Retrieve commit object that is direct child for <tt>revName</tt> revision reference.
@@ -627,7 +613,7 @@ public interface GitClient {
      * @return a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    ObjectId revParse(String revName) throws GitException, InterruptedException;
+    ObjectId revParse(String revName) throws GitException, InterruptedException, IOException;
 
     /**
      * revList_.
@@ -643,7 +629,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    List<ObjectId> revListAll() throws GitException, InterruptedException;
+    List<ObjectId> revListAll() throws GitException, InterruptedException, IOException;
 
     /**
      * revList.
@@ -653,7 +639,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    List<ObjectId> revList(String ref) throws GitException, InterruptedException;
+    List<ObjectId> revList(String ref) throws GitException, InterruptedException, IOException;
 
 
     // --- submodules
@@ -673,7 +659,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    boolean hasGitModules() throws GitException, InterruptedException;
+    boolean hasGitModules() throws GitException, InterruptedException, IOException;
 
     /**
      * Finds all the submodule references in this repository at the specified tree.
@@ -683,7 +669,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    List<IndexEntry> getSubmodules( String treeIsh ) throws GitException, InterruptedException;
+    List<IndexEntry> getSubmodules( String treeIsh ) throws GitException, InterruptedException, IOException;
 
     /**
      * Create a submodule in subdir child directory for remote repository
@@ -693,7 +679,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void addSubmodule(String remoteURL, String subdir) throws GitException, InterruptedException;
+    void addSubmodule(String remoteURL, String subdir) throws GitException, InterruptedException, IOException;
 
     /**
      * Run submodule update optionally recursively on all submodules
@@ -704,7 +690,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void submoduleUpdate(boolean recursive)  throws GitException, InterruptedException;
+    void submoduleUpdate(boolean recursive)  throws GitException, InterruptedException, IOException;
 
     /**
      * Run submodule update optionally recursively on all submodules, with a specific
@@ -717,7 +703,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void submoduleUpdate(boolean recursive, String reference) throws GitException, InterruptedException;
+    void submoduleUpdate(boolean recursive, String reference) throws GitException, InterruptedException, IOException;
 
     /**
      * Run submodule update optionally recursively on all submodules, optionally with remoteTracking submodules
@@ -729,7 +715,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void submoduleUpdate(boolean recursive, boolean remoteTracking)  throws GitException, InterruptedException;
+    void submoduleUpdate(boolean recursive, boolean remoteTracking)  throws GitException, InterruptedException, IOException;
     /**
      * Run submodule update optionally recursively on all submodules, optionally with remoteTracking, with a specific
      * reference passed to git clone if needing to --init.
@@ -742,7 +728,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void submoduleUpdate(boolean recursive, boolean remoteTracking, String reference)  throws GitException, InterruptedException;
+    void submoduleUpdate(boolean recursive, boolean remoteTracking, String reference)  throws GitException, InterruptedException, IOException;
 
     /**
      * submoduleUpdate.
@@ -758,7 +744,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void submoduleClean(boolean recursive)  throws GitException, InterruptedException;
+    void submoduleClean(boolean recursive)  throws GitException, InterruptedException, IOException;
 
     /**
      * submoduleInit.
@@ -766,7 +752,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void submoduleInit()  throws GitException, InterruptedException;
+    void submoduleInit()  throws GitException, InterruptedException, IOException;
 
     /**
      * Set up submodule URLs so that they correspond to the remote pertaining to
@@ -777,7 +763,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void setupSubmoduleUrls( Revision rev, TaskListener listener ) throws GitException, InterruptedException;
+    void setupSubmoduleUrls( Revision rev, TaskListener listener ) throws GitException, InterruptedException, IOException;
 
 
     // --- commit log and notes
@@ -792,7 +778,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void changelog(String revFrom, String revTo, OutputStream os) throws GitException, InterruptedException;
+    void changelog(String revFrom, String revTo, OutputStream os) throws GitException, InterruptedException, IOException;
 
     /**
      * Adds the changelog entries for commits in the range revFrom..revTo.
@@ -805,7 +791,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void changelog(String revFrom, String revTo, Writer os) throws GitException, InterruptedException;
+    void changelog(String revFrom, String revTo, Writer os) throws GitException, InterruptedException, IOException;
 
     /**
      * Returns a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} to build up the git-log invocation.
@@ -826,7 +812,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void appendNote(String note, String namespace ) throws GitException, InterruptedException;
+    void appendNote(String note, String namespace ) throws GitException, InterruptedException, IOException;
 
     /**
      * Adds a new git-note on the current HEAD commit.
@@ -838,7 +824,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void addNote(String note, String namespace ) throws GitException, InterruptedException;
+    void addNote(String note, String namespace ) throws GitException, InterruptedException, IOException;
 
     /**
      * showRevision.
@@ -848,7 +834,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public List<String> showRevision(ObjectId r) throws GitException, InterruptedException;
+    public List<String> showRevision(ObjectId r) throws GitException, InterruptedException, IOException;
 
     /**
      * Given a Revision, show it as if it were an entry from git whatchanged, so that it
@@ -868,7 +854,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    List<String> showRevision(ObjectId from, ObjectId to) throws GitException, InterruptedException;
+    List<String> showRevision(ObjectId from, ObjectId to) throws GitException, InterruptedException, IOException;
 
     /**
      * Given a Revision, show it as if it were an entry from git whatchanged, so that it
@@ -893,7 +879,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput) throws GitException, InterruptedException;
+    List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput) throws GitException, InterruptedException, IOException;
 
 
     /**
@@ -906,7 +892,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    String describe(String commitIsh) throws GitException, InterruptedException;
+    String describe(String commitIsh) throws GitException, InterruptedException, IOException;
 
     /**
      * setCredentials.
@@ -931,5 +917,5 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException on Git exceptions
      * @throws java.lang.InterruptedException on thread interruption
      */
-    List<Branch> getBranchesContaining(String revspec, boolean allBranches) throws GitException, InterruptedException;
+    List<Branch> getBranchesContaining(String revspec, boolean allBranches) throws GitException, InterruptedException, IOException;
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitCommand.java
@@ -2,6 +2,8 @@ package org.jenkinsci.plugins.gitclient;
 
 import hudson.plugins.git.GitException;
 
+import java.io.IOException;
+
 /**
  * Base type for the builder style command object for various git commands.
  *
@@ -14,5 +16,5 @@ public interface GitCommand {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void execute() throws GitException, InterruptedException;
+    void execute() throws GitException, InterruptedException, IOException;
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -47,6 +47,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.time.FastDateFormat;
 import org.eclipse.jgit.api.AddNoteCommand;
 import org.eclipse.jgit.api.CommitCommand;
@@ -137,19 +138,41 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     private final TaskListener listener;
     private PersonIdent author, committer;
+    private final File workspace;
 
     private transient CredentialsProvider provider;
 
     JGitAPIImpl(File workspace, TaskListener listener) {
         /* If workspace is null, then default to current directory to match 
          * CliGitAPIImpl behavior */
-        super(workspace == null ? new File(".") : workspace);
+        super();
+        this.workspace = workspace;
         this.listener = listener;
 
         // to avoid rogue plugins from clobbering what we use, always
         // make a point of overwriting it with ours.
         SshSessionFactory.setInstance(new TrileadSessionFactory());
     }
+
+    /** {@inheritDoc} */
+    @Deprecated
+    public boolean hasGitModules(String treeIsh) throws GitException {
+        return hasGitModules();
+    }
+
+    /** {@inheritDoc} */
+    public boolean hasGitModules() throws GitException {
+        try {
+            return new File(workspace, ".gitmodules").exists();
+        } catch (SecurityException ex) {
+            throw new GitException(
+                    "Security error when trying to check for .gitmodules. Are you sure you have correct permissions?",
+                    ex);
+        } catch (Exception e) {
+            throw new GitException("Couldn't check for .gitmodules", e);
+        }
+    }
+
 
     /**
      * clearCredentials.
@@ -209,7 +232,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public void init() throws GitException, InterruptedException {
+    public void init() throws GitException, InterruptedException, IOException {
         init_().workspace(workspace.getAbsolutePath()).execute();
     }
 
@@ -653,7 +676,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @throws hudson.plugins.git.GitException if any.
      * @throws java.lang.InterruptedException if any.
      */
-    public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
+    public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException, IOException {
         fetch_().from(url, refspecs).execute();
     }
 
@@ -946,11 +969,20 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      */
     @NonNull
-    public Repository getRepository() throws GitException {
+    private Repository getRepository() throws GitException {
         try {
             return new RepositoryBuilder().setWorkTree(workspace).build();
         } catch (IOException e) {
             throw new GitException(e);
+        }
+    }
+
+    public <T> T withRepository(RepositoryCallback<T> callable) throws IOException, InterruptedException {
+        Repository repo = getRepository();
+        try {
+            return callable.invoke(repo, Jenkins.MasterComputer.localChannel);
+        } finally {
+            repo.close();
         }
     }
 
@@ -2019,6 +2051,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             revListCommand.execute();
         } catch (InterruptedException e) {
             throw new GitException(e);
+        } catch (IOException e) {
+            throw new GitException(e);
         }
         return oidList;
     }
@@ -2032,6 +2066,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         try {
             revListCommand.execute();
         } catch (InterruptedException e) {
+            throw new GitException(e);
+        } catch (IOException e) {
             throw new GitException(e);
         }
         return oidList;
@@ -2219,7 +2255,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /** {@inheritDoc} */
     @Deprecated
-    public void push(RemoteConfig repository, String refspec) throws GitException, InterruptedException {
+    public void push(RemoteConfig repository, String refspec) throws GitException, InterruptedException, IOException {
         push(repository.getName(),refspec);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -17,6 +17,7 @@ import hudson.remoting.Callable;
 import hudson.remoting.Channel;
 import hudson.remoting.RemoteOutputStream;
 import hudson.remoting.RemoteWriter;
+import jenkins.security.MasterToSlaveCallable;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
@@ -140,9 +141,9 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
             throw new IllegalStateException("Unexpected invocation: "+method);
         }
 
-        public void execute() throws GitException, InterruptedException {
+        public void execute() throws GitException, InterruptedException, IOException {
             try {
-                channel.call(new Callable<Void, GitException>() {
+                channel.call(new MasterToSlaveCallable<Void, GitException>() {
                     public Void call() throws GitException {
                         try {
                             GitCommand cmd = createCommand();
@@ -156,6 +157,8 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
                         } catch (IllegalAccessException e) {
                             throw new GitException(e);
                         } catch (InterruptedException e) {
+                            throw new GitException(e);
+                        } catch (IOException e) {
                             throw new GitException(e);
                         }
                     }
@@ -178,17 +181,6 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
 
     private OutputStream wrap(OutputStream os) {
         return new RemoteOutputStream(os);
-    }
-
-    /**
-     * getRepository.
-     *
-     * @return a {@link org.eclipse.jgit.lib.Repository} object.
-     * @throws hudson.plugins.git.GitException if underlying git operation fails.
-     */
-    @NonNull
-    public Repository getRepository() throws GitException {
-        throw new UnsupportedOperationException();
     }
 
     /**
@@ -234,7 +226,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     }
 
     /** {@inheritDoc} */
-    public <T> T withRepository(RepositoryCallback<T> callable) throws IOException, InterruptedException {
+    public <T> T withRepository(RepositoryCallback<T> callable) throws InterruptedException, IOException {
         return proxy.withRepository(callable);
     }
 
@@ -253,22 +245,22 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public void init() throws GitException, InterruptedException {
+    public void init() throws GitException, InterruptedException, IOException {
         proxy.init();
     }
 
     /** {@inheritDoc} */
-    public void add(String filePattern) throws GitException, InterruptedException {
+    public void add(String filePattern) throws GitException, InterruptedException, IOException {
         proxy.add(filePattern);
     }
 
     /** {@inheritDoc} */
-    public void commit(String message) throws GitException, InterruptedException {
+    public void commit(String message) throws GitException, InterruptedException, IOException {
         proxy.commit(message);
     }
 
     /** {@inheritDoc} */
-    public void commit(String message, PersonIdent author, PersonIdent committer) throws GitException, InterruptedException {
+    public void commit(String message, PersonIdent author, PersonIdent committer) throws GitException, InterruptedException, IOException {
         proxy.commit(message, author, committer);
     }
 
@@ -279,37 +271,37 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public boolean hasGitRepo() throws GitException, InterruptedException {
+    public boolean hasGitRepo() throws GitException, InterruptedException, IOException {
         return proxy.hasGitRepo();
     }
 
     /** {@inheritDoc} */
-    public boolean isCommitInRepo(ObjectId commit) throws GitException, InterruptedException {
+    public boolean isCommitInRepo(ObjectId commit) throws GitException, InterruptedException, IOException {
         return proxy.isCommitInRepo(commit);
     }
 
     /** {@inheritDoc} */
-    public String getRemoteUrl(String name) throws GitException, InterruptedException {
+    public String getRemoteUrl(String name) throws GitException, InterruptedException, IOException {
         return proxy.getRemoteUrl(name);
     }
 
     /** {@inheritDoc} */
-    public void setRemoteUrl(String name, String url) throws GitException, InterruptedException {
+    public void setRemoteUrl(String name, String url) throws GitException, InterruptedException, IOException {
         proxy.setRemoteUrl(name, url);
     }
 
     /** {@inheritDoc} */
-    public void addRemoteUrl(String name, String url) throws GitException, InterruptedException {
+    public void addRemoteUrl(String name, String url) throws GitException, InterruptedException, IOException {
         proxy.addRemoteUrl(name, url);
     }
 
     /** {@inheritDoc} */
-    public void checkout(String ref) throws GitException, InterruptedException {
+    public void checkout(String ref) throws GitException, InterruptedException, IOException {
         proxy.checkout(ref);
     }
 
     /** {@inheritDoc} */
-    public void checkout(String ref, String branch) throws GitException, InterruptedException {
+    public void checkout(String ref, String branch) throws GitException, InterruptedException, IOException {
         proxy.checkout(ref, branch);
     }
 
@@ -323,27 +315,27 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     }
 
     /** {@inheritDoc} */
-    public void checkoutBranch(String branch, String ref) throws GitException, InterruptedException {
+    public void checkoutBranch(String branch, String ref) throws GitException, InterruptedException, IOException {
         proxy.checkoutBranch(branch, ref);
     }
 
     /** {@inheritDoc} */
-    public ObjectId mergeBase(ObjectId sha1, ObjectId sha12) throws InterruptedException {
+    public ObjectId mergeBase(ObjectId sha1, ObjectId sha12) throws InterruptedException, IOException {
         return getGitAPI().mergeBase(sha1, sha12);
     }
 
     /** {@inheritDoc} */
-    public String getAllLogEntries(String branch) throws InterruptedException {
+    public String getAllLogEntries(String branch) throws InterruptedException, IOException {
         return getGitAPI().getAllLogEntries(branch);
     }
 
     /** {@inheritDoc} */
-    public List<String> showRevision(Revision r) throws GitException, InterruptedException {
+    public List<String> showRevision(Revision r) throws GitException, InterruptedException, IOException {
         return getGitAPI().showRevision(r);
     }
 
     /** {@inheritDoc} */
-    public void clone(String url, String origin, boolean useShallowClone, String reference) throws GitException, InterruptedException {
+    public void clone(String url, String origin, boolean useShallowClone, String reference) throws GitException, InterruptedException, IOException {
         proxy.clone(url, origin, useShallowClone, reference);
     }
 
@@ -409,37 +401,37 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if any.
      * @throws java.lang.InterruptedException if any.
      */
-    public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
+    public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException, IOException {
         proxy.fetch(url, refspecs);
     }
 
     /** {@inheritDoc} */
-    public void fetch(String remoteName, RefSpec... refspec) throws GitException, InterruptedException {
+    public void fetch(String remoteName, RefSpec... refspec) throws GitException, InterruptedException, IOException {
         proxy.fetch(remoteName, refspec);
     }
 
     /** {@inheritDoc} */
-    public void fetch(String remoteName, RefSpec refspec) throws GitException, InterruptedException {
+    public void fetch(String remoteName, RefSpec refspec) throws GitException, InterruptedException, IOException {
         fetch(remoteName, new RefSpec[]{refspec});
     }
 
     /** {@inheritDoc} */
-    public void push(String remoteName, String refspec) throws GitException, InterruptedException {
+    public void push(String remoteName, String refspec) throws GitException, InterruptedException, IOException {
         proxy.push(remoteName, refspec);
     }
 
     /** {@inheritDoc} */
-    public void push(URIish url, String refspec) throws GitException, InterruptedException {
+    public void push(URIish url, String refspec) throws GitException, InterruptedException, IOException {
         proxy.push(url, refspec);
     }
 
     /** {@inheritDoc} */
-    public void merge(ObjectId rev) throws GitException, InterruptedException {
+    public void merge(ObjectId rev) throws GitException, InterruptedException, IOException {
         proxy.merge(rev);
     }
 
     /** {@inheritDoc} */
-    public void prune(RemoteConfig repository) throws GitException, InterruptedException {
+    public void prune(RemoteConfig repository) throws GitException, InterruptedException, IOException {
         proxy.prune(repository);
     }
 
@@ -449,17 +441,17 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public void clean() throws GitException, InterruptedException {
+    public void clean() throws GitException, InterruptedException, IOException {
         proxy.clean();
     }
 
     /** {@inheritDoc} */
-    public void branch(String name) throws GitException, InterruptedException {
+    public void branch(String name) throws GitException, InterruptedException, IOException {
         proxy.branch(name);
     }
 
     /** {@inheritDoc} */
-    public void deleteBranch(String name) throws GitException, InterruptedException {
+    public void deleteBranch(String name) throws GitException, InterruptedException, IOException {
         proxy.deleteBranch(name);
     }
 
@@ -470,7 +462,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public Set<Branch> getBranches() throws GitException, InterruptedException {
+    public Set<Branch> getBranches() throws GitException, InterruptedException, IOException {
         return proxy.getBranches();
     }
 
@@ -481,77 +473,77 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public Set<Branch> getRemoteBranches() throws GitException, InterruptedException {
+    public Set<Branch> getRemoteBranches() throws GitException, InterruptedException, IOException {
         return proxy.getRemoteBranches();
     }
 
     /** {@inheritDoc} */
-    public void tag(String tagName, String comment) throws GitException, InterruptedException {
+    public void tag(String tagName, String comment) throws GitException, InterruptedException, IOException {
         proxy.tag(tagName, comment);
     }
 
     /** {@inheritDoc} */
-    public boolean tagExists(String tagName) throws GitException, InterruptedException {
+    public boolean tagExists(String tagName) throws GitException, InterruptedException, IOException {
         return proxy.tagExists(tagName);
     }
 
     /** {@inheritDoc} */
-    public String getTagMessage(String tagName) throws GitException, InterruptedException {
+    public String getTagMessage(String tagName) throws GitException, InterruptedException, IOException {
         return proxy.getTagMessage(tagName);
     }
 
     /** {@inheritDoc} */
-    public void deleteTag(String tagName) throws GitException, InterruptedException {
+    public void deleteTag(String tagName) throws GitException, InterruptedException, IOException {
         proxy.deleteTag(tagName);
     }
 
     /** {@inheritDoc} */
-    public Set<String> getTagNames(String tagPattern) throws GitException, InterruptedException {
+    public Set<String> getTagNames(String tagPattern) throws GitException, InterruptedException, IOException {
         return proxy.getTagNames(tagPattern);
     }
 
     /** {@inheritDoc} */
-    public void ref(String refName) throws GitException, InterruptedException {
+    public void ref(String refName) throws GitException, InterruptedException, IOException {
 	proxy.ref(refName);
     }
 
     /** {@inheritDoc} */
-    public boolean refExists(String refName) throws GitException, InterruptedException {
+    public boolean refExists(String refName) throws GitException, InterruptedException, IOException {
 	return proxy.refExists(refName);
     }
 
     /** {@inheritDoc} */
-    public void deleteRef(String refName) throws GitException, InterruptedException {
+    public void deleteRef(String refName) throws GitException, InterruptedException, IOException {
 	proxy.deleteRef(refName);
     }
 
     /** {@inheritDoc} */
-    public Set<String> getRefNames(String refPrefix) throws GitException, InterruptedException {
+    public Set<String> getRefNames(String refPrefix) throws GitException, InterruptedException, IOException {
 	return proxy.getRefNames(refPrefix);
     }
 
     /** {@inheritDoc} */
-    public Set<String> getRemoteTagNames(String tagPattern) throws GitException, InterruptedException {
+    public Set<String> getRemoteTagNames(String tagPattern) throws GitException, InterruptedException, IOException {
         return proxy.getTagNames(tagPattern);
     }
 
     /** {@inheritDoc} */
-    public Map<String, ObjectId> getHeadRev(String url) throws GitException, InterruptedException {
+    public Map<String, ObjectId> getHeadRev(String url) throws GitException, InterruptedException, IOException {
         return proxy.getHeadRev(url);
     }
 
     /** {@inheritDoc} */
-    public ObjectId getHeadRev(String remoteRepoUrl, String branch) throws GitException, InterruptedException {
+    public ObjectId getHeadRev(String remoteRepoUrl, String branch) throws GitException, InterruptedException, IOException {
         return proxy.getHeadRev(remoteRepoUrl, branch);
     }
 
     /** {@inheritDoc} */
-    public Map<String, ObjectId> getRemoteReferences(String remoteRepoUrl, String pattern, boolean headsOnly, boolean tagsOnly) throws GitException, InterruptedException {
+    public Map<String, ObjectId> getRemoteReferences(String remoteRepoUrl, String pattern, boolean headsOnly, boolean tagsOnly) throws GitException, InterruptedException, IOException {
         return proxy.getRemoteReferences(remoteRepoUrl, pattern, headsOnly, tagsOnly);
     }
 
     /** {@inheritDoc} */
-    public ObjectId revParse(String revName) throws GitException, InterruptedException {
+    public ObjectId revParse(String revName) throws GitException, InterruptedException, IOException {
         return proxy.revParse(revName);
     }
 
@@ -571,12 +563,12 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public List<ObjectId> revListAll() throws GitException, InterruptedException {
+    public List<ObjectId> revListAll() throws GitException, InterruptedException, IOException {
         return proxy.revListAll();
     }
 
     /** {@inheritDoc} */
-    public List<ObjectId> revList(String ref) throws GitException, InterruptedException {
+    public List<ObjectId> revList(String ref) throws GitException, InterruptedException, IOException {
         return proxy.revList(ref);
     }
 
@@ -592,22 +584,22 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public boolean hasGitModules() throws GitException, InterruptedException {
+    public boolean hasGitModules() throws GitException, InterruptedException, IOException {
         return proxy.hasGitModules();
     }
 
     /** {@inheritDoc} */
-    public List<IndexEntry> getSubmodules(String treeIsh) throws GitException, InterruptedException {
+    public List<IndexEntry> getSubmodules(String treeIsh) throws GitException, InterruptedException, IOException {
         return proxy.getSubmodules(treeIsh);
     }
 
     /** {@inheritDoc} */
-    public void addSubmodule(String remoteURL, String subdir) throws GitException, InterruptedException {
+    public void addSubmodule(String remoteURL, String subdir) throws GitException, InterruptedException, IOException {
         proxy.addSubmodule(remoteURL, subdir);
     }
 
     /** {@inheritDoc} */
-    public void submoduleUpdate(boolean recursive) throws GitException, InterruptedException {
+    public void submoduleUpdate(boolean recursive) throws GitException, InterruptedException, IOException {
         proxy.submoduleUpdate(recursive);
     }
 
@@ -619,17 +611,17 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if any.
      * @throws java.lang.InterruptedException if any.
      */
-    public void submoduleUpdate(boolean recursive, String ref) throws GitException, InterruptedException {
+    public void submoduleUpdate(boolean recursive, String ref) throws GitException, InterruptedException, IOException {
         proxy.submoduleUpdate(recursive, ref);
     }
 
     /** {@inheritDoc} */
-    public void submoduleUpdate(boolean recursive, boolean remoteTracking) throws GitException, InterruptedException {
+    public void submoduleUpdate(boolean recursive, boolean remoteTracking) throws GitException, InterruptedException, IOException {
         proxy.submoduleUpdate(recursive, remoteTracking);
     }
 
     /** {@inheritDoc} */
-    public void submoduleUpdate(boolean recursive, boolean remoteTracking, String reference) throws GitException, InterruptedException {
+    public void submoduleUpdate(boolean recursive, boolean remoteTracking, String reference) throws GitException, InterruptedException, IOException {
         proxy.submoduleUpdate(recursive, remoteTracking, reference);
     }
 
@@ -643,17 +635,17 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     }
 
     /** {@inheritDoc} */
-    public void submoduleClean(boolean recursive) throws GitException, InterruptedException {
+    public void submoduleClean(boolean recursive) throws GitException, InterruptedException, IOException {
         proxy.submoduleClean(recursive);
     }
 
     /** {@inheritDoc} */
-    public void setupSubmoduleUrls(Revision rev, TaskListener listener) throws GitException, InterruptedException {
+    public void setupSubmoduleUrls(Revision rev, TaskListener listener) throws GitException, InterruptedException, IOException {
         proxy.setupSubmoduleUrls(rev, listener);
     }
 
     /** {@inheritDoc} */
-    public void changelog(String revFrom, String revTo, OutputStream os) throws GitException, InterruptedException {
+    public void changelog(String revFrom, String revTo, OutputStream os) throws GitException, InterruptedException, IOException {
         proxy.changelog(revFrom, revTo, wrap(os));
     }
 
@@ -666,7 +658,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if any.
      * @throws java.lang.InterruptedException if any.
      */
-    public void changelog(String revFrom, String revTo, Writer os) throws GitException, InterruptedException {
+    public void changelog(String revFrom, String revTo, Writer os) throws GitException, InterruptedException, IOException {
         proxy.changelog(revFrom, revTo, os); // TODO: wrap
     }
 
@@ -680,47 +672,47 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     }
 
     /** {@inheritDoc} */
-    public void appendNote(String note, String namespace) throws GitException, InterruptedException {
+    public void appendNote(String note, String namespace) throws GitException, InterruptedException, IOException {
         proxy.appendNote(note, namespace);
     }
 
     /** {@inheritDoc} */
-    public void addNote(String note, String namespace) throws GitException, InterruptedException {
+    public void addNote(String note, String namespace) throws GitException, InterruptedException, IOException {
         proxy.addNote(note, namespace);
     }
 
     /** {@inheritDoc} */
-    public List<String> showRevision(ObjectId r) throws GitException, InterruptedException {
+    public List<String> showRevision(ObjectId r) throws GitException, InterruptedException, IOException {
         return proxy.showRevision(r);
     }
 
     /** {@inheritDoc} */
-    public List<String> showRevision(ObjectId from, ObjectId to) throws GitException, InterruptedException {
+    public List<String> showRevision(ObjectId from, ObjectId to) throws GitException, InterruptedException, IOException {
         return proxy.showRevision(from, to);
     }
 
     /** {@inheritDoc} */
-    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput) throws GitException, InterruptedException {
+    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput) throws GitException, InterruptedException, IOException {
         return proxy.showRevision(from, to, useRawOutput);
     }
 
     /** {@inheritDoc} */
-    public boolean hasGitModules(String treeIsh) throws GitException, InterruptedException {
+    public boolean hasGitModules(String treeIsh) throws GitException, InterruptedException, IOException {
         return getGitAPI().hasGitModules(treeIsh);
     }
 
     /** {@inheritDoc} */
-    public String getRemoteUrl(String name, String GIT_DIR) throws GitException, InterruptedException {
+    public String getRemoteUrl(String name, String GIT_DIR) throws GitException, InterruptedException, IOException {
         return getGitAPI().getRemoteUrl(name, GIT_DIR);
     }
 
     /** {@inheritDoc} */
-    public void setRemoteUrl(String name, String url, String GIT_DIR) throws GitException, InterruptedException {
+    public void setRemoteUrl(String name, String url, String GIT_DIR) throws GitException, InterruptedException, IOException {
         getGitAPI().setRemoteUrl(name, url, GIT_DIR);
     }
 
     /** {@inheritDoc} */
-    public String getDefaultRemote(String _default_) throws GitException, InterruptedException {
+    public String getDefaultRemote(String _default_) throws GitException, InterruptedException, IOException {
         return getGitAPI().getDefaultRemote(_default_);
     }
 
@@ -731,12 +723,12 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public boolean isBareRepository() throws GitException, InterruptedException {
+    public boolean isBareRepository() throws GitException, InterruptedException, IOException {
         return getGitAPI().isBareRepository();
     }
 
     /** {@inheritDoc} */
-    public boolean isBareRepository(String GIT_DIR) throws GitException, InterruptedException {
+    public boolean isBareRepository(String GIT_DIR) throws GitException, InterruptedException, IOException {
         return getGitAPI().isBareRepository(GIT_DIR);
     }
 
@@ -746,7 +738,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public void submoduleInit() throws GitException, InterruptedException {
+    public void submoduleInit() throws GitException, InterruptedException, IOException {
         getGitAPI().submoduleInit();
     }
 
@@ -756,37 +748,37 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public void submoduleSync() throws GitException, InterruptedException {
+    public void submoduleSync() throws GitException, InterruptedException, IOException {
         getGitAPI().submoduleSync();
     }
 
     /** {@inheritDoc} */
-    public String getSubmoduleUrl(String name) throws GitException, InterruptedException {
+    public String getSubmoduleUrl(String name) throws GitException, InterruptedException, IOException {
         return getGitAPI().getSubmoduleUrl(name);
     }
 
     /** {@inheritDoc} */
-    public void setSubmoduleUrl(String name, String url) throws GitException, InterruptedException {
+    public void setSubmoduleUrl(String name, String url) throws GitException, InterruptedException, IOException {
         getGitAPI().setSubmoduleUrl(name, url);
     }
 
     /** {@inheritDoc} */
-    public void fixSubmoduleUrls(String remote, TaskListener listener) throws GitException, InterruptedException {
+    public void fixSubmoduleUrls(String remote, TaskListener listener) throws GitException, InterruptedException, IOException {
         getGitAPI().fixSubmoduleUrls(remote, listener);
     }
 
     /** {@inheritDoc} */
-    public void setupSubmoduleUrls(String remote, TaskListener listener) throws GitException, InterruptedException {
+    public void setupSubmoduleUrls(String remote, TaskListener listener) throws GitException, InterruptedException, IOException {
         getGitAPI().setupSubmoduleUrls(remote, listener);
     }
 
     /** {@inheritDoc} */
-    public void fetch(String repository, String refspec) throws GitException, InterruptedException {
+    public void fetch(String repository, String refspec) throws GitException, InterruptedException, IOException {
         getGitAPI().fetch(repository, refspec);
     }
 
     /** {@inheritDoc} */
-    public void fetch(RemoteConfig remoteRepository) throws InterruptedException {
+    public void fetch(RemoteConfig remoteRepository) throws InterruptedException, IOException {
         getGitAPI().fetch(remoteRepository);
     }
 
@@ -796,12 +788,12 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public void fetch() throws GitException, InterruptedException {
+    public void fetch() throws GitException, InterruptedException, IOException {
         getGitAPI().fetch();
     }
 
     /** {@inheritDoc} */
-    public void reset(boolean hard) throws GitException, InterruptedException {
+    public void reset(boolean hard) throws GitException, InterruptedException, IOException {
         getGitAPI().reset(hard);
     }
 
@@ -811,57 +803,57 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    public void reset() throws GitException, InterruptedException {
+    public void reset() throws GitException, InterruptedException, IOException {
         getGitAPI().reset();
     }
 
     /** {@inheritDoc} */
-    public void push(RemoteConfig repository, String revspec) throws GitException, InterruptedException {
+    public void push(RemoteConfig repository, String revspec) throws GitException, InterruptedException, IOException {
         getGitAPI().push(repository, revspec);
     }
 
     /** {@inheritDoc} */
-    public void merge(String revSpec) throws GitException, InterruptedException {
+    public void merge(String revSpec) throws GitException, InterruptedException, IOException {
         getGitAPI().merge(revSpec);
     }
 
     /** {@inheritDoc} */
-    public void clone(RemoteConfig source) throws GitException, InterruptedException {
+    public void clone(RemoteConfig source) throws GitException, InterruptedException, IOException {
         getGitAPI().clone(source);
     }
 
     /** {@inheritDoc} */
-    public void clone(RemoteConfig rc, boolean useShallowClone) throws GitException, InterruptedException {
+    public void clone(RemoteConfig rc, boolean useShallowClone) throws GitException, InterruptedException, IOException {
         getGitAPI().clone(rc, useShallowClone);
     }
 
     /** {@inheritDoc} */
-    public List<Branch> getBranchesContaining(String revspec) throws GitException, InterruptedException {
+    public List<Branch> getBranchesContaining(String revspec) throws GitException, InterruptedException, IOException {
         return getGitAPI().getBranchesContaining(revspec);
     }
 
     /** {@inheritDoc} */
-    public List<IndexEntry> lsTree(String treeIsh) throws GitException, InterruptedException {
+    public List<IndexEntry> lsTree(String treeIsh) throws GitException, InterruptedException, IOException {
         return getGitAPI().lsTree(treeIsh);
     }
 
     /** {@inheritDoc} */
-    public List<IndexEntry> lsTree(String treeIsh, boolean recursive) throws GitException, InterruptedException {
+    public List<IndexEntry> lsTree(String treeIsh, boolean recursive) throws GitException, InterruptedException, IOException {
         return getGitAPI().lsTree(treeIsh, recursive);
     }
 
     /** {@inheritDoc} */
-    public List<ObjectId> revListBranch(String branchId) throws GitException, InterruptedException {
+    public List<ObjectId> revListBranch(String branchId) throws GitException, InterruptedException, IOException {
         return getGitAPI().revListBranch(branchId);
     }
 
     /** {@inheritDoc} */
-    public String describe(String commitIsh) throws GitException, InterruptedException {
+    public String describe(String commitIsh) throws GitException, InterruptedException, IOException {
         return getGitAPI().describe(commitIsh);
     }
 
     /** {@inheritDoc} */
-    public List<Tag> getTagsOnCommit(String revName) throws GitException, IOException, InterruptedException {
+    public List<Tag> getTagsOnCommit(String revName) throws GitException, IOException, InterruptedException, IOException {
         return getGitAPI().getTagsOnCommit(revName);
     }
 
@@ -874,7 +866,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
 
     /** {@inheritDoc} */
     public List<Branch> getBranchesContaining(String revspec, boolean allBranches)
-            throws GitException, InterruptedException {
+            throws GitException, InterruptedException, IOException {
         return getGitAPI().getBranchesContaining(revspec, allBranches);
     }
 }

--- a/src/test/java/hudson/plugins/git/GitAPIBadInitTest.java
+++ b/src/test/java/hudson/plugins/git/GitAPIBadInitTest.java
@@ -3,6 +3,7 @@ package hudson.plugins.git;
 import hudson.EnvVars;
 import hudson.model.TaskListener;
 import hudson.util.StreamTaskListener;
+import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
 
@@ -47,7 +48,7 @@ public class GitAPIBadInitTest {
 
     @Test
     public void testInitExistingDirectory() throws Exception {
-        GitClient git = new GitAPI("git", tempDir, listener, env);
+        GitClient git = Git.with(listener, env).using("git").in(tempDir).getClient();
         git.init();
         File gitDir = new File(tempDir, ".git");
         assertTrue(gitDir + " not created", gitDir.exists());
@@ -57,7 +58,7 @@ public class GitAPIBadInitTest {
     @Test
     public void testInitNoDirectory() throws Exception {
         File nonExistentDirectory = new File(tempDir, "dir-does-not-exist");
-        GitClient git = new GitAPI("git", nonExistentDirectory, listener, env);
+        GitClient git = Git.with(listener, env).using("git").in(nonExistentDirectory).getClient();
         thrown.expect(GitException.class);
         thrown.expectMessage("Could not init " + nonExistentDirectory.getAbsolutePath());
         git.init();
@@ -67,7 +68,7 @@ public class GitAPIBadInitTest {
     public void testInitExistingFile() throws Exception {
         File existingFile = new File(tempDir, "file-exists");
         FileUtils.writeStringToFile(existingFile, "git init should fail due to this file", "UTF-8");
-        GitClient git = new GitAPI("git", existingFile, listener, env);
+        GitClient git = Git.with(listener, env).using("git").in(existingFile).getClient();
         thrown.expect(GitException.class);
         thrown.expectMessage("Could not init " + existingFile.getAbsolutePath());
         git.init();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.gitclient;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import static junit.framework.TestCase.assertTrue;
@@ -56,9 +57,9 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         }
     }
 
-    private void doTest(String versionOutput, VersionTest[] versions) {
+    private void doTest(String versionOutput, VersionTest[] versions) throws IOException, InterruptedException, IOException {
         setTimeoutVisibleInCurrentTest(false); /* No timeout for git --version command */
-        CliGitAPIImpl git = new CliGitAPIImpl("git", new File("."), listener, env);
+        CliGitAPIImpl git = (CliGitAPIImpl) Git.with(listener, env).using("git").in(new File(".")).getClient();
         git.computeGitVersion(versionOutput);
         for (int i = 0; i < versions.length; ++i) {
             String msg = versionOutput + " for " + versions[i].major + versions[i].minor + versions[i].rev + versions[i].bugfix;
@@ -78,7 +79,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         }
     }
 
-    public void test_git_version_debian_wheezy() {
+    public void test_git_version_debian_wheezy() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 7, 10, 4),
             new VersionTest(true,  1, 7, 10, 3),
@@ -87,7 +88,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.7.10.4", versions);
     }
 
-    public void test_git_version_debian_testing() {
+    public void test_git_version_debian_testing() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  2, 0, 1, 0),
             new VersionTest(true,  2, 0, 0, 0),
@@ -97,7 +98,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 2.0.1", versions);
     }
 
-    public void test_git_version_debian_testing_old() {
+    public void test_git_version_debian_testing_old() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  2, 0,  0,  0),
             new VersionTest(true,  1, 9, 99, 99),
@@ -110,7 +111,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 2", versions);   // mythical version
     }
 
-    public void test_git_version_debian_testing_older() {
+    public void test_git_version_debian_testing_older() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 9,  0,  0),
             new VersionTest(true,  1, 8, 99, 99),
@@ -119,7 +120,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.9.0", versions);
     }
 
-    public void test_git_version_windows_1800() {
+    public void test_git_version_windows_1800() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 8,  0, 0),
             new VersionTest(true,  1, 7, 99, 0),
@@ -128,7 +129,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.8.0.msysgit.0", versions);
     }
 
-    public void test_git_version_windows_1840() {
+    public void test_git_version_windows_1840() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 8, 4,  0),
             new VersionTest(true,  1, 8, 3, 99),
@@ -137,7 +138,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.8.4.msysgit.0", versions);
     }
 
-    public void test_git_version_windows_1852() {
+    public void test_git_version_windows_1852() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 8, 5, 2),
             new VersionTest(true,  1, 8, 5, 1),
@@ -146,7 +147,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.8.5.2.msysgit.0", versions);
     }
 
-    public void test_git_version_windows_1900() {
+    public void test_git_version_windows_1900() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 9,  0, 0),
             new VersionTest(true,  1, 8, 99, 0),
@@ -155,7 +156,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.9.0.msysgit.0", versions);
     }
 
-    public void test_git_version_windows_1920() {
+    public void test_git_version_windows_1920() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 9, 2,  0),
             new VersionTest(true,  1, 9, 1, 99),
@@ -164,7 +165,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.9.2.msysgit.0", versions);
     }
 
-    public void test_git_version_windows_1940() {
+    public void test_git_version_windows_1940() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 9, 4,  0),
             new VersionTest(true,  1, 9, 3, 99),
@@ -173,7 +174,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.9.4.msysgit.0", versions);
     }
 
-    public void test_git_version_windows_2501() {
+    public void test_git_version_windows_2501() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  2, 5, 0, 1),
             new VersionTest(true,  2, 5, 0, 0),
@@ -182,7 +183,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 2.5.0.windows.1", versions);
     }
 
-    public void test_git_version_redhat_5() {
+    public void test_git_version_redhat_5() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 8, 2, 1),
             new VersionTest(true,  1, 8, 2, 0),
@@ -191,7 +192,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.8.2.1", versions);
     }
 
-    public void test_git_version_redhat_65() {
+    public void test_git_version_redhat_65() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 7, 1,  0),
             new VersionTest(true,  1, 7, 0, 99),
@@ -201,7 +202,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.7.1", versions);
     }
 
-    public void test_git_version_opensuse_13() {
+    public void test_git_version_opensuse_13() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 8, 4, 5),
             new VersionTest(true,  1, 8, 4, 4),
@@ -210,7 +211,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.8.4.5", versions);
     }
 
-    public void test_git_version_ubuntu_13() {
+    public void test_git_version_ubuntu_13() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  1, 8, 3, 2),
             new VersionTest(true,  1, 8, 3, 1),
@@ -219,7 +220,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 1.8.3.2", versions);
     }
 
-    public void test_git_version_ubuntu_14_04_ppa() {
+    public void test_git_version_ubuntu_14_04_ppa() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  2, 2, 2, 0),
             new VersionTest(true,  2, 2, 1, 0),
@@ -228,7 +229,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 2.2.2", versions);
     }
 
-    public void test_git_version_ubuntu_14_04_ppa_2_3_0() {
+    public void test_git_version_ubuntu_14_04_ppa_2_3_0() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  2, 3, 0, 0),
             new VersionTest(true,  2, 2, 9, 0),
@@ -237,7 +238,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         doTest("git version 2.3.0", versions);
     }
 
-    public void test_git_version_ubuntu_14_04_ppa_2_3_5() {
+    public void test_git_version_ubuntu_14_04_ppa_2_3_5() throws IOException, InterruptedException {
         VersionTest[] versions = {
             new VersionTest(true,  2, 3, 5, 0),
             new VersionTest(true,  2, 2, 9, 9),

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -7,6 +7,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import com.google.common.io.Files;
 import hudson.plugins.git.GitException;
+import hudson.remoting.VirtualChannel;
 import hudson.util.LogTaskListener;
 import hudson.util.StreamTaskListener;
 import java.io.File;
@@ -27,6 +28,7 @@ import java.util.regex.Pattern;
 import static junit.framework.TestCase.assertTrue;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.URIish;
 import org.junit.After;
@@ -313,8 +315,8 @@ public class CredentialsTest {
         log().println("Checking out " + master + " from " + gitRepoURL);
         git.checkout().branch("master").ref(master.getName()).deleteBranchIfExist(true).execute();
         assertTrue("master: " + master + " not in repo", git.isCommitInRepo(master));
-        assertEquals("Master != HEAD", master, git.getRepository().getRef("master").getObjectId());
-        assertEquals("Wrong branch", "master", git.getRepository().getBranch());
+        assertEquals("Master != HEAD", master, git.withRepository(GetMasterHead));
+        assertEquals("Wrong branch", "master", git.withRepository(GetBranch));
         assertTrue("No file " + fileToCheck + ", has " + listDir(repo), clonedFile.exists());
         checkExpectedLogSubstring();
     }
@@ -341,8 +343,8 @@ public class CredentialsTest {
             subcmd.execute();
         }
         assertTrue("master: " + master + " not in repo", git.isCommitInRepo(master));
-        assertEquals("Master != HEAD", master, git.getRepository().getRef("master").getObjectId());
-        assertEquals("Wrong branch", "master", git.getRepository().getBranch());
+        assertEquals("Master != HEAD", master, git.withRepository(GetMasterHead));
+        assertEquals("Wrong branch", "master", git.withRepository(GetBranch));
         assertTrue("No file " + fileToCheck + " in " + repo + ", has " + listDir(repo), clonedFile.exists());
         checkExpectedLogSubstring();
     }
@@ -357,4 +359,18 @@ public class CredentialsTest {
     private static final String NOT_JENKINS = System.getProperty("JOB_NAME") == null ? "true" : "false";
     private static final boolean TEST_ALL_CREDENTIALS = Boolean.valueOf(System.getProperty("TEST_ALL_CREDENTIALS", NOT_JENKINS));
     private static final Pattern URL_MUST_MATCH_PATTERN = Pattern.compile(System.getProperty("URL_MUST_MATCH_PATTERN", ".*"));
+
+    private static RepositoryCallback<ObjectId> GetMasterHead = new RepositoryCallback<ObjectId>() {
+        @Override
+        public ObjectId invoke(Repository repo, VirtualChannel channel) throws IOException, InterruptedException {
+            return repo.getRef("master").getObjectId();
+        }
+    };
+
+    private static RepositoryCallback<String> GetBranch = new RepositoryCallback<String>() {
+        @Override
+        public String invoke(Repository repo, VirtualChannel channel) throws IOException, InterruptedException {
+            return repo.getBranch();
+        }
+    };
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -89,7 +89,7 @@ public abstract class GitAPITestCase extends TestCase {
     private static final String SRC_DIR = (new File(".")).getAbsolutePath();
     private String revParseBranchName = null;
 
-    private void createRevParseBranch() throws GitException, InterruptedException {
+    private void createRevParseBranch() throws GitException, InterruptedException, IOException {
         revParseBranchName = "rev-parse-branch-" + UUID.randomUUID().toString();
         w.git.checkout("origin/master", revParseBranchName);
     }
@@ -583,8 +583,8 @@ public abstract class GitAPITestCase extends TestCase {
         final String alternates = ".git" + File.separator + "objects" + File.separator + "info" + File.separator + "alternates";
 
         assertTrue("Alternates file not found: " + alternates, w.exists(alternates));
-        final String expectedContent = localMirror().replace("\\", "/") + "/objects";
-        final String actualContent = w.contentOf(alternates);
+        final String expectedContent = new File(localMirror().replace("\\", "/") + "/objects").getCanonicalPath();
+        final String actualContent = new File(w.contentOf(alternates)).getCanonicalPath();
         assertEquals("Alternates file wrong content", expectedContent, actualContent);
         final File alternatesDir = new File(actualContent);
         assertTrue("Alternates destination " + actualContent + " missing", alternatesDir.isDirectory());
@@ -599,8 +599,8 @@ public abstract class GitAPITestCase extends TestCase {
         assertBranchesExist(w.git.getBranches(), "master");
         final String alternates = ".git" + File.separator + "objects" + File.separator + "info" + File.separator + "alternates";
         assertTrue("Alternates file not found: " + alternates, w.exists(alternates));
-        final String expectedContent = SRC_DIR.replace("\\", "/") + "/.git/objects";
-        final String actualContent = w.contentOf(alternates);
+        final String expectedContent = new File(SRC_DIR.replace("\\", "/") + "/.git/objects").getCanonicalPath();
+        final String actualContent = new File(w.contentOf(alternates)).getCanonicalPath();
         assertEquals("Alternates file wrong content", expectedContent, actualContent);
         final File alternatesDir = new File(actualContent);
         assertTrue("Alternates destination " + actualContent + " missing", alternatesDir.isDirectory());
@@ -1764,7 +1764,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue("committed-file missing at commit1", w.file("committed-file").exists());
     }
 
-    public void assertFixSubmoduleUrlsThrows() throws InterruptedException {
+    public void assertFixSubmoduleUrlsThrows() throws InterruptedException, IOException {
         try {
             w.igit().fixSubmoduleUrls("origin", listener);
             fail("Expected exception not thrown");
@@ -2987,8 +2987,7 @@ public abstract class GitAPITestCase extends TestCase {
                 expectedObjectId, actualObjectId);
     }
 
-    private List<Branch> getBranches(ObjectId objectId) throws GitException, InterruptedException
-    {
+    private List<Branch> getBranches(ObjectId objectId) throws GitException, InterruptedException, IOException {
         List<Branch> matches = new ArrayList<Branch>();
         Set<Branch> branches = w.git.getBranches();
         for(Branch branch : branches) {
@@ -3081,8 +3080,7 @@ public abstract class GitAPITestCase extends TestCase {
         check_headRev(w.repoPath(), getMirrorHead());
     }
 
-    private void check_changelog_sha1(final String sha1, final String branchName) throws InterruptedException
-    {
+    private void check_changelog_sha1(final String sha1, final String branchName) throws InterruptedException, IOException {
         ChangelogCommand changelogCommand = w.git.changelog();
         changelogCommand.max(1);
         StringWriter writer = new StringWriter();
@@ -3171,8 +3169,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue(diffs.isEmpty());
     }
 
-    private void check_bounded_changelog_sha1(final String sha1Begin, final String sha1End, final String branchName) throws InterruptedException
-    {
+    private void check_bounded_changelog_sha1(final String sha1Begin, final String sha1End, final String branchName) throws InterruptedException, IOException {
         StringWriter writer = new StringWriter();
         w.git.changelog(sha1Begin, sha1End, writer);
         String splitLog[] = writer.toString().split("[\\n\\r]", 3); // Extract first line of changelog

--- a/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
@@ -126,21 +126,21 @@ public class LegacyCompatibleGitAPIImplTest {
         RemoteConfig remoteConfig = new RemoteConfig(config, remoteName);
         List<URIish> list = remoteConfig.getURIs();
         git.clone(remoteConfig);
-        File[] files = git.workspace.listFiles();
+        File[] files = repo.listFiles();
         assertEquals(files.length + "files in " + Arrays.toString(files), 1, files.length);
         assertEquals("Wrong file name", ".git", files[0].getName());
     }
 
     @Test
     @Deprecated
-    public void testHasGitModules_default_ignored_arg() {
+    public void testHasGitModules_default_ignored_arg() throws IOException, InterruptedException {
         assertFalse((new File(repo, ".gitmodules")).exists());
         assertFalse(git.hasGitModules("ignored treeIsh argument 1"));
     }
 
     @Test
     @Deprecated
-    public void testHasGitModules_default_no_arg() {
+    public void testHasGitModules_default_no_arg() throws IOException, InterruptedException {
         assertFalse((new File(repo, ".gitmodules")).exists());
         assertFalse(git.hasGitModules());
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
@@ -48,7 +48,7 @@ public class MergeCommandTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
-    public void createMergeTestRepo() throws IOException, InterruptedException {
+    public void createMergeTestRepo() throws IOException, InterruptedException, IOException {
         EnvVars env = new hudson.EnvVars();
         TaskListener listener = StreamTaskListener.fromStdout();
         File repo = temporaryDirectoryAllocator.allocate();
@@ -150,7 +150,7 @@ public class MergeCommandTest {
     }
 
     @Test
-    public void testSetRevisionToMergeCommit1() throws GitException, InterruptedException {
+    public void testSetRevisionToMergeCommit1() throws GitException, InterruptedException, IOException {
         mergeCmd.setRevisionToMerge(commit1Branch).execute();
         assertTrue("branch commit 1 not on master branch after merge", git.revList("master").contains(commit1Branch));
         assertFalse("branch commit 2 on master branch prematurely", git.revList("master").contains(commit2Branch));
@@ -158,14 +158,14 @@ public class MergeCommandTest {
     }
 
     @Test
-    public void testSetRevisionToMergeCommit2() throws GitException, InterruptedException {
+    public void testSetRevisionToMergeCommit2() throws GitException, InterruptedException, IOException {
         mergeCmd.setRevisionToMerge(commit2Branch).execute();
         assertTrue("branch commit 1 not on master branch after merge", git.revList("master").contains(commit1Branch));
         assertTrue("branch commit 2 not on master branch after merge", git.revList("master").contains(commit2Branch));
         assertTrue("README 1 missing on master branch", readmeOne.exists());
     }
 
-    private void assertMessageInGitLog(ObjectId head, String substring) throws GitException, InterruptedException {
+    private void assertMessageInGitLog(ObjectId head, String substring) throws GitException, InterruptedException, IOException {
         List<String> logged = git.showRevision(head);
         boolean found = false;
         for (String logLine : logged) {
@@ -177,28 +177,28 @@ public class MergeCommandTest {
     }
 
     @Test
-    public void testCustomMergeMessage() throws GitException, InterruptedException {
+    public void testCustomMergeMessage() throws GitException, InterruptedException, IOException {
         String customMessage = "Custom merge message from test";
         mergeCmd.setMessage(customMessage).setRevisionToMerge(commit2Branch).execute();
         assertMessageInGitLog(git.revParse("HEAD"), customMessage);
     }
 
     @Test
-    public void testDefaultMergeMessage() throws GitException, InterruptedException {
+    public void testDefaultMergeMessage() throws GitException, InterruptedException, IOException {
         String defaultMessage = "Merge commit '" + commit2Branch.getName() + "'";
         mergeCmd.setRevisionToMerge(commit2Branch).execute();
         assertMessageInGitLog(git.revParse("HEAD"), defaultMessage);
     }
 
     @Test
-    public void testEmptyMergeMessage() throws GitException, InterruptedException {
+    public void testEmptyMergeMessage() throws GitException, InterruptedException, IOException {
         String emptyMessage = "";
         mergeCmd.setMessage(emptyMessage).setRevisionToMerge(commit2Branch).execute();
         /* Asserting an empty string in the merge message is too hard, only check for exceptions thrown */
     }
 
     @Test
-    public void testDefaultStrategy() throws GitException, InterruptedException {
+    public void testDefaultStrategy() throws GitException, InterruptedException, IOException {
         mergeCmd.setStrategy(MergeCommand.Strategy.DEFAULT).setRevisionToMerge(commit2Branch).execute();
         assertTrue("branch commit 1 not on master branch after merge", git.revList("master").contains(commit1Branch));
         assertTrue("branch commit 2 not on master branch after merge", git.revList("master").contains(commit2Branch));
@@ -206,7 +206,7 @@ public class MergeCommandTest {
     }
 
     @Test
-    public void testResolveStrategy() throws GitException, InterruptedException {
+    public void testResolveStrategy() throws GitException, InterruptedException, IOException {
         mergeCmd.setStrategy(MergeCommand.Strategy.RESOLVE).setRevisionToMerge(commit2Branch).execute();
         assertTrue("branch commit 1 not on master branch after merge", git.revList("master").contains(commit1Branch));
         assertTrue("branch commit 2 not on master branch after merge", git.revList("master").contains(commit2Branch));
@@ -214,7 +214,7 @@ public class MergeCommandTest {
     }
 
     @Test
-    public void testRecursiveStrategy() throws GitException, InterruptedException {
+    public void testRecursiveStrategy() throws GitException, InterruptedException, IOException {
         mergeCmd.setStrategy(MergeCommand.Strategy.RECURSIVE).setRevisionToMerge(commit2Branch).execute();
         assertTrue("branch commit 1 not on master branch after merge", git.revList("master").contains(commit1Branch));
         assertTrue("branch commit 2 not on master branch after merge", git.revList("master").contains(commit2Branch));
@@ -223,7 +223,7 @@ public class MergeCommandTest {
 
     /* Octopus merge strategy is not implemented in JGit, not exposed in CliGitAPIImpl */
     @Test
-    public void testOctopusStrategy() throws GitException, InterruptedException {
+    public void testOctopusStrategy() throws GitException, InterruptedException, IOException {
         mergeCmd.setStrategy(MergeCommand.Strategy.OCTOPUS).setRevisionToMerge(commit2Branch).execute();
         assertTrue("branch commit 1 not on master branch after merge", git.revList("master").contains(commit1Branch));
         assertTrue("branch commit 2 not on master branch after merge", git.revList("master").contains(commit2Branch));
@@ -231,7 +231,7 @@ public class MergeCommandTest {
     }
 
     @Test
-    public void testOursStrategy() throws GitException, InterruptedException {
+    public void testOursStrategy() throws GitException, InterruptedException, IOException {
         mergeCmd.setStrategy(MergeCommand.Strategy.OURS).setRevisionToMerge(commit2Branch).execute();
         assertTrue("branch commit 1 not on master branch after merge", git.revList("master").contains(commit1Branch));
         assertTrue("branch commit 2 not on master branch after merge", git.revList("master").contains(commit2Branch));
@@ -241,7 +241,7 @@ public class MergeCommandTest {
     }
 
     @Test
-    public void testSubtreeStrategy() throws GitException, InterruptedException {
+    public void testSubtreeStrategy() throws GitException, InterruptedException, IOException {
         mergeCmd.setStrategy(MergeCommand.Strategy.SUBTREE).setRevisionToMerge(commit2Branch).execute();
         assertTrue("branch commit 1 not on master branch after merge", git.revList("master").contains(commit1Branch));
         assertTrue("branch commit 2 not on master branch after merge", git.revList("master").contains(commit2Branch));
@@ -249,7 +249,7 @@ public class MergeCommandTest {
     }
 
     @Test
-    public void testSquash() throws GitException, InterruptedException {
+    public void testSquash() throws GitException, InterruptedException, IOException {
         mergeCmd.setSquash(true).setRevisionToMerge(commit2Branch).execute();
         assertFalse("branch commit 1 on master branch after squash merge", git.revList("master").contains(commit1Branch));
         assertFalse("branch commit 2 on master branch after squash merge", git.revList("master").contains(commit2Branch));
@@ -257,7 +257,7 @@ public class MergeCommandTest {
     }
 
     @Test
-    public void testCommitOnMerge() throws GitException, InterruptedException {
+    public void testCommitOnMerge() throws GitException, InterruptedException, IOException {
         mergeCmd.setCommit(true).setRevisionToMerge(commit2Branch).execute();
         assertTrue("branch commit 1 not on master branch after merge with commit", git.revList("master").contains(commit1Branch));
         assertTrue("branch commit 2 not on master branch after merge with commit", git.revList("master").contains(commit2Branch));
@@ -265,7 +265,7 @@ public class MergeCommandTest {
     }
 
     @Test
-    public void testNoCommitOnMerge() throws GitException, InterruptedException {
+    public void testNoCommitOnMerge() throws GitException, InterruptedException, IOException {
         mergeCmd.setCommit(false).setRevisionToMerge(commit2Branch).execute();
         assertFalse("branch commit 1 on master branch after merge without commit", git.revList("master").contains(commit1Branch));
         assertFalse("branch commit 2 on master branch after merge without commit", git.revList("master").contains(commit2Branch));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
@@ -235,7 +235,7 @@ public class PushTest {
         workingCommit = commitFileToCurrentBranch();
     }
 
-    private ObjectId checkoutBranch(boolean useOldCommit) throws GitException, InterruptedException {
+    private ObjectId checkoutBranch(boolean useOldCommit) throws GitException, InterruptedException, IOException {
         /* Checkout branchName */
         workingGitClient.checkoutBranch(branchName, "origin/" + branchName + (useOldCommit ? "^" : ""));
         List<Branch> branches = workingGitClient.getBranchesContaining(branchName, false);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/RemotingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/RemotingTest.java
@@ -6,6 +6,7 @@ import hudson.model.StreamBuildListener;
 import hudson.remoting.Callable;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
+import jenkins.security.MasterToSlaveCallable;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.jvnet.hudson.test.HudsonTestCase;
@@ -33,7 +34,7 @@ public class RemotingTest extends HudsonTestCase {
         channel.close();
     }
 
-    private static class Work implements Callable<Void,IOException> {
+    private static class Work extends MasterToSlaveCallable<Void, IOException> {
         private final GitClient git;
 
         public Work(GitClient git) {


### PR DESCRIPTION
This (long) pull-request is about making CLIGitAPIImpl rely on `FilePath` and `Launcher` and have logic run on master JVM (as expected by the remoting abstraction). As JGitAPIImpl relies on JGit - so on java.io.File - it has to run fully remotely, so had to split logic between implementations.

Most changes are about moving from `File` to `FilePath` and adding `IOException` to API methods.

Also removed getRepository that was deprecated since 1.1 as not being remotable.

Final goal is to let git-client rely on configured Launcher, which hold the computer environment or customized behavior from caller (using `DecoratedLauncher`)
see https://issues.jenkins-ci.org/browse/JENKINS-30600, also applies to git ran inside Pipeline as computer's NodeProperties are exposed to git by Launcher.