### PR TITLE
JENKINS-43198: restart clean as long as we catch a false jgit failure

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1262,26 +1262,34 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      */
     public void clean() throws GitException {
-        try (Repository repo = getRepository()) {
-            Git git = git(repo);
-            git.reset().setMode(HARD).call();
-            git.clean().setCleanDirectories(true).setIgnore(false).call();
-        } catch (GitAPIException e) {
-            throw new GitException(e);
-        // Fix JENKINS-43198:
-        // don't throw a "Could not delete file" if the file has actually been deleted
-        // See JGit bug 514434 https://bugs.eclipse.org/bugs/show_bug.cgi?id=514434
-        } catch(JGitInternalException e) {
-            String expected = "Could not delete file ";
-            if (e.getMessage().startsWith(expected)) {
-                String path = e.getMessage().substring(expected.length());
-                if (Files.exists(Paths.get(path))) {
-                    throw e;
-                } // else don't throw, everything is ok.
-            } else {
-                throw e;
-            }
-        }
+        boolean hadJGitFalseError = false;
+        do {
+	        try (Repository repo = getRepository()) {
+	            Git git = git(repo);
+	            git.reset().setMode(HARD).call();
+	            git.clean().setCleanDirectories(true).setIgnore(false).call();
+	            hadJGitFalseError = false;
+	        } catch (GitAPIException e) {
+	            throw new GitException(e);
+	        // Fix JENKINS-43198:
+	        // don't throw a "Could not delete file" if the file has actually been deleted
+	        // See JGit bug 514434 https://bugs.eclipse.org/bugs/show_bug.cgi?id=514434
+	        } catch(JGitInternalException e) {
+	            String expected = "Could not delete file ";
+	            if (e.getMessage().startsWith(expected)) {
+	                String path = e.getMessage().substring(expected.length());
+	                if (Files.exists(Paths.get(path))) {
+	                    throw e;
+	                } else {
+                        // else don't throw, everything is ok.
+                        hadJGitFalseError = true;
+                        listener.getLogger().println("[INFO] Caught a JGit issue on deleting " + path);
+	                }
+	            } else {
+	                throw e;
+	            }
+	        }
+        } while(hadJGitFalseError);
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -210,12 +210,16 @@ public class GitClientTest {
     @Test
     @Issue("43198")
     public void testCleanSubdirGitignore() throws Exception {
-        final String filename = "this_is/not_ok/more/subdirs/file.txt";
-        commitFile(".gitignore", "/this_is/not_ok\n", "set up gitignore");
-        createFile(filename, "hi there");
-        assertFileInWorkingDir(gitClient, filename);
+        final String filename1 =  "this_is/not_ok/more/subdirs/file.txt";
+        final String filename2 =  "this_is_also/not_ok_either/more/subdirs/file.txt";
+        commitFile(".gitignore", "/this_is/not_ok\n/this_is_also/not_ok_either\n", "set up gitignore");
+        createFile(filename1, "hi there");
+        createFile(filename2, "hi there");
+        assertFileInWorkingDir(gitClient, filename1);
+        assertFileInWorkingDir(gitClient, filename2);
         gitClient.clean();
         assertDirNotInWorkingDir(gitClient, "this_is");
+        assertDirNotInWorkingDir(gitClient, "this_is_also");
     }
 
     @Test


### PR DESCRIPTION
The previous fix was not ok: it could leave files or directories untouched instead of deleting them.