### PR TITLE
use git log that acts like git whatchanged. include merge commits

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -9,7 +9,7 @@ import java.io.Writer;
  * Command builder for generating changelog in the format {@code GitSCM} expects.
  *
  * <p>
- * The output format is that of <tt>git-whatchanged</tt>, which looks something like this:
+ * The output format is that of <tt>git-log</tt>, which looks something like this:
  *
  * <pre>
  * commit dadaf808d99c4c23c53476b0c48e25a181016300

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -837,7 +837,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             public void execute() throws GitException, InterruptedException {
-                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "whatchanged", "--no-abbrev", "-M");
+                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "log", "--no-abbrev", "--raw", "--diff-filter=ACDMRTUXB", "-M");
                 args.add("--format="+RAW);
                 if (n!=null)
                     args.add("-n").add(n);
@@ -846,14 +846,14 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (out==null)  throw new IllegalStateException();
 
-                // "git whatchanged" std output gives us byte stream of data
+                // "git log" std output gives us byte stream of data
                 // Commit messages in that byte stream are UTF-8 encoded.
                 // We want to decode bytestream to strings using UTF-8 encoding.
                 try (WriterOutputStream w = new WriterOutputStream(out, Charset.forName("UTF-8"))) {
                     if (launcher.launch().cmds(args).envs(environment).stdout(w).stderr(listener.getLogger()).pwd(workspace).join() != 0)
-                        throw new GitException("Error launching git whatchanged");
+                        throw new GitException("Error launching git log");
                 } catch (IOException e) {
-                    throw new GitException("Error launching git whatchanged",e);
+                    throw new GitException("Error launching git log",e);
                 }
             }
         };

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -865,7 +865,7 @@ public interface GitClient {
     public List<String> showRevision(ObjectId r) throws GitException, InterruptedException;
 
     /**
-     * Given a Revision, show it as if it were an entry from git whatchanged, so that it
+     * Given a Revision, show it as if it were an entry from git log, so that it
      * can be parsed by GitChangeLogParser.
      *
      * <p>
@@ -885,7 +885,7 @@ public interface GitClient {
     List<String> showRevision(ObjectId from, ObjectId to) throws GitException, InterruptedException;
 
     /**
-     * Given a Revision, show it as if it were an entry from git whatchanged, so that it
+     * Given a Revision, show it as if it were an entry from git log, so that it
      * can be parsed by GitChangeLogParser.
      *
      * <p>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -157,7 +157,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     JGitAPIImpl(File workspace, TaskListener listener, final PreemptiveAuthHttpClientConnectionFactory httpConnectionFactory) {
-        /* If workspace is null, then default to current directory to match 
+        /* If workspace is null, then default to current directory to match
          * CliGitAPIImpl behavior */
         super(workspace == null ? new File(".") : workspace);
         this.listener = listener;
@@ -1174,7 +1174,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
          *      Commit to format.
          * @param parent
          *      Optional parent commit to produce the diff against. This only matters
-         *      for merge commits, and git-log/git-whatchanged/etc behaves differently with respect to this.
+         *      for merge commits.
          */
         @SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE",
                 justification = "Windows git implementation requires specific line termination")


### PR DESCRIPTION
we ran some tests that compared the output of git log and git whatchanged on several repos, and determined that this set of arguments made them act the same for our repos. then we removed the --no-merges flag from git log so it will include merge commits per https://issues.jenkins-ci.org/browse/JENKINS-28907 (see also the comment there). updated all references to git whatchanged in comments, since whatchanged no longer appears in the source code of this repo.

working w/ jasquat.