### PR TITLE
1.21.x diagnose testCheckout_String failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ To Do
 * Complete more of the JGit implementation
 * Combine CliGitAPIImplTest & JGitAPIImplTest into GitClientTest
 * Increase automated test coverage
+* Support windows credentials store

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ To Do
 * Fix [bugs](https://issues.jenkins-ci.org/secure/IssueNavigator.jspa?mode=hide&reset=true&jqlQuery=project+%3D+JENKINS+AND+status+in+%28Open%2C+"In+Progress"%2C+Reopened%29+AND+component+%3D+git-client-plugin)
 * Create infrastructure to detect [files opened during a unit test](https://issues.jenkins-ci.org/browse/JENKINS-19994) and left open at exit from test
 * Complete more of the JGit implementation
-* Combine CliGitAPIImplTest and JGitAPIImplTest into GitClientTest
+* Combine CliGitAPIImplTest & JGitAPIImplTest into GitClientTest

--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ To Do
 * Create infrastructure to detect [files opened during a unit test](https://issues.jenkins-ci.org/browse/JENKINS-19994) and left open at exit from test
 * Complete more of the JGit implementation
 * Combine CliGitAPIImplTest & JGitAPIImplTest into GitClientTest
+* Increase automated test coverage

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -787,7 +787,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             final FetchConnection c = tn.openFetch();
             try {
                 for (final Ref r : c.getRefs()) {
+                    // JGit getHeadRev(String) returns more entries than CliGit getHeadRev(String)
+                    // See GitClientTest.testGetHeadRev_String() for the failure
+                    // if (r.getName().startsWith(Constants.R_HEADS)) {
                     heads.put(r.getName(), r.getPeeledObjectId() != null ? r.getPeeledObjectId() : r.getObjectId());
+                    // }
                 }
             } finally {
                 c.close();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -403,6 +403,29 @@ public class GitClientTest {
         assertEquals(1, gitDirListing.length);
     }
 
+    private void assertGitDirContents(GitClient gitClient) throws Exception {
+        assertTrue(gitClient.hasGitRepo());
+        File gitDir = new File(repoFolder.getRoot(), ".git");
+        File[] expectedDirsJGit = {
+            new File(gitDir, "branches"),
+            new File(gitDir, "config"),
+            new File(gitDir, "FETCH_HEAD"),
+            new File(gitDir, "HEAD"),
+            new File(gitDir, "hooks"),
+            new File(gitDir, "logs"),
+            new File(gitDir, "objects"),
+            new File(gitDir, "refs"),};
+        File[] gitDirListing = gitDir.listFiles();
+        assertThat(Arrays.asList(gitDirListing), hasItems(expectedDirsJGit));
+        if (gitImplName.equals("git")) {
+            File[] additionalDirsCliGit = {
+                new File(gitDir, "description"), // JGit doesn't create on fetch
+                new File(gitDir, "info"), // JGit doesn't create on fetch
+            };
+            assertThat(Arrays.asList(gitDirListing), hasItems(additionalDirsCliGit));
+        }
+    }
+
     private void assertDetachedHead(GitClient client, ObjectId ref) throws Exception {
         CliGitCommand gitCmd = new CliGitCommand(client);
         gitCmd.run("status");
@@ -452,6 +475,7 @@ public class GitClientTest {
 
         /* Fetch from origin repo */
         fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
+        assertGitDirContents(gitClient);
 
         /* Gather diagnostic information in case checkout fails */
         final String originUrl = gitClient.getRemoteUrl("origin");
@@ -488,7 +512,9 @@ public class GitClientTest {
 
     @Test
     public void testCheckout_String_String() throws Exception {
+        assertEmptyWorkingDir(gitClient);
         fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
+        assertGitDirContents(gitClient);
 
         /* Gather diagnostic information in case checkout fails */
         final String originUrl = gitClient.getRemoteUrl("origin");
@@ -531,7 +557,9 @@ public class GitClientTest {
 
     @Test
     public void testCheckout_0args() throws Exception {
+        assertEmptyWorkingDir(gitClient);
         fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
+        assertGitDirContents(gitClient);
 
         /* Gather diagnostic information in case checkout fails */
         final String originUrl = gitClient.getRemoteUrl("origin");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -461,7 +461,6 @@ public class GitClientTest {
         /* Fetch from origin repo */
         fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
         originBranches = gitClient.getRemoteBranches();
-        assertThat(originBranches, is(not(empty())));
 
         /* Checkout a commit after README was added, before src directory was added */
         String ref = "5a865818566c9d03738cdcd49cc0a1543613fd41";

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -417,7 +417,6 @@ public class GitClientTest {
             new File(gitDir, "objects"),
             new File(gitDir, "refs"),};
         List<File> gitDirListing = Arrays.asList(gitDir.listFiles());
-        System.out.println("Git dir listing: " + gitDirListing);
         assertThat(gitDirListing, hasItems(expectedDirsJGit));
         if (gitImplName.equals("git")) {
             File[] additionalDirsCliGit = { // CLI git only

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -480,7 +480,7 @@ public class GitClientTest {
         /* Gather diagnostic information in case checkout fails */
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
         String[] head = gitCmd.run("rev-parse", "5a865818566c9d03738cdcd49cc0a1543613fd41");
-        System.out.println("Last fetch " + lastFetchPath + "HEAD rev-parse output is " + Arrays.toString(head));
+        System.out.println("Last fetch " + lastFetchPath + " HEAD rev-parse output is " + Arrays.toString(head));
         String[] status = gitCmd.run("status");
         assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
         String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");
@@ -520,7 +520,7 @@ public class GitClientTest {
         /* Gather diagnostic information in case checkout fails */
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
         String[] head = gitCmd.run("rev-parse", "5a865818566c9d03738cdcd49cc0a1543613fd41");
-        System.out.println("Last fetch " + lastFetchPath + "HEAD rev-parse output is " + Arrays.toString(head));
+        System.out.println("Last fetch " + lastFetchPath + " HEAD rev-parse output is " + Arrays.toString(head));
         String[] status = gitCmd.run("status");
         assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
         String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");
@@ -566,7 +566,7 @@ public class GitClientTest {
         /* Gather diagnostic information in case checkout fails */
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
         String[] head = gitCmd.run("rev-parse", "5a865818566c9d03738cdcd49cc0a1543613fd41");
-        System.out.println("Last fetch " + lastFetchPath + "HEAD rev-parse output is " + Arrays.toString(head));
+        System.out.println("Last fetch " + lastFetchPath + " HEAD rev-parse output is " + Arrays.toString(head));
         String[] status = gitCmd.run("status");
         assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
         String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -406,7 +406,7 @@ public class GitClientTest {
     private void assertGitDirContents(GitClient gitClient) throws Exception {
         assertTrue(gitClient.hasGitRepo());
         File gitDir = new File(repoFolder.getRoot(), ".git");
-        File[] expectedDirsJGit = {
+        File[] expectedDirsJGit = { // CLI git && JGit
             new File(gitDir, "branches"),
             new File(gitDir, "config"),
             new File(gitDir, "FETCH_HEAD"),
@@ -416,12 +416,12 @@ public class GitClientTest {
             new File(gitDir, "objects"),
             new File(gitDir, "refs"),};
         File[] gitDirListing = gitDir.listFiles();
+        System.out.println("Git dir listing: " + Arrays.toString(gitDirListing));
         assertThat(Arrays.asList(gitDirListing), hasItems(expectedDirsJGit));
         if (gitImplName.equals("git")) {
-            File[] additionalDirsCliGit = {
-                new File(gitDir, "description"), // JGit doesn't create on fetch
-                new File(gitDir, "info"), // JGit doesn't create on fetch
-            };
+            File[] additionalDirsCliGit = { // CLI git only
+                new File(gitDir, "description"),
+                new File(gitDir, "info"),};
             assertThat(Arrays.asList(gitDirListing), hasItems(additionalDirsCliGit));
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -454,11 +454,6 @@ public class GitClientTest {
         Set<Branch> originBranches = gitClient.getRemoteBranches();
         assertThat(originBranches, is(empty())); /* Nothing fetched into gitClient repo yet */
         final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
-        List<ObjectId> originObjectIds = new ArrayList<ObjectId>(originHeads.values());
-        String originRef = "refs/remotes/origin/tests/getSubmodules-jgit";
-        ObjectId originRefId = ObjectId.fromString("607d87f71911ff66db898ccb338ec73d6668edde");
-        assertThat(originHeads.keySet(), hasItems(originRef));
-        assertThat(originHeads.get(originRef), is(originRefId));
         for (String originHead : originHeads.keySet()) {
             System.out.println(gitImplName + " origin head: " + originHead);
         }
@@ -467,14 +462,6 @@ public class GitClientTest {
         fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
         originBranches = gitClient.getRemoteBranches();
         assertThat(originBranches, is(not(empty())));
-        List<ObjectId> branchObjectIds = new ArrayList<ObjectId>();
-        for (Branch branch : originBranches) {
-            branchObjectIds.add(branch.getSHA1());
-        }
-        if (gitImplName.equals("git")) {
-            // JGit getHeadRev(String) returns more entries than CliGit getHeadRev(String)
-            assertThat(branchObjectIds, containsInAnyOrder(originObjectIds.toArray()));
-        }
 
         /* Checkout a commit after README was added, before src directory was added */
         String ref = "5a865818566c9d03738cdcd49cc0a1543613fd41";

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -479,6 +479,8 @@ public class GitClientTest {
 
         /* Gather diagnostic information in case checkout fails */
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
+        String[] head = gitCmd.run("rev-parse", "HEAD");
+        System.out.println("HEAD rev-parse output is " + Arrays.toString(head));
         String[] status = gitCmd.run("status");
         assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
         String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");
@@ -517,6 +519,8 @@ public class GitClientTest {
 
         /* Gather diagnostic information in case checkout fails */
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
+        String[] head = gitCmd.run("rev-parse", "HEAD");
+        System.out.println("HEAD rev-parse output is " + Arrays.toString(head));
         String[] status = gitCmd.run("status");
         assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
         String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");
@@ -561,6 +565,8 @@ public class GitClientTest {
 
         /* Gather diagnostic information in case checkout fails */
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
+        String[] head = gitCmd.run("rev-parse", "HEAD");
+        System.out.println("HEAD rev-parse output is " + Arrays.toString(head));
         String[] status = gitCmd.run("status");
         assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
         String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -455,8 +455,8 @@ public class GitClientTest {
         assertThat(originBranches, is(empty())); /* Nothing fetched into gitClient repo yet */
         final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
         List<ObjectId> originObjectIds = new ArrayList<ObjectId>(originHeads.values());
-        String originRef = "refs/heads/ongoing/lts";
-        ObjectId originRefId = ObjectId.fromString("cb5d4f6c84b8d8a6898dd6d9f957eca188160255");
+        String originRef = "refs/remotes/origin/tests/getSubmodules-jgit";
+        ObjectId originRefId = ObjectId.fromString("607d87f71911ff66db898ccb338ec73d6668edde");
         assertThat(originHeads.keySet(), hasItems(originRef));
         assertThat(originHeads.get(originRef), is(originRefId));
         for (String originHead : originHeads.keySet()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -409,7 +409,6 @@ public class GitClientTest {
         File[] expectedDirsJGit = { // CLI git && JGit
             new File(gitDir, "branches"),
             new File(gitDir, "config"),
-            new File(gitDir, "FETCH_HEAD"),
             new File(gitDir, "HEAD"),
             new File(gitDir, "hooks"),
             new File(gitDir, "objects"),
@@ -420,6 +419,7 @@ public class GitClientTest {
         if (gitImplName.equals("git")) {
             File[] additionalDirsCliGit = { // CLI git only
                 new File(gitDir, "description"),
+                new File(gitDir, "FETCH_HEAD"),
                 new File(gitDir, "info"),};
             assertThat(gitDirListing, hasItems(additionalDirsCliGit));
         }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -448,24 +448,26 @@ public class GitClientTest {
         /* Confirm files not visible in empty repo */
         assertEmptyWorkingDir(gitClient);
 
+        /* Fetch from origin repo */
+        fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
+
         /* Gather diagnostic information in case checkout fails */
         final String originUrl = gitClient.getRemoteUrl("origin");
         System.out.println("Origin URL: " + originUrl);
         Set<Branch> originBranches = gitClient.getRemoteBranches();
-        assertThat(originBranches, is(empty())); /* Nothing fetched into gitClient repo yet */
+        assertThat(originBranches, is(not(empty()))); /* fetched into gitClient repo */
         final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
         for (String originHead : originHeads.keySet()) {
             System.out.println(gitImplName + " origin head: " + originHead);
         }
-
-        /* Fetch from origin repo */
-        fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
+        CliGitCommand gitCmd = new CliGitCommand(gitClient);
+        String[] logAll = gitCmd.run("log", "--all", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate");
+        assertTrue("Last fetch " + lastFetchPath + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
+        String[] log = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "5a865818566c9d03738cdcd49cc0a1543613fd41");
+        assertTrue("Last fetch " + lastFetchPath + ", log: '" + Arrays.toString(log) + "', logAll: '" + Arrays.toString(logAll) + "'", log.length > 1);
 
         /* Checkout a commit after README was added, before src directory was added */
         String ref = "5a865818566c9d03738cdcd49cc0a1543613fd41";
-        CliGitCommand gitCmd = new CliGitCommand(gitClient);
-        String[] log = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", ref);
-        assertTrue("Last fetch " + lastFetchPath + ", log: '" + Arrays.toString(log) + "'", log.length > 1);
         gitClient.checkout(ref);
         /* Confirm README.md visible, src directory not */
         assertFileInWorkingDir(gitClient, "README.md");
@@ -490,6 +492,22 @@ public class GitClientTest {
     @Test
     public void testCheckout_String_String() throws Exception {
         fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
+
+        /* Gather diagnostic information in case checkout fails */
+        final String originUrl = gitClient.getRemoteUrl("origin");
+        System.out.println("Origin URL: " + originUrl);
+        Set<Branch> originBranches = gitClient.getRemoteBranches();
+        assertThat(originBranches, is(not(empty()))); /* fetched into gitClient repo */
+        final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
+        for (String originHead : originHeads.keySet()) {
+            System.out.println(gitImplName + " origin head: " + originHead);
+        }
+        CliGitCommand gitCmd = new CliGitCommand(gitClient);
+        String[] logAll = gitCmd.run("log", "--all", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate");
+        assertTrue("Last fetch " + lastFetchPath + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
+        String[] log = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "5a865818566c9d03738cdcd49cc0a1543613fd41");
+        assertTrue("Last fetch " + lastFetchPath + ", log: '" + Arrays.toString(log) + "', logAll: '" + Arrays.toString(logAll) + "'", log.length > 1);
+
         int branchNumber = 10 + random.nextInt(80);
         String baseName = "branchA-";
         String branchName = baseName + branchNumber++;
@@ -522,6 +540,22 @@ public class GitClientTest {
     @Test
     public void testCheckout_0args() throws Exception {
         fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
+
+        /* Gather diagnostic information in case checkout fails */
+        final String originUrl = gitClient.getRemoteUrl("origin");
+        System.out.println("Origin URL: " + originUrl);
+        Set<Branch> originBranches = gitClient.getRemoteBranches();
+        assertThat(originBranches, is(not(empty()))); /* fetched into gitClient repo */
+        final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
+        for (String originHead : originHeads.keySet()) {
+            System.out.println(gitImplName + " origin head: " + originHead);
+        }
+        CliGitCommand gitCmd = new CliGitCommand(gitClient);
+        String[] logAll = gitCmd.run("log", "--all", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate");
+        assertTrue("Last fetch " + lastFetchPath + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
+        String[] log = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "5a865818566c9d03738cdcd49cc0a1543613fd41");
+        assertTrue("Last fetch " + lastFetchPath + ", log: '" + Arrays.toString(log) + "', logAll: '" + Arrays.toString(logAll) + "'", log.length > 1);
+
         int branchNumber = 10 + random.nextInt(80);
         String baseName = "branchA-";
         String branchName = baseName + branchNumber++;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -434,11 +434,13 @@ public class GitClientTest {
             default:
             case 0:
                 client.fetch(remote, refSpecs.toArray(new RefSpec[0]));
+                System.out.println("Last fetch path: " + lastFetchPath);
                 break;
             case 1:
                 URIish repoURL = new URIish(client.getRepository().getConfig().getString("remote", remote, "url"));
                 boolean fetchTags = random.nextBoolean();
                 client.fetch_().from(repoURL, refSpecs).tags(fetchTags).execute();
+                System.out.println("Last fetch path: " + lastFetchPath + " with tags - " + fetchTags);
                 break;
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -48,6 +48,9 @@ import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
 
 // import org.jvnet.hudson.test.Issue;
 /**
+ * GitClient tests, parameterized for multiple git implementations.
+ * Refer to conditionals in the tests for those cases where the
+ * implementations behave differently.
  *
  * @author Mark Waite
  */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -453,9 +453,7 @@ public class GitClientTest {
 
         /* Gather diagnostic information in case checkout fails */
         final String originUrl = gitClient.getRemoteUrl("origin");
-        System.out.println("Origin URL: " + originUrl);
         Set<Branch> originBranches = gitClient.getRemoteBranches();
-        assertThat(originBranches, is(not(empty()))); /* fetched into gitClient repo */
         final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
         for (String originHead : originHeads.keySet()) {
             System.out.println(gitImplName + " origin head: " + originHead);
@@ -495,9 +493,7 @@ public class GitClientTest {
 
         /* Gather diagnostic information in case checkout fails */
         final String originUrl = gitClient.getRemoteUrl("origin");
-        System.out.println("Origin URL: " + originUrl);
         Set<Branch> originBranches = gitClient.getRemoteBranches();
-        assertThat(originBranches, is(not(empty()))); /* fetched into gitClient repo */
         final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
         for (String originHead : originHeads.keySet()) {
             System.out.println(gitImplName + " origin head: " + originHead);
@@ -543,9 +539,7 @@ public class GitClientTest {
 
         /* Gather diagnostic information in case checkout fails */
         final String originUrl = gitClient.getRemoteUrl("origin");
-        System.out.println("Origin URL: " + originUrl);
         Set<Branch> originBranches = gitClient.getRemoteBranches();
-        assertThat(originBranches, is(not(empty()))); /* fetched into gitClient repo */
         final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
         for (String originHead : originHeads.keySet()) {
             System.out.println(gitImplName + " origin head: " + originHead);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -473,20 +473,18 @@ public class GitClientTest {
     public void testCheckout_String() throws Exception {
         /* Confirm files not visible in empty repo */
         assertEmptyWorkingDir(gitClient);
-
         /* Fetch from origin repo */
         fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
         assertGitDirContents(gitClient);
 
         /* Gather diagnostic information in case checkout fails */
-        final String originUrl = gitClient.getRemoteUrl("origin");
-        Set<Branch> originBranches = gitClient.getRemoteBranches();
-        final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
-        String[] logAll = gitCmd.run("log", "--all", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate");
-        assertTrue("Last fetch " + lastFetchPath + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
+        String[] status = gitCmd.run("status");
+        assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
+        String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");
+        assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
         String[] log = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "5a865818566c9d03738cdcd49cc0a1543613fd41");
-        assertTrue("Last fetch " + lastFetchPath + ", log: '" + Arrays.toString(log) + "', logAll: '" + Arrays.toString(logAll) + "'", log.length > 1);
+        assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + ", log: '" + Arrays.toString(log) + "', logAll: '" + Arrays.toString(logAll) + "'", log.length > 1);
 
         /* Checkout a commit after README was added, before src directory was added */
         String ref = "5a865818566c9d03738cdcd49cc0a1543613fd41";
@@ -518,14 +516,13 @@ public class GitClientTest {
         assertGitDirContents(gitClient);
 
         /* Gather diagnostic information in case checkout fails */
-        final String originUrl = gitClient.getRemoteUrl("origin");
-        Set<Branch> originBranches = gitClient.getRemoteBranches();
-        final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
-        String[] logAll = gitCmd.run("log", "--all", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate");
-        assertTrue("Last fetch " + lastFetchPath + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
+        String[] status = gitCmd.run("status");
+        assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
+        String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");
+        assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
         String[] log = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "5a865818566c9d03738cdcd49cc0a1543613fd41");
-        assertTrue("Last fetch " + lastFetchPath + ", log: '" + Arrays.toString(log) + "', logAll: '" + Arrays.toString(logAll) + "'", log.length > 1);
+        assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + ", log: '" + Arrays.toString(log) + "', logAll: '" + Arrays.toString(logAll) + "'", log.length > 1);
 
         int branchNumber = 10 + random.nextInt(80);
         String baseName = "branchA-";
@@ -563,14 +560,13 @@ public class GitClientTest {
         assertGitDirContents(gitClient);
 
         /* Gather diagnostic information in case checkout fails */
-        final String originUrl = gitClient.getRemoteUrl("origin");
-        Set<Branch> originBranches = gitClient.getRemoteBranches();
-        final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
-        String[] logAll = gitCmd.run("log", "--all", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate");
-        assertTrue("Last fetch " + lastFetchPath + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
+        String[] status = gitCmd.run("status");
+        assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
+        String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");
+        assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
         String[] log = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "5a865818566c9d03738cdcd49cc0a1543613fd41");
-        assertTrue("Last fetch " + lastFetchPath + ", log: '" + Arrays.toString(log) + "', logAll: '" + Arrays.toString(logAll) + "'", log.length > 1);
+        assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + ", log: '" + Arrays.toString(log) + "', logAll: '" + Arrays.toString(logAll) + "'", log.length > 1);
 
         int branchNumber = 10 + random.nextInt(80);
         String baseName = "branchA-";

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -582,13 +582,37 @@ public class GitClientTest {
 
         ObjectId commitA = commitOneFile();
         Map<String, ObjectId> headRevMapA = gitClient.getHeadRev(url);
-        assertThat(headRevMapA.keySet(), hasItems("refs/heads/master"));
+        if (gitImplName.equals("git")) {
+            assertThat(headRevMapA.keySet(), contains("refs/heads/master"));
+        } else {
+            // JGit getHeadRev(String) returns more entries than CliGit getHeadRev(String)
+            assertThat(headRevMapA.keySet(), hasItems("refs/heads/master"));
+        }
         assertThat(headRevMapA.get("refs/heads/master"), is(commitA));
 
         ObjectId commitB = commitOneFile();
         Map<String, ObjectId> headRevMapB = gitClient.getHeadRev(url);
-        assertThat(headRevMapB.keySet(), hasItems("refs/heads/master"));
+        if (gitImplName.equals("git")) {
+            assertThat(headRevMapB.keySet(), contains("refs/heads/master"));
+        } else {
+            // JGit getHeadRev(String) returns more entries than CliGit getHeadRev(String)
+            assertThat(headRevMapB.keySet(), hasItems("refs/heads/master"));
+        }
         assertThat(headRevMapB.get("refs/heads/master"), is(commitB));
+
+        /* Fetch from origin repo, should not change head rev */
+        fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
+        Map<String, ObjectId> headRevMapC = gitClient.getHeadRev(url);
+        if (gitImplName.equals("git")) {
+            assertThat(headRevMapC.keySet(), contains("refs/heads/master"));
+        } else {
+            // JGit getHeadRev(String) returns more entries than CliGit getHeadRev(String)
+            assertThat(headRevMapC.keySet(), hasItems("refs/heads/master"));
+        }
+        assertThat(headRevMapC.get("refs/heads/master"), is(commitB));
+        if (gitImplName.equals("git")) {
+            assertEquals(headRevMapB, headRevMapC);
+        }
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -479,8 +479,8 @@ public class GitClientTest {
 
         /* Gather diagnostic information in case checkout fails */
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
-        String[] head = gitCmd.run("rev-parse", "HEAD");
-        System.out.println("HEAD rev-parse output is " + Arrays.toString(head));
+        String[] head = gitCmd.run("rev-parse", "5a865818566c9d03738cdcd49cc0a1543613fd41");
+        System.out.println("Last fetch " + lastFetchPath + "HEAD rev-parse output is " + Arrays.toString(head));
         String[] status = gitCmd.run("status");
         assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
         String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");
@@ -519,8 +519,8 @@ public class GitClientTest {
 
         /* Gather diagnostic information in case checkout fails */
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
-        String[] head = gitCmd.run("rev-parse", "HEAD");
-        System.out.println("HEAD rev-parse output is " + Arrays.toString(head));
+        String[] head = gitCmd.run("rev-parse", "5a865818566c9d03738cdcd49cc0a1543613fd41");
+        System.out.println("Last fetch " + lastFetchPath + "HEAD rev-parse output is " + Arrays.toString(head));
         String[] status = gitCmd.run("status");
         assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
         String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");
@@ -565,8 +565,8 @@ public class GitClientTest {
 
         /* Gather diagnostic information in case checkout fails */
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
-        String[] head = gitCmd.run("rev-parse", "HEAD");
-        System.out.println("HEAD rev-parse output is " + Arrays.toString(head));
+        String[] head = gitCmd.run("rev-parse", "5a865818566c9d03738cdcd49cc0a1543613fd41");
+        System.out.println("Last fetch " + lastFetchPath + "HEAD rev-parse output is " + Arrays.toString(head));
         String[] status = gitCmd.run("status");
         assertTrue("Last fetch " + lastFetchPath + ", status: '" + Arrays.toString(status) + "'", status.length > 0);
         String[] logAll = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", "--all");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -412,7 +412,6 @@ public class GitClientTest {
             new File(gitDir, "FETCH_HEAD"),
             new File(gitDir, "HEAD"),
             new File(gitDir, "hooks"),
-            new File(gitDir, "logs"),
             new File(gitDir, "objects"),
             new File(gitDir, "refs"),};
         List<File> gitDirListing = Arrays.asList(gitDir.listFiles());

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -455,9 +455,6 @@ public class GitClientTest {
         final String originUrl = gitClient.getRemoteUrl("origin");
         Set<Branch> originBranches = gitClient.getRemoteBranches();
         final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
-        for (String originHead : originHeads.keySet()) {
-            System.out.println(gitImplName + " origin head: " + originHead);
-        }
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
         String[] logAll = gitCmd.run("log", "--all", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate");
         assertTrue("Last fetch " + lastFetchPath + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
@@ -495,9 +492,6 @@ public class GitClientTest {
         final String originUrl = gitClient.getRemoteUrl("origin");
         Set<Branch> originBranches = gitClient.getRemoteBranches();
         final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
-        for (String originHead : originHeads.keySet()) {
-            System.out.println(gitImplName + " origin head: " + originHead);
-        }
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
         String[] logAll = gitCmd.run("log", "--all", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate");
         assertTrue("Last fetch " + lastFetchPath + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);
@@ -541,9 +535,6 @@ public class GitClientTest {
         final String originUrl = gitClient.getRemoteUrl("origin");
         Set<Branch> originBranches = gitClient.getRemoteBranches();
         final Map<String, ObjectId> originHeads = gitClient.getHeadRev(originUrl);
-        for (String originHead : originHeads.keySet()) {
-            System.out.println(gitImplName + " origin head: " + originHead);
-        }
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
         String[] logAll = gitCmd.run("log", "--all", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate");
         assertTrue("Last fetch " + lastFetchPath + ", logAll: '" + Arrays.toString(logAll) + "'", logAll.length > 1);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -460,10 +460,12 @@ public class GitClientTest {
 
         /* Fetch from origin repo */
         fetch(gitClient, "origin", "+refs/heads/*:refs/remotes/origin/*");
-        originBranches = gitClient.getRemoteBranches();
 
         /* Checkout a commit after README was added, before src directory was added */
         String ref = "5a865818566c9d03738cdcd49cc0a1543613fd41";
+        CliGitCommand gitCmd = new CliGitCommand(gitClient);
+        String[] log = gitCmd.run("log", "--graph", "--pretty=oneline", "--abbrev-commit", "--decorate", ref);
+        assertTrue("Last fetch " + lastFetchPath + ", log: '" + Arrays.toString(log) + "'", log.length > 1);
         gitClient.checkout(ref);
         /* Confirm README.md visible, src directory not */
         assertFileInWorkingDir(gitClient, "README.md");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -415,14 +415,14 @@ public class GitClientTest {
             new File(gitDir, "logs"),
             new File(gitDir, "objects"),
             new File(gitDir, "refs"),};
-        File[] gitDirListing = gitDir.listFiles();
-        System.out.println("Git dir listing: " + Arrays.toString(gitDirListing));
-        assertThat(Arrays.asList(gitDirListing), hasItems(expectedDirsJGit));
+        List<File> gitDirListing = Arrays.asList(gitDir.listFiles());
+        System.out.println("Git dir listing: " + gitDirListing);
+        assertThat(gitDirListing, hasItems(expectedDirsJGit));
         if (gitImplName.equals("git")) {
             File[] additionalDirsCliGit = { // CLI git only
                 new File(gitDir, "description"),
                 new File(gitDir, "info"),};
-            assertThat(Arrays.asList(gitDirListing), hasItems(additionalDirsCliGit));
+            assertThat(gitDirListing, hasItems(additionalDirsCliGit));
         }
     }
 


### PR DESCRIPTION
Diagnostic pull request to evaluate ci.jenkins.io job failures without committing to the target branch