### PR TITLE
Added support for running "git lfs pull" in submodules.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -955,6 +955,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             String  ref                            = null;
             Map<String, String> submodBranch   = new HashMap<>();
             public Integer timeout;
+            String lfsRemote;
 
             public SubmoduleUpdateCommand recursive(boolean recursive) {
                 this.recursive = recursive;
@@ -983,6 +984,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             public SubmoduleUpdateCommand timeout(Integer timeout) {
                 this.timeout = timeout;
+                return this;
+            }
+
+            public SubmoduleUpdateCommand lfsRemote(String lfsRemote) {
+                this.lfsRemote = lfsRemote;
                 return this;
             }
 
@@ -1069,11 +1075,32 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     }
                     if (cred == null) cred = defaultCredentials;
 
+                    EnvVars env = environment;
+                    if (lfsRemote != null) {
+                        env = new EnvVars(environment);
+                        env.put("GIT_LFS_SKIP_SMUDGE", "1");
+                    }
+
                     // Find the path for this submodule
                     String sModulePath = getSubmodulePath(sModuleName);
 
                     perModuleArgs.add(sModulePath);
-                    launchCommandWithCredentials(perModuleArgs, workspace, cred, urIish, timeout);
+                    launchCommandWithCredentials(perModuleArgs, workspace, env, cred, urIish, timeout);
+                    if (lfsRemote != null) {
+                        final String url = getRemoteUrl(lfsRemote);
+                        cred = credentials.get(url);
+                        if (cred == null) cred = defaultCredentials;
+                        final File submoduleDir = new File(workspace, sModulePath);
+                        ArgumentListBuilder lfsArgs = new ArgumentListBuilder();
+                        lfsArgs.add("lfs");
+                        lfsArgs.add("pull");
+                        lfsArgs.add(lfsRemote);
+                        try {
+                            launchCommandWithCredentials(lfsArgs, submoduleDir, cred, new URIish(url), timeout);
+                        } catch (URISyntaxException e) {
+                            throw new GitException("Invalid URL " + url, e);
+                        }
+                    }
                 }
             }
         };
@@ -1513,7 +1540,16 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     		@NonNull URIish url) throws GitException, InterruptedException {
     	return launchCommandWithCredentials(args, workDir, credentials, url, TIMEOUT);
     }
+
     private String launchCommandWithCredentials(ArgumentListBuilder args, File workDir,
+                                                StandardCredentials credentials,
+                                                @NonNull URIish url,
+                                                Integer timeout) throws GitException, InterruptedException {
+        return launchCommandWithCredentials(args, workDir, environment, credentials, url, timeout);
+    }
+
+    private String launchCommandWithCredentials(ArgumentListBuilder args, File workDir,
+                                                EnvVars env,
                                                 StandardCredentials credentials,
                                                 @NonNull URIish url,
                                                 Integer timeout) throws GitException, InterruptedException {
@@ -1522,7 +1558,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         File ssh = null;
         File pass = null;
         File askpass = null;
-        EnvVars env = environment;
         try {
             if (credentials instanceof SSHUserPrivateKey) {
                 SSHUserPrivateKey sshUser = (SSHUserPrivateKey) credentials;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2054,6 +2054,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand lfsRemote(String lfsRemote) {
+                // No-op for JGit implementation
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 if (remoteTracking) {
                     listener.getLogger().println("[ERROR] JGit doesn't support remoteTracking submodules yet.");

--- a/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
@@ -58,4 +58,12 @@ public interface SubmoduleUpdateCommand extends GitCommand {
      * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
      */
     SubmoduleUpdateCommand timeout(Integer timeout);
+    
+    /**
+     * Call "git lfs pull" for the given remote after updating the submodule.
+     *
+     * @param lfsRemote name of the remote used for git lfs operations (typically "origin").
+     * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
+     */
+    SubmoduleUpdateCommand lfsRemote(String lfsRemote);
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -650,6 +650,63 @@ public class GitClientTest {
     }
 
     @Test
+    public void testCLICheckoutSubmoduleWithGitLFS() throws Exception {
+        assumeThat(gitImplName, is("git"));
+        assumeTrue(CLI_GIT_HAS_GIT_LFS);
+        String branch = "tests/getLargeFileSubmodules";
+        String remote = fetchLFSTestRepo(branch);
+        gitClient.checkout().branch(branch).ref(remote + "/" + branch).execute();
+        gitClient.submoduleInit();
+        gitClient.submoduleUpdate().lfsRemote("origin").execute();
+        assertSubmoduleStatus(gitClient, true, "large-files");
+
+        File uuidFile = new File(repoRoot + "/modules/large-files", "uuid.txt");
+        String fileContent = FileUtils.readFileToString(uuidFile, "utf-8").trim();
+        String expectedContent = "5e7733d8acc94636850cb466aec524e4";
+        assertEquals("Incorrect LFS file contents in " + uuidFile, expectedContent, fileContent);
+    }
+
+    // If LFS installed and not enabled, checkout submodule content without download
+    @Test
+    public void testCLICheckoutSubmoduleWithoutLFSWhenLFSAvailable() throws Exception {
+        assumeThat(gitImplName, is("git"));
+        assumeTrue(CLI_GIT_HAS_GIT_LFS);
+        String branch = "tests/getLargeFileSubmodules";
+        String remote = fetchLFSTestRepo(branch);
+        gitClient.checkout().branch(branch).ref(remote + "/" + branch).execute();
+        gitClient.submoduleInit();
+        gitClient.submoduleUpdate().execute();
+        assertSubmoduleStatus(gitClient, true, "large-files");
+
+        File uuidFile = new File(repoRoot + "/modules/large-files", "uuid.txt");
+        String fileContent = FileUtils.readFileToString(uuidFile, "utf-8").trim();
+        String expectedContent = "version https://git-lfs.github.com/spec/v1\n"
+                + "oid sha256:75d122e4160dc91480257ff72403e77ef276e24d7416ed2be56d4e726482d86e\n"
+                + "size 33";
+        assertEquals("Incorrect LFS file contents in " + uuidFile, expectedContent, fileContent);
+    }
+
+    // If LFS not installed and not enabled, checkout submodule content without download
+    @Test
+    public void testCLICheckoutSubmoduleWithoutLFSWhenLFSNotAvailable() throws Exception {
+        assumeThat(gitImplName, is("git"));
+        assumeFalse(CLI_GIT_HAS_GIT_LFS);
+        String branch = "tests/getLargeFileSubmodules";
+        String remote = fetchLFSTestRepo(branch);
+        gitClient.checkout().branch(branch).ref(remote + "/" + branch).execute();
+        gitClient.submoduleInit();
+        gitClient.submoduleUpdate().execute();
+        assertSubmoduleStatus(gitClient, true, "large-files");
+
+        File uuidFile = new File(repoRoot + "/modules/large-files", "uuid.txt");
+        String fileContent = FileUtils.readFileToString(uuidFile, "utf-8").trim();
+        String expectedContent = "version https://git-lfs.github.com/spec/v1\n"
+                + "oid sha256:75d122e4160dc91480257ff72403e77ef276e24d7416ed2be56d4e726482d86e\n"
+                + "size 33";
+        assertEquals("Incorrect LFS file contents in " + uuidFile, expectedContent, fileContent);
+    }
+
+    @Test
     public void testDeleteRef() throws Exception {
         assertThat(gitClient.getRefNames(""), is(empty()));
         if (gitImplName.startsWith("jgit")) {


### PR DESCRIPTION
This is a follow-up to #232 "Added simple git lfs support".

These changes add a new property called `lfsRemote` to `SubmoduleUpdateCommand`.  When `lfsRemote` is not null, Jenkins will automatically run `git lfs pull <lfsRemote>` after checking out each submodule.  I only implemented this functionality in the git CLI implementation.  I could not get JGit to work.

These changes depend on a new test branch called `tests/getLargeFileSubmodules`.  I have a copy of the branch at https://github.com/creste/git-client-plugin/tree/tests/getLargeFileSubmodules.  I'm not sure how to get that branch into this repository because it is an "orphaned" branch that doesn't share any history with existing branches in this repository.  I tried to make the branch as similar as possible to the `tests/getSubmodules` branch.  My new branch also makes https://github.com/MarkEWaite/jenkins-pipeline-utils.git a submodule because that repository has files stored using git LFS.

I added a few test cases to cover the basic operations.  I tried adding test cases for JGit to confirm that it wouldn't cause problems but I couldn't get JGit to checkout the submodule used in `tests/GetLargeFileSubmodules`.  I'm not sure if that was my fault or if it is a bug in JGit.

A separate PR for jenkinsci/git-plugin is forthcoming.