### PR TITLE
Correctly handle submodules whose name and path do not match

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -961,6 +961,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
              * @throws InterruptedException if called methods throw same exception
              */
             public void execute() throws GitException, InterruptedException {
+                // Initialize the submodules to ensure that the git config
+                // contains the URLs from .gitmodules.
+                submoduleInit();
+
                 ArgumentListBuilder args = new ArgumentListBuilder();
                 args.add("submodule", "update");
                 if (recursive) {
@@ -1008,16 +1012,18 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 Matcher matcher = pattern.matcher(cfgOutput);
                 while (matcher.find()) {
                     ArgumentListBuilder perModuleArgs = args.clone();
-                    String sUrl = matcher.group(1);
+                    String sModuleName = matcher.group(1);
 
+                    // Find the URL for this submodule
                     URIish urIish = null;
                     try {
-                        urIish = new URIish(getSubmoduleUrl(sUrl));
+                        urIish = new URIish(getSubmoduleUrl(sModuleName));
                     } catch (URISyntaxException e) {
-                        listener.error("Invalid repository for " + sUrl);
-                        throw new GitException("Invalid repository for " + sUrl);
+                        listener.error("Invalid repository for " + sModuleName);
+                        throw new GitException("Invalid repository for " + sModuleName);
                     }
 
+                    // Find credentials for this URL
                     StandardCredentials cred = credentials.get(urIish.toPrivateString());
                     if (parentCredentials) {
                         String parentUrl = getRemoteUrl(getDefaultRemote());
@@ -1033,7 +1039,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     }
                     if (cred == null) cred = defaultCredentials;
 
-                    perModuleArgs.add(sUrl);
+                    // Find the path for this submodule
+                    String sModulePath = getSubmodulePath(sModuleName);
+
+                    perModuleArgs.add(sModulePath);
                     launchCommandWithCredentials(perModuleArgs, workspace, cred, urIish, timeout);
                 }
             }
@@ -1093,6 +1102,16 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     public void setSubmoduleUrl(String name, String url) throws GitException, InterruptedException {
         launchCommand( "config", "submodule."+name+".url", url );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Get submodule path
+     */
+    public @CheckForNull String getSubmodulePath(String name) throws GitException, InterruptedException {
+        String result = launchCommand( "config", "-f", ".gitmodules", "--get", "submodule."+name+".path" );
+        return StringUtils.trim(firstLine(result));
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
## Bug to fix
The Jenkins git-client plugin currently checks out submodules by initializing them into PATH, where PATH is erroneously specified as the *name* of the submodule. In many repositories, the submodule name and path match, but this is not a git requirement. When they do not match, this results in an error condition. [JENKINS-37495](https://issues.jenkins-ci.org/browse/JENKINS-37495)

## What I did
I added a new method named `getSubmodulePath()`, which takes the name of the submodule and fetches the `path` as defined in `.gitmodules`. I updated the existing submodule update code to call this method and get the path explicitly, rather than reusing the *name* of the submodule, which was mislabeled as `sUrl`. The old `sUrl` was renamed `sModuleName` to reflect its true nature.

Automated testing isn't going to like this one...

## How to demonstrate the bug in `master`
1. Clone `https://github.com/courtarro/git-client-plugin.git` into `target/clone.git`. This repository has an additional submodule that demonstrates the bug.
2. Run the tests (`mvn test`). You can run just the test in question with `mvn -Dtest=org.jenkinsci.plugins.gitclient.CliGitAPIImplTest test`
3. Observed the error that includes `error: pathspec 'puppetssh' did not match any file(s) known to git.`. This is the bug. Git-client tried to run `git submodule update puppetssh` when it should have run `git submodule update modules/sshkeys`

## How to test that the fix works
1. Check out this branch
2. Follow steps 1 and 2 above.
3. Observe that the tests succeed.