### PR TITLE
Implement merge as source commit author

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
@@ -26,6 +26,14 @@ public interface MergeCommand extends GitCommand {
     MergeCommand setMessage(String message);
 
     /**
+     * setMergeAsSourceCommitAuthor.
+     *
+     * @param mergeAsSourceCommitAuthor ensure the author of the resultant merge commit is the author of the source commit.
+     * @return a {@link org.jenkinsci.plugins.gitclient.MergeCommand} object.
+     */
+    MergeCommand setMergeAsSourceCommitAuthor(boolean mergeAsSourceCommitAuthor);
+
+    /**
      * setStrategy.
      *
      * @param strategy a {@link org.jenkinsci.plugins.gitclient.MergeCommand.Strategy} object.


### PR DESCRIPTION
This PR will allow me to make this change to the git-plugin: https://github.com/bjacklyn/git-plugin/tree/user/bjacklyn/implement-option-to-perform-merge-as-author-of-from-branch

No PR for that one at the moment since it will fail with compilation errors until this goes in.

The motivation for this change is to match Github/Bitbucket's behavior when merging PR's, which is to make the merge commit author  as the HEAD committer on source branch. Currently our Jenkins instance performs the merge as the "tomcat7" user and pushes that into our repo.
