### PR TITLE
[JENKINS-40834] Add an API to resolve symbolic refs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2614,27 +2614,29 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     @Override
     public Map<String, String> getRemoteSymbolicReferences(String url, String pattern)
             throws GitException, InterruptedException {
-        ArgumentListBuilder args = new ArgumentListBuilder("ls-remote");
-        args.add("--symref");
-        args.add(url);
-        if (pattern != null) {
-            args.add(pattern);
-        }
-
-        StandardCredentials cred = credentials.get(url);
-        if (cred == null) cred = defaultCredentials;
-
-        String result = launchCommandWithCredentials(args, null, cred, url);
-
         Map<String, String> references = new HashMap<>();
-        String[] lines = result.split("\n");
-        Pattern symRefPattern = Pattern.compile("^ref:\\s+([^ ]+)\\s+([^ ]+)$");
-        for (String line : lines) {
-            Matcher matcher = symRefPattern.matcher(line);
-            if (matcher.matches()) {
-                references.put(matcher.group(2), matcher.group(1));
-            } else  if (line.length() < 41) {
-                throw new GitException("unexpected ls-remote output " + line);
+        if (isAtLeastVersion(2, 8, 0, 0)) {
+            // --symref is only understood by ls-remote starting from git 2.8.0
+            // https://github.com/git/git/blob/afd6726309/Documentation/RelNotes/2.8.0.txt#L72-L73
+            ArgumentListBuilder args = new ArgumentListBuilder("ls-remote");
+            args.add("--symref");
+            args.add(url);
+            if (pattern != null) {
+                args.add(pattern);
+            }
+
+            StandardCredentials cred = credentials.get(url);
+            if (cred == null) cred = defaultCredentials;
+
+            String result = launchCommandWithCredentials(args, null, cred, url);
+
+            String[] lines = result.split("\n");
+            Pattern symRefPattern = Pattern.compile("^ref:\\s+([^ ]+)\\s+([^ ]+)$");
+            for (String line : lines) {
+                Matcher matcher = symRefPattern.matcher(line);
+                if (matcher.matches()) {
+                    references.put(matcher.group(2), matcher.group(1));
+                }
             }
         }
         return references;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -621,11 +621,13 @@ public interface GitClient {
 
     /**
      * List symbolic references in a remote repository. Equivalent to <tt>git ls-remote --symref &lt;repository&gt;
-     * [&lt;refs&gt;]</tt>.
+     * [&lt;refs&gt;]</tt>. Note: the response may be empty for multiple reasons
      *
      * @param remoteRepoUrl Remote repository URL.
      * @param pattern       Only references matching the given pattern are displayed.
-     * @return a map of references name and its underlying reference. Empty if none.
+     * @return a map of references name and its underlying reference. Empty if none or if the remote does not report
+     * symbolic references (i.e. Git 1.8.4 or earlier) or if the client does not support reporting symbolic references
+     * (e.g. command line Git prior to 2.8.0).
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException  if interrupted.
      */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -620,6 +620,18 @@ public interface GitClient {
     Map<String, ObjectId> getRemoteReferences(String remoteRepoUrl, String pattern, boolean headsOnly, boolean tagsOnly) throws GitException, InterruptedException;
 
     /**
+     * List symbolic references in a remote repository. Equivalent to <tt>git ls-remote --symref &lt;repository&gt;
+     * [&lt;refs&gt;]</tt>.
+     *
+     * @param remoteRepoUrl Remote repository URL.
+     * @param pattern       Only references matching the given pattern are displayed.
+     * @return a map of references name and its underlying reference. Empty if none.
+     * @throws hudson.plugins.git.GitException if underlying git operation fails.
+     * @throws java.lang.InterruptedException  if interrupted.
+     */
+    Map<String, String> getRemoteSymbolicReferences(String remoteRepoUrl, String pattern) throws GitException, InterruptedException;
+
+    /**
      * Retrieve commit object that is direct child for <tt>revName</tt> revision reference.
      *
      * @param revName a commit sha1 or tag/branch refname

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -840,38 +840,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                             }
                         }
                     }
-                } catch (URISyntaxException | NotSupportedException | TransportException e) {
                     // ignore this is a total hack
                 }
             } catch (IllegalAccessException | NoSuchFieldException e) {
-                // ignore, we just have to try it the Git 1.8.4 way
+                // ignore, caller will just have to try it the Git 1.8.4 way, we'll return an empty map
             }
-
-            LsRemoteCommand lsRemote = new LsRemoteCommand(repo);
-            lsRemote.setRemote(url);
-            lsRemote.setCredentialsProvider(getProvider());
-            Map<String, Ref> refs = lsRemote.callAsMap();
-
-            Ref target = refs.get(Constants.HEAD);
-            if (target == null) {
-                return references;
-            }
-            Set<String> candidates = new HashSet<>();
-            for (Map.Entry<String, Ref> entry: refs.entrySet()) {
-                if (entry.getValue() == target) {
-                    continue;
-                }
-                if (entry.getValue().getObjectId().equals(target.getObjectId())) {
-                    candidates.add(entry.getKey());
-                }
-            }
-            if (candidates.size() == 1) {
-                references.put(Constants.HEAD, candidates.iterator().next());
-            } else if (candidates.contains(Constants.R_HEADS+Constants.MASTER)) {
-                // if multiple heads have the same object ID, git 1.8.4 and earlier would give priority to master
-                references.put(Constants.HEAD, Constants.R_HEADS + Constants.MASTER);
-            } // else we have an inconclusive resolution
-        } catch (GitAPIException | IOException e) {
+        } catch (IOException | URISyntaxException e) {
             throw new GitException(e);
         }
         return references;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -548,6 +548,12 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     }
 
     /** {@inheritDoc} */
+    public Map<String, String> getRemoteSymbolicReferences(String remoteRepoUrl, String pattern)
+            throws GitException, InterruptedException {
+        return proxy.getRemoteSymbolicReferences(remoteRepoUrl, pattern);
+    }
+
+    /** {@inheritDoc} */
     public ObjectId revParse(String revName) throws GitException, InterruptedException {
         return proxy.revParse(revName);
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -17,6 +17,11 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         return Git.with(listener, env).in(ws).using("git").getClient();
     }
 
+    @Override
+    protected boolean hasWorkingGetRemoteSymbolicReferences() {
+        return ((CliGitAPIImpl)(w.git)).isAtLeastVersion(2,8,0,0);
+    }
+
     private static boolean cliGitDefaultsSet = false;
 
     private void setCliGitDefaults() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -6,6 +6,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.jenkinsci.plugins.gitclient.StringSharesPrefix.sharesPrefix;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assume.assumeThat;
+
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
@@ -3376,14 +3378,18 @@ public abstract class GitAPITestCase extends TestCase {
      * Test getRemoteSymbolicReferences with listing all references
      */
     public void test_getRemoteSymbolicReferences() throws Exception {
+        assumeThat(hasWorkingGetRemoteSymbolicReferences(), is(true));
         Map<String, String> references = w.git.getRemoteSymbolicReferences(remoteMirrorURL, null);
         assertThat(references, hasEntry(is(Constants.HEAD), is(Constants.R_HEADS + Constants.MASTER)));
     }
+
+    protected abstract boolean hasWorkingGetRemoteSymbolicReferences();
 
     /**
      * Test getRemoteSymbolicReferences with listing all references
      */
     public void test_getRemoteSymbolicReferences_withMatchingPattern() throws Exception {
+        assumeThat(hasWorkingGetRemoteSymbolicReferences(), is(true));
         Map<String, String> references = w.git.getRemoteSymbolicReferences(remoteMirrorURL, Constants.HEAD);
         assertThat(references, hasEntry(is(Constants.HEAD), is(Constants.R_HEADS + Constants.MASTER)));
         assertThat(references.size(), is(1));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -3372,6 +3372,23 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue(references.isEmpty());
     }
 
+    /**
+     * Test getRemoteSymbolicReferences with listing all references
+     */
+    public void test_getRemoteSymbolicReferences() throws Exception {
+        Map<String, String> references = w.git.getRemoteSymbolicReferences(remoteMirrorURL, null);
+        assertThat(references, hasEntry(is(Constants.HEAD), is(Constants.R_HEADS + Constants.MASTER)));
+    }
+
+    /**
+     * Test getRemoteSymbolicReferences with listing all references
+     */
+    public void test_getRemoteSymbolicReferences_withMatchingPattern() throws Exception {
+        Map<String, String> references = w.git.getRemoteSymbolicReferences(remoteMirrorURL, Constants.HEAD);
+        assertThat(references, hasEntry(is(Constants.HEAD), is(Constants.R_HEADS + Constants.MASTER)));
+        assertThat(references.size(), is(1));
+    }
+
     private Properties parseLsRemote(File file) throws IOException
     {
         Properties properties = new Properties();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.gitclient;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import org.eclipse.jgit.transport.BasePackFetchConnection;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -11,6 +12,17 @@ public class JGitAPIImplTest extends GitAPITestCase {
     @Override
     protected GitClient setupGitAPI(File ws) throws Exception {
         return Git.with(listener, env).in(ws).using("jgit").getClient();
+    }
+
+    @Override
+    protected boolean hasWorkingGetRemoteSymbolicReferences() {
+        try {
+            // TODO if JGit implement https://bugs.eclipse.org/bugs/show_bug.cgi?id=514052 we should switch to that
+            BasePackFetchConnection.class.getSuperclass().getDeclaredField("remoteCapablities");
+            return true;
+        } catch (NoSuchFieldException e) {
+            return false;
+        }
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitApacheAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitApacheAPIImplTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.gitclient;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import org.eclipse.jgit.transport.BasePackFetchConnection;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -11,6 +12,17 @@ public class JGitApacheAPIImplTest extends GitAPITestCase {
     @Override
     protected GitClient setupGitAPI(File ws) throws Exception {
         return Git.with(listener, env).in(ws).using("jgitapache").getClient();
+    }
+
+    @Override
+    protected boolean hasWorkingGetRemoteSymbolicReferences() {
+        try {
+            // TODO if JGit implement https://bugs.eclipse.org/bugs/show_bug.cgi?id=514052 we should switch to that
+            BasePackFetchConnection.class.getSuperclass().getDeclaredField("remoteCapablities");
+            return true;
+        } catch (NoSuchFieldException e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
- Sadly JGit needs to try and guess

@reviewbybees

(Downstream PR for git-plugin to use the API will follow - based on WIP in https://github.com/jenkinsci/git-plugin/tree/jenkins-40834 that needed this change to have a hope of working)