### PR TITLE
Use java agent on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 properties([[$class: 'BuildDiscarderProperty',
                 strategy: [$class: 'LogRotator', numToKeepStr: '10']]])
 
-node {
+node('java') {
   stage('Checkout') {
     checkout scm
   }


### PR DESCRIPTION
There are some issues on ci.jenkins.io with GIT_COMMITTER_NAME and
GIT_COMMITTER_EMAIL not getting set properly, but the "java" agents
either have properly configured ~/.gitconfig files or git is
autodetermining the email somehow. In any case, this should be better
in general.

cc @rtyler