### PR TITLE
[JENKINS-34309] Only parse reasonable branch line output

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1822,6 +1822,15 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         String line;
         try {
             while ((line = rdr.readLine()) != null) {
+                if (line.length() < 44 || !line.contains(" ")) {
+                    // Line must contain 2 leading characters, branch
+                    // name (at least 1 character), a space, and 40
+                    // character SHA1.
+                    // JENKINS-34309 found cases where a Ctrl-M was
+                    // inserted into the output of
+                    // "git branch -v --no-abbrev"
+                    continue;
+                }
                 // Ignore leading 2 characters (marker for current branch)
                 // Ignore line if second field is not SHA1 length (40 characters)
                 // Split fields into branch name, SHA1, and rest of line

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -244,6 +244,13 @@ public abstract class GitAPITestCase extends TestCase {
         }
 
         /**
+         * Creates a JGit implementation. Sometimes we need this for testing CliGit impl.
+         */
+        protected JGitAPIImpl jgit() throws Exception {
+            return (JGitAPIImpl)Git.with(listener, env).in(repo).using("jgit").getClient();
+        }
+
+        /**
          * Creates a {@link Repository} object out of it.
          */
         protected FileRepository repo() throws IOException {
@@ -1295,14 +1302,36 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue("test branch not listed", branches.contains("test"));
     }
 
+    @Bug(34309)
     public void test_list_branches() throws Exception {
         w.init();
-        w.commitEmpty("init");
-        w.git.branch("test");
-        w.git.branch("another");
         Set<Branch> branches = w.git.getBranches();
+        assertEquals(0, branches.size()); // empty repo should have 0 branches
+        w.commitEmpty("init");
+
+        w.git.branch("test");
+        w.touch("test-branch.txt");
+        w.git.add("test-branch.txt");
+        // JGit commit doesn't end commit message with Ctrl-M, even when passed
+        final String testBranchCommitMessage = "test branch commit ends in Ctrl-M";
+        w.jgit().commit(testBranchCommitMessage + "\r");
+
+        w.git.branch("another");
+        w.touch("another-branch.txt");
+        w.git.add("another-branch.txt");
+        // CliGit commit doesn't end commit message with Ctrl-M, even when passed
+        final String anotherBranchCommitMessage = "test branch commit ends in Ctrl-M";
+        w.cgit().commit(anotherBranchCommitMessage + "\r");
+
+        branches = w.git.getBranches();
         assertBranchesExist(branches, "master", "test", "another");
         assertEquals(3, branches.size());
+        String output = w.cmd("git branch -v --no-abbrev");
+        assertFalse("git branch -v --no-abbrev contains Ctrl-M: '" + output + "'", output.contains("\r"));
+        assertTrue("git branch -v --no-abbrev missing test commit msg: '" + output + "'", output.contains(testBranchCommitMessage));
+        assertFalse("git branch -v --no-abbrev missing test commit msg Ctrl-M: '" + output + "'", output.contains(testBranchCommitMessage + "\r"));
+        assertTrue("git branch -v --no-abbrev missing another commit msg: '" + output + "'", output.contains(anotherBranchCommitMessage));
+        assertFalse("git branch -v --no-abbrev missing another commit msg Ctrl-M: '" + output + "'", output.contains(anotherBranchCommitMessage + "\r"));
     }
 
     public void test_list_remote_branches() throws Exception {


### PR DESCRIPTION
Avoid string index out of bounds exception on unexpected output from
"git branch -v --no-abbrev" (as reported in JENKINS-34309).

The JENKINS-34309 issue may be related to gitlab bug 14453
https://gitlab.com/gitlab-org/gitlab-ce/issues/14453

Added a test to check that empty repo reports no branches.  Empty
repo does not show the problem which was detected in JENKINS-34309.
My attempts to duplicate JENKINS-34309 in an automated test have all
failed.  Those attempts are included in this commit (though unsuccessful
at duplicating the problem).