### PR TITLE
[JENKINS-23476] Let git client default timeout be configurable on a global level.

### DIFF
--- a/src/main/java/hudson/plugins/git/GitTool.java
+++ b/src/main/java/hudson/plugins/git/GitTool.java
@@ -13,6 +13,7 @@ import hudson.tools.ToolProperty;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.math.NumberUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -26,7 +27,6 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import static hudson.init.InitMilestone.EXTENSIONS_AUGMENTED;
-import java.util.logging.Level;
 
 /**
  * Information about Git installation. A GitTool is used to select
@@ -135,6 +135,8 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
     @Extension @Symbol("git")
     public static class DescriptorImpl extends ToolDescriptor<GitTool> {
 
+        private Integer gitDefaultTimeout;
+
         public DescriptorImpl() {
             super();
             load();
@@ -148,8 +150,18 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             setInstallations(req.bindJSONToList(clazz, json.get("tool")).toArray(new GitTool[0]));
+            if (json.has("gitDefaultTimeout")) {
+                setGitDefaultTimeout(json.getInt("gitDefaultTimeout"));
+            }
             save();
             return true;
+        }
+
+        public FormValidation doCheckGitDefaultTimeout(@QueryParameter String value) {
+            if (NumberUtils.isDigits(value)) {
+                return FormValidation.ok();
+            }
+            return FormValidation.error("Git default timeout must be an integer value");
         }
 
         public FormValidation doCheckHome(@QueryParameter File value) {
@@ -192,6 +204,14 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
                 }
             }
             return r;
+        }
+
+        public void setGitDefaultTimeout(Integer gitDefaultTimeout) {
+            this.gitDefaultTimeout = gitDefaultTimeout;
+        }
+
+        public Integer getGitDefaultTimeout() {
+            return gitDefaultTimeout;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2060,6 +2060,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     } else {
                         timeout = TIMEOUT;
                     }
+                } else {
+                    timeout = TIMEOUT;
                 }
             }
             listener.getLogger().println(" > " + command + (TIMEOUT_LOG_PREFIX + timeout));

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -4,8 +4,9 @@ package org.jenkinsci.plugins.gitclient;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.UsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import com.google.common.collect.Lists;
+
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
@@ -26,6 +27,7 @@ import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.Secret;
+
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -39,17 +41,7 @@ import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 import org.kohsuke.stapler.framework.io.WriterOutputStream;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.Writer;
+import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2018,7 +2018,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private String launchCommandIn(ArgumentListBuilder args, File workDir, EnvVars env) throws GitException, InterruptedException {
-    	return launchCommandIn(args, workDir, environment, null);
+        return launchCommandIn(args, workDir, environment, null);
     }
 
     private String launchCommandIn(ArgumentListBuilder args, File workDir, EnvVars env, Integer timeout) throws GitException, InterruptedException {
@@ -2044,16 +2044,13 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             if (timeout == null) {
+                timeout = TIMEOUT;
                 Jenkins jenkins = Jenkins.getInstance();
                 if (jenkins != null) {
                     GitTool.DescriptorImpl gitTool = (GitTool.DescriptorImpl) jenkins.getDescriptor(GitTool.class);
                     if (gitTool != null && gitTool.getGitDefaultTimeout() != null && gitTool.getGitDefaultTimeout() > 0) {
                         timeout = gitTool.getGitDefaultTimeout();
-                    } else {
-                        timeout = TIMEOUT;
                     }
-                } else {
-                    timeout = TIMEOUT;
                 }
             }
             listener.getLogger().println(" > " + command + (TIMEOUT_LOG_PREFIX + timeout));

--- a/src/main/resources/hudson/plugins/git/GitTool/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitTool/global.jelly
@@ -31,5 +31,8 @@ THE SOFTWARE.
                      addCaption="${%Add Git}" hasHeader="true"
                      deleteCaption="${%Delete Git}"/>
     </f:entry>
+    <f:entry title="${%Git default timeout in minutes}" >
+      <f:textbox field="gitDefaultTimeout" />
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/git/GitTool/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitTool/global.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
                      addCaption="${%Add Git}" hasHeader="true"
                      deleteCaption="${%Delete Git}"/>
     </f:entry>
-    <f:entry title="${%Git default timeout in minutes}" >
+    <f:entry title="${%Command-line Git default timeout in minutes}" >
       <f:textbox field="gitDefaultTimeout" />
     </f:entry>
   </f:section>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplWithJenkinsRuleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplWithJenkinsRuleTest.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitTool;
+import hudson.slaves.DumbSlave;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.jenkinsci.plugins.gitclient.CliGitAPIImpl.TIMEOUT_LOG_PREFIX;
+
+/**
+ * Created by a165807 on 2016-11-01.
+ */
+public class CliGitAPIImplWithJenkinsRuleTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void test_global_config_timeout() throws Exception {
+        GitTool.onLoaded();
+        GitTool gitTool = GitTool.getDefaultInstallation();
+        Assert.assertNotNull(gitTool);
+        Assert.assertNotNull(gitTool.getDescriptor());
+        gitTool.getDescriptor().setGitDefaultTimeout(999);
+        DumbSlave slave = j.createSlave();
+        slave.setMode(Node.Mode.EXCLUSIVE);
+        hudson.EnvVars env = new hudson.EnvVars();
+
+        LogHandler handler = new LogHandler();
+        handler.setLevel(Level.ALL);
+        Logger logger = Logger.getLogger(this.getClass().getName());
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        logger.setLevel(Level.ALL);
+
+        TaskListener listener = new hudson.util.LogTaskListener(logger, Level.ALL);
+
+        CliGitAPIImpl git = new CliGitAPIImpl("git", new File("."), listener, env);
+        git.launchCommand("--version");
+
+        Assert.assertTrue(handler.containsMessageSubstring(TIMEOUT_LOG_PREFIX + 999));
+    }
+}


### PR DESCRIPTION
Today, the default timeout for Git client is based on a [system property ](https://github.com/jenkinsci/git-client-plugin/blob/0aa5973b3fec1cc14a5e56d6f6e36cea4310d293/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java#L2629).

This limits configurability and requires a Jenkins restart to be changed. Some plugins, such as the [Multibranch pipeline plugin](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Multibranch+Plugin) will use this timeout without allowing overriding. This will result in timeouts for large repos or slow connections. ([Example issue](https://issues.jenkins-ci.org/browse/JENKINS-39173))

This PR allows setting the default timeout in Jenkins global configuration, with fallback on the previously mentioned system property.

Fixes [JENKINS-23476](https://issues.jenkins-ci.org/browse/JENKINS-23476)
