### PR TITLE
Add getCredentials API - credentials tracking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>git-client</artifactId>
-  <version>2.4.2-SNAPSHOT</version>
+  <version>2.5.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Jenkins Git client plugin</name>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1443,6 +1443,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     		@NonNull URIish url) throws GitException, InterruptedException {
     	return launchCommandWithCredentials(args, workDir, credentials, url, TIMEOUT);
     }
+
     private String launchCommandWithCredentials(ArgumentListBuilder args, File workDir,
                                                 StandardCredentials credentials,
                                                 @NonNull URIish url,
@@ -2372,6 +2373,16 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     public void addCredentials(String url, StandardCredentials credentials) {
         this.credentials.put(url, credentials);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<StandardCredentials> getCredentials() {
+        List<StandardCredentials> combined = new ArrayList<>(credentials.values());
+        if (defaultCredentials != null) {
+            combined.add(defaultCredentials);
+        }
+        return combined;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -69,6 +69,15 @@ public interface GitClient {
     void addCredentials(String url, StandardCredentials credentials);
 
     /**
+     * Returns credentials known to this object. If default credentials are
+     * assigned to the object, they are included in the returned list.
+     *
+     * @return credentials known to this object
+     * @since 2.5.0
+     */
+    List<StandardCredentials> getCredentials();
+
+    /**
      * Adds credentials to be used when there are not url specific credentials defined.
      *
      * @param credentials the credentials to use.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -184,6 +184,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /** {@inheritDoc} */
+    public List<StandardCredentials> getCredentials() {
+        return asSmartCredentialsProvider().getCredentials();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void addDefaultCredentials(StandardCredentials credentials) {
         asSmartCredentialsProvider().addDefaultCredentials(credentials);
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -201,6 +201,11 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     }
 
     /** {@inheritDoc} */
+    public List<StandardCredentials> getCredentials() {
+        return proxy.getCredentials();
+    }
+
+    /** {@inheritDoc} */
     public void setCredentials(StandardUsernameCredentials cred) {
         proxy.setCredentials(CredentialsProvider.snapshot(StandardUsernameCredentials.class, cred)); // credentials are Serializable
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/trilead/SmartCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/trilead/SmartCredentialsProvider.java
@@ -10,7 +10,9 @@ import org.eclipse.jgit.transport.CredentialItem;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.URIish;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -56,6 +58,20 @@ public class SmartCredentialsProvider extends CredentialsProvider {
      */
     public synchronized void addCredentials(String url, StandardCredentials credentials) {
         specificCredentials.put(url, credentials);
+    }
+
+    /**
+     * Returns credentials assigned to this provider, including both URL specific and default credentials.
+     *
+     * @return credentials assigned to this provider
+     * @since 2.5.0
+     */
+    public synchronized List<StandardCredentials> getCredentials() {
+        List<StandardCredentials> combined = new ArrayList<>(specificCredentials.values());
+        if (defaultCredentials != null) {
+            combined.add(defaultCredentials);
+        }
+        return combined;
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -334,6 +334,7 @@ public class CredentialsTest {
         } else {
             git.addCredentials(gitRepoURL, testedCredential);
         }
+        assertThat(git.getCredentials(), hasItem(testedCredential));
     }
 
     // @Test


### PR DESCRIPTION
Callers of the git client API are best suited to track credential usage.  They are currently able to add credentials and clear credentials.  This allows callers to also get the credentials so that they can pass those credentials to CredentialsProvider.track().