### PR TITLE
Reference the .gitmodules file to get a list of current submodules

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -961,6 +961,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
              * @throws InterruptedException if called methods throw same exception
              */
             public void execute() throws GitException, InterruptedException {
+                // Initialize the submodules to ensure that the git config
+                // contains the URLs from .gitmodules.
+                submoduleInit();
+
                 ArgumentListBuilder args = new ArgumentListBuilder();
                 args.add("submodule", "update");
                 if (recursive) {
@@ -995,7 +999,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 try {
                     // We might fail if we have no modules, so catch this
                     // exception and just return.
-                    cfgOutput = launchCommand("config", "--get-regexp", "^submodule");
+                    cfgOutput = launchCommand("config", "-f", ".gitmodules", "--get-regexp", "^submodule\\.(.*)\\.url");
                 } catch (GitException e) {
                     listener.error("No submodules found.");
                     return;


### PR DESCRIPTION
# Bug to fix

The Jenkins git client currently determines the list of submodules by reading `.git/config`. Unfortunately, this file may contain references and URLs for any submodules that have been accessed in the working directory of this repository, not simply the ones that exist in the active branch. In many cases this will result in Jenkins attempting to clone non-existent submodules and fail. [JENKINS-37419](https://issues.jenkins-ci.org/browse/JENKINS-37419)

# What I did

I explicitly instruct git to read the `.gitmodules` file when gathering its list of submodules to update. By iterating through `.gitmodules`, this ensures that only submodules for *this* branch are synchronized and updated. The regex string used is the same as the one a few lines later. Along with #225, this should fix some issues related to the new submodule update approach.

# How to test

There is currently no test that shows the previous bug. This would require a checkout of a branch with a one set of submodules, then switching to a branch with a non-common set of submodules. Since there is currently an effort to rewrite the submodule tests (by @MarkEWaite, I believe), I decided to forgo writing one of my own. If this would be useful, let me know.