### PR TITLE
Properly escape special Windows Batch characters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1515,9 +1515,18 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private String quoteWindowsCredentials(String str) {
-        // Assumes the only meaningful character is %, this may be
-        // insufficient.
-        return str.replace("%", "%%");
+        // Quote special characters for Windows Batch Files
+        // See: http://ss64.com/nt/syntax-esc.html
+        String quoted = str.replace("%", "%%")
+                        .replace("^", "^^")
+                        .replace(" ", "^ ")
+                        .replace("\t", "^\t")
+                        .replace("\\", "^\\")
+                        .replace("&", "^&")
+                        .replace("|", "^|")
+                        .replace(">", "^>")
+                        .replace("<", "^<");
+        return quoted;
     }
 
     private String quoteUnixCredentials(String str) {


### PR DESCRIPTION
This was a blocking issue for us, so I went ahead and implemented the simplest fix. 

Related JIRA issue: https://issues.jenkins-ci.org/browse/JENKINS-40166

I looked into adding UnitTests for quoting, but it didn't seem straightforward and it's platform dependent. 