### PR TITLE
Limit the number of objects returned from rev-list

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2189,6 +2189,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public boolean firstParent;
             public String refspec;
             public List<ObjectId> out;
+            public int maxCount = 0;
 
             public RevListCommand all() {
                 this.all = true;
@@ -2210,6 +2211,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public RevListCommand maxCount(int count){
+                this.maxCount = count;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 ArgumentListBuilder args = new ArgumentListBuilder("rev-list");
 
@@ -2223,6 +2229,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (refspec != null) {
                    args.add(refspec);
+                }
+
+                if (maxCount > 0) {
+                    args.add("--max-count=" + maxCount);
                 }
 
                 String result = launchCommand(args);
@@ -2261,10 +2271,16 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /** {@inheritDoc} */
     public List<ObjectId> revList(String ref) throws GitException, InterruptedException {
+        return revList(ref, 0);
+    }
+
+    /** {@inheritDoc} */
+    public List<ObjectId> revList(String ref, int count) throws GitException, InterruptedException {
         List<ObjectId> oidList = new ArrayList<>();
         RevListCommand revListCommand = revList_();
         revListCommand.reference(ref);
         revListCommand.to(oidList);
+        revListCommand.maxCount(count);
         revListCommand.execute();
         return oidList;
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -655,6 +655,16 @@ public interface GitClient {
      */
     List<ObjectId> revList(String ref) throws GitException, InterruptedException;
 
+    /**
+     * revList.
+     *
+     * @param ref a {@link java.lang.String} object.
+     * @param count the number of objects to return (0 for all)
+     * @return a {@link java.util.List} object.
+     * @throws hudson.plugins.git.GitException if underlying git operation fails.
+     * @throws java.lang.InterruptedException if interrupted.
+     */
+    List<ObjectId> revList(String ref, int count) throws GitException, InterruptedException;
 
     // --- submodules
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -577,6 +577,11 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     }
 
     /** {@inheritDoc} */
+    public List<ObjectId> revList(String ref, int count) throws GitException, InterruptedException {
+        return proxy.revList(ref, count);
+    }
+
+    /** {@inheritDoc} */
     public GitClient subGit(String subdir) {
         return proxy.subGit(subdir);
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RevListCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RevListCommand.java
@@ -24,6 +24,13 @@ public interface RevListCommand extends GitCommand {
     RevListCommand firstParent();
 
     /**
+     * Set the maximum numer of objects returned.
+     *
+     * @return a {@link org.jenkinsci.plugins.gitclient.RevListCommand} object.
+     */
+    RevListCommand maxCount(int count);
+
+    /**
      * to.
      *
      * @param revs a {@link java.util.List} object.


### PR DESCRIPTION
Add a new method that allows a rev-list limit to be specified. This improves performance when fetching tags for multibranch projects.