### PR TITLE
Added puppetlabs-sshkeys repository as a submodule named 'sshkeys'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "modules/ntp"]
 	path = modules/ntp
 	url = https://github.com/puppetlabs/puppetlabs-ntp.git
+[submodule "puppetssh"]
+	path = modules/sshkeys
+	url = https://github.com/puppetlabs/puppetlabs-sshkeys.git


### PR DESCRIPTION
## Bug to fix
The Jenkins git-client plugin currently checks out submodules by initializing them into PATH, where PATH is erroneously specified as the *name* of the submodule. In many repositories, the submodule name and path match, but this is not a git requirement. When they do not match, this results in an error condition. [JENKINS-37495](https://issues.jenkins-ci.org/browse/JENKINS-37495)

## What I did
I added a new submodule named [`puppetssh`](https://github.com/puppetlabs/puppetlabs-sshkeys.git) that uses the path `modules/sshkeys`. Since these mismatch, they will trigger the bug in the old `master`.

## How to test it
See pull request #225