### PR TITLE
[JENKINS-37185] Honor checkout timeout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1976,7 +1976,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                     if (branch!=null && deleteBranch) {
                         // First, checkout to detached HEAD, so we can delete the branch.
-                        launchCommand("checkout", "-f", ref);
+                        ArgumentListBuilder args = new ArgumentListBuilder();
+                        args.add("checkout", "-f", ref);
+                        launchCommandIn(args, workspace, environment, timeout);
 
                         // Second, check to see if the branch actually exists, and then delete it if it does.
                         for (Branch b : getBranches()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -3409,6 +3409,20 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals("Wrong SHA1 as checkout of git-client-1.6.0", sha1Expected, sha1);
     }
 
+    @Bug(37185)
+    @NotImplementedInJGit /* JGit doesn't have timeout */
+    public void test_checkout_honor_timeout() throws Exception {
+        w = clone(localMirror());
+
+        int newTimeout = 7;
+        w.git.checkout().branch("master").ref("origin/master").timeout(newTimeout).deleteBranchIfExist(true).execute();
+
+        Map timeouts = new HashMap<Integer, Integer>();
+        timeouts.put(1, newTimeout);
+        timeouts.put(4, newTimeout);
+        setExpectedTimeoutAtPositions(timeouts);
+    }
+
     @Bug(25353)
     @NotImplementedInJGit /* JGit lock file management ignored for now */
     public void test_checkout_interrupted() throws Exception {


### PR DESCRIPTION
**Expectation**: When I set the checkout timeout, I'm expecting that Jenkins uses it when it comes to checkout a commit.

**Problem**: However, it appears that when you select the "Check out to a specific local branch", the first checkout command does not set correctly the timeout.

**Why it's a problem**: I'm using git lfs, and git lfs files are downloaded during the checkout option. For other reasons I can't use the git lfs pull command. 

**How to reproduce it**: 
 1. Use any version of git-plugin and git-client-plugin. 
 2. Create a freestyle project, add the following parameters: 
   1. Timeout=120 for the Advanced checkout option
   2. ** for the Checkout to a specific local branch. 
 3. Build the project.

The first checkout will be displayed with a timeout of 10 instead of 120.

**Before**:

```
Checking out Revision 2695971df91e03443bd2aa11109dca740c341448 (refs/remotes/origin/master)
 > git.exe config core.sparsecheckout # timeout=10
 > git.exe checkout -f 2695971df91e03443bd2aa11109dca740c341448 # timeout=10
 > git.exe branch -a -v --no-abbrev # timeout=10
 > git.exe branch -D master # timeout=10
 > git.exe checkout -b master 2695971df91e03443bd2aa11109dca740c341448 # timeout=120
 > git.exe rev-list 2695971df91e03443bd2aa11109dca740c341448 # timeout=10
Finished: SUCCESS
```

**After**:  
*(Check the third line)*

```
Checking out Revision 2695971df91e03443bd2aa11109dca740c341448 (refs/remotes/origin/master)
 > git.exe config core.sparsecheckout # timeout=10
 > git.exe checkout -f 2695971df91e03443bd2aa11109dca740c341448 # timeout=120
 > git.exe branch -a -v --no-abbrev # timeout=10
 > git.exe checkout -b master 2695971df91e03443bd2aa11109dca740c341448 # timeout=120
 > git.exe rev-list 2695971df91e03443bd2aa11109dca740c341448 # timeout=10
Finished: SUCCESS
```