### PR TITLE
[JENKINS-35687] Add simple git lfs support

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
@@ -49,4 +49,11 @@ public interface CheckoutCommand extends GitCommand {
      * @return a {@link org.jenkinsci.plugins.gitclient.CheckoutCommand} object.
      */
     CheckoutCommand timeout(Integer timeout);
+    
+    /**
+     * Enable LFS checkout.
+     * 
+     * @return a {@link org.jenkinsci.plugins.gitclient.CheckoutCommand} object.
+     */
+    CheckoutCommand withLFS();
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
@@ -51,9 +51,10 @@ public interface CheckoutCommand extends GitCommand {
     CheckoutCommand timeout(Integer timeout);
     
     /**
-     * Enable LFS checkout.
+     * Call "git lfs pull" for the given remote after checkout.
      * 
+     * @param remote a {@link java.lang.String} object.
      * @return a {@link org.jenkinsci.plugins.gitclient.CheckoutCommand} object.
      */
-    CheckoutCommand withLFS();
+    CheckoutCommand lfsRemote(String lfsRemote);
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
@@ -49,10 +49,10 @@ public interface CheckoutCommand extends GitCommand {
      * @return a {@link org.jenkinsci.plugins.gitclient.CheckoutCommand} object.
      */
     CheckoutCommand timeout(Integer timeout);
-    
+
     /**
      * Call "git lfs pull" for the given remote after checkout.
-     * 
+     *
      * @param remote a {@link java.lang.String} object.
      * @return a {@link org.jenkinsci.plugins.gitclient.CheckoutCommand} object.
      */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1988,7 +1988,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 this.timeout = timeout;
                 return this;
             }
-            
+
             public CheckoutCommand lfsRemote(String lfsRemote) {
                 this.lfsRemote = lfsRemote;
                 return this;
@@ -2055,7 +2055,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     }
                     args.add(ref);
                     launchCommandIn(args, workspace, checkoutEnv, timeout);
-                    
+
                     if (lfsRemote != null) {
                         final String url = getRemoteUrl(lfsRemote);
                         StandardCredentials cred = credentials.get(url);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1962,7 +1962,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public boolean deleteBranch;
             public List<String> sparseCheckoutPaths = Collections.emptyList();
             public Integer timeout;
-            public boolean withLFS;
+            public String lfsRemote;
 
             public CheckoutCommand ref(String ref) {
                 this.ref = ref;
@@ -1989,8 +1989,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
             
-            public CheckoutCommand withLFS() {
-                this.withLFS = true;
+            public CheckoutCommand lfsRemote(String lfsRemote) {
+                this.lfsRemote = lfsRemote;
                 return this;
             }
 
@@ -2025,7 +2025,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     sparseCheckout(sparseCheckoutPaths);
 
                     EnvVars checkoutEnv = environment;
-                    if (withLFS) {
+                    if (lfsRemote != null) {
                         // Disable the git-lfs smudge filter because it is much slower on
                         // certain OSes than doing a single "git lfs pull" after checkout.
                         checkoutEnv = new EnvVars(checkoutEnv);
@@ -2056,15 +2056,14 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     args.add(ref);
                     launchCommandIn(args, workspace, checkoutEnv, timeout);
                     
-                    if (withLFS) {
-                        final String remote = getDefaultRemote();
-                        final String url = getRemoteUrl(remote);
+                    if (lfsRemote != null) {
+                        final String url = getRemoteUrl(lfsRemote);
                         StandardCredentials cred = credentials.get(url);
                         if (cred == null) cred = defaultCredentials;
                         ArgumentListBuilder lfsArgs = new ArgumentListBuilder();
                         lfsArgs.add("lfs");
                         lfsArgs.add("pull");
-                        lfsArgs.add(remote);
+                        lfsArgs.add(lfsRemote);
                         try {
                             launchCommandWithCredentials(lfsArgs, workspace, cred, new URIish(url), timeout);
                         } catch (URISyntaxException e) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -276,7 +276,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
-            public CheckoutCommand withLFS() {
+            public CheckoutCommand lfsRemote(String lfsRemote) {
                 listener.getLogger().println("[WARNING] JGit doesn't support LFS checkout. This flag is ignored.");
                 return this;
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -275,6 +275,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Override
+            public CheckoutCommand withLFS() {
+                listener.getLogger().println("[WARNING] JGit doesn't support LFS checkout. This flag is ignored.");
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
 
                 if(! sparseCheckoutPaths.isEmpty()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -108,7 +108,7 @@ public class GitClientTest {
         CLI_GIT_SUPPORTS_SUBMODULES = cliGitClient.isAtLeastVersion(1, 8, 0, 0);
         CLI_GIT_SUPPORTS_SUBMODULE_DEINIT = cliGitClient.isAtLeastVersion(1, 9, 0, 0);
         CLI_GIT_SUPPORTS_SUBMODULE_RENAME = cliGitClient.isAtLeastVersion(1, 9, 0, 0);
-        
+
         boolean gitLFSExists = false;
         try {
             // If git-lfs is installed then the version string should look like this:
@@ -564,7 +564,7 @@ public class GitClientTest {
         gitClient.checkoutBranch(branch, remote + "/" + branch);
         assertTrue(src.isDirectory());
     }
-    
+
     @Issue("35687") // Add simple git lfs support
     @Test
     public void testCheckoutWithGitLFS() throws Exception {


### PR DESCRIPTION
This is a refactoring of @matthauck's changes from jenkinsci/git-client-plugin#206.  I could not get his changes to work because `git lfs fetch` was failing with this error: can't resolve ref: "HEAD" (See https://github.com/jenkinsci/git-plugin/pull/414#issuecomment-260159466).  After reading git-lfs/git-lfs#1307, I realized that `git lfs fetch` requires the code to be checked out before it can know which large files to download.  The original code was attempting to run `git lfs fetch` after `git fetch` but before `git checkout`, which wasn't working because there wasn't a local `HEAD` yet.  This means the changes proposed by @estyrke in https://github.com/jenkinsci/git-plugin/pull/414#issuecomment-263843310 also won't work.  The fix was to remove the call to `git lfs fetch` and add a call to `git lfs pull` after the code was checked out.

Next, I ran into problems with doing `git lfs pull` after the `git checkout` when credentials are required by the remote repository.  The checkout command doesn't accept a set of credentials so there wasn't an obvious way to know which credentials should be used for the `git lfs pull`.  I decided to retrieve the credentials based on the remote repository URL.  That also was problematic because if the local repository has multiple remotes then there isn't a good way to know which remote should be used for `git lfs pull`.  This is a known issue with git lfs and is documented at git-lfs/git-lfs#436.  If no remote is provided to `git lfs pull` then git-lfs has some fallback logic that eventually defaults to `origin`.  This fallback logic is different from the fallback logic in `CLIGitAPIImpl::getDefaultRemote()`.  Since I already needed the remote URL to know which credentials to use for `git lfs pull`, I decided to use `getDefaultRemote()` to know which remote to pull from.  In most cases it will pull from `origin`, which is very similar to the default behavior of `git lfs pull`.  This could cause problems in the future.  If it does, then we can add an additional parameter for users to specify the name of the remote to use with `git lfs pull`.

I tested these changes locally.  I tried to add unit tests, but couldn't find any existing tests to act as a guideline.  If unit tests are required then guidance would be greatly appreciated.

@MarkEWaite, I noticed this comment in jenkinsci/git-client-plugin#206:
>Wouldn't it be better to check that LFS is available in the git version being used, rather than just throw an exception when it fails?

I agree with @matthauck that an explicit setting is needed.  There are use cases where a repository has files stored using git-lfs but the user doesn't want to pull those files during the initial checkout.  Making the `git lfs pull` an option gives users flexibility to decide when/if they want to pull the files.

A separate PR for jenkinsci/git-plugin is forthcoming.