### PR TITLE
Fix workspace path regressions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1439,12 +1439,14 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * their path, otherwise they break ssh argument passing through
      * the GIT_SSH or SSH_ASKPASS environment variable.
      *
+     * Package protected for testing.  Not to be used outside this class
+     *
      * @param prefix file name prefix for the generated temporary file
      * @param suffix file name suffix for the generated temporary file
      * @return temporary file
      * @throws IOException on error
      */
-    private File createTempFile(String prefix, String suffix) throws IOException {
+    File createTempFile(String prefix, String suffix) throws IOException {
         if (workspace == null) {
             return createTempFileInSystemDir(prefix, suffix);
         }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPITempFileTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPITempFileTest.java
@@ -1,0 +1,123 @@
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.EnvVars;
+import hudson.model.TaskListener;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Test that createTempFile is adapting its directory name choices to match
+ * platform limitations of command line git.
+ *
+ * @author Mark Waite
+ */
+@RunWith(Parameterized.class)
+public class CliGitAPITempFileTest {
+
+    private final String workspaceDirName;
+    private final boolean mustUseSystemTempDir;
+    /* Should temp folder be in same parent dir as workspace? */
+
+    private static final String INVALID_CHARACTERS = "%" + (isWindows() ? " ()" : "`");
+
+    @Rule
+    public TemporaryFolder workspaceParentFolder = new TemporaryFolder();
+
+    public CliGitAPITempFileTest(String workspaceDirName, boolean mustUseSystemTempDir) {
+        this.workspaceDirName = workspaceDirName;
+        this.mustUseSystemTempDir = mustUseSystemTempDir;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection workspaceDirNames() {
+        List<Object[]> workspaceNames = new ArrayList<>();
+        for (int charIndex = 0; charIndex < INVALID_CHARACTERS.length(); charIndex++) {
+            Object[] oneWorkspace = {"use " + INVALID_CHARACTERS.charAt(charIndex) + " dir", true};
+            workspaceNames.add(oneWorkspace);
+        }
+        String[] goodNames = {
+            "$5.00",
+            "b&d",
+            "f[x]",
+            "mark@home"
+        };
+        for (String goodName : goodNames) {
+            Object[] oneWorkspace = {goodName, false};
+            workspaceNames.add(oneWorkspace);
+        }
+        String[] badNames = {
+            "50%off"
+        };
+        for (String badName : badNames) {
+            Object[] oneWorkspace = {badName, true};
+            workspaceNames.add(oneWorkspace);
+        }
+        String[] platformNames = {
+            "(abc)",
+            "abs(x)",
+            "shame's own"
+        };
+        for (String platformName : platformNames) {
+            Object[] oneWorkspace = {platformName, isWindows()};
+            workspaceNames.add(oneWorkspace);
+        }
+        return workspaceNames;
+    }
+
+    private File workspace;
+
+    @Before
+    public void createWorkspace() throws Exception {
+        workspace = workspaceParentFolder.newFolder(workspaceDirName);
+        assertTrue("'" + workspace.getAbsolutePath() + "' not a directory", workspace.isDirectory());
+        assertThat(workspace.getAbsolutePath(), containsString(workspaceDirName));
+    }
+
+    /**
+     * Check that the file path returned by CliGitAPIImpl.createTempFile
+     * contains no characters that are invalid for CLI git authentication.
+     *
+     */
+    @Test
+    @Issue("44301") // and 43931 and ...
+    public void testTempFilePathCharactersValid() throws IOException {
+        CliGitAPIImplExtension cliGit = new CliGitAPIImplExtension("git", workspace, null, null);
+        for (int charIndex = 0; charIndex < INVALID_CHARACTERS.length(); charIndex++) {
+            File tempFile = cliGit.createTempFile("pre", ".suff");
+            assertThat(tempFile.getAbsolutePath(), not(containsString("" + INVALID_CHARACTERS.charAt(charIndex))));
+            if (!mustUseSystemTempDir) {
+                File tempParent = tempFile.getParentFile();
+                File tempGrandparent = tempParent.getParentFile();
+                File workspaceParent = workspace.getParentFile();
+                assertThat("Parent dir not shared by workspace '" + workspace.getAbsolutePath() + "' and tempdir", workspaceParent, is(tempGrandparent));
+            }
+        }
+    }
+
+    /**
+     * inline ${@link hudson.Functions#isWindows()} to prevent a transient
+     * remote classloader issue
+     */
+    private static boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
+
+    private class CliGitAPIImplExtension extends CliGitAPIImpl {
+
+        public CliGitAPIImplExtension(String gitExe, File workspace, TaskListener listener, EnvVars environment) {
+            super(gitExe, workspace, listener, environment);
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -70,6 +70,7 @@ public class CredentialsTest {
     private final String fileToCheck;
     private final Boolean submodules;
     private final Boolean useParentCreds;
+    private final char specialCharacter;
 
     private GitClient git;
     private File repo;
@@ -102,6 +103,11 @@ public class CredentialsTest {
         return StreamTaskListener.fromStdout().getLogger();
     }
 
+    /* Windows refuses directory names with '*', '<', '>', '|', '?', and ':' */
+    private final String SPECIALS_TO_CHECK = "%()`$&{}[]"
+            + (isWindows() ? "" : "*<>:|?");
+    private static int specialsIndex = 0;
+
     public CredentialsTest(String gitImpl, String gitRepoUrl, String username, String password, File privateKey, String passphrase, String fileToCheck, Boolean submodules, Boolean useParentCreds) {
         this.gitImpl = gitImpl;
         this.gitRepoURL = gitRepoUrl;
@@ -112,27 +118,32 @@ public class CredentialsTest {
         this.fileToCheck = fileToCheck;
         this.submodules = submodules;
         this.useParentCreds = useParentCreds;
+        this.specialCharacter = SPECIALS_TO_CHECK.charAt(specialsIndex);
+        specialsIndex = specialsIndex + 1;
+        if (specialsIndex >= SPECIALS_TO_CHECK.length()) {
+            specialsIndex = 0;
+        }
         log().println(show("Repo", gitRepoUrl)
-                + show("implementation", gitImpl)
-                + show("username", username)
-                + show("password", password)
+                + show("spec", specialCharacter)
+                + show("impl", gitImpl)
+                + show("user", username)
+                + show("pass", password)
                 + show("key", privateKey));
     }
 
     @Before
     public void setUp() throws IOException, InterruptedException {
+        git = null;
         repo = tempFolder.newFolder();
-        if (random.nextBoolean()) {
-            /* Randomly use a repo with a space in name - JENKINS-43931 */
-            String newDirName = "a space";
-            File repoParent = repo;
-            repo = new File(repoParent, newDirName);
-            boolean dirCreated = repo.mkdirs();
-            assertTrue("Failed to create " + repo.getAbsolutePath(), dirCreated);
-            File repoTemp = new File(repoParent, newDirName + "@tmp"); // use adjacent temp directory
-            dirCreated = repoTemp.mkdirs();
-            assertTrue("Failed to create " + repoTemp.getAbsolutePath(), dirCreated);
-        }
+        /* Use a repo with a special character in name - JENKINS-43931 */
+        String newDirName = "use " + specialCharacter + " dir";
+        File repoParent = repo;
+        repo = new File(repoParent, newDirName);
+        boolean dirCreated = repo.mkdirs();
+        assertTrue("Failed to create " + repo.getAbsolutePath(), dirCreated);
+        File repoTemp = new File(repoParent, newDirName + "@tmp"); // use adjacent temp directory
+        dirCreated = repoTemp.mkdirs();
+        assertTrue("Failed to create " + repoTemp.getAbsolutePath(), dirCreated);
         Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);
         handler = new LogHandler();
         handler.setLevel(Level.ALL);
@@ -323,10 +334,7 @@ public class CredentialsTest {
             }
         }
         Collections.shuffle(repos); // randomize test order
-        int toIndex = repos.size() < 3 ? repos.size() : 3;
-        if (TEST_ALL_CREDENTIALS) {
-            toIndex = Math.min(repos.size(), 60); // Don't run more than 60 variations of test - about 9 minutes
-        }
+        int toIndex = Math.min(repos.size(), TEST_ALL_CREDENTIALS ? 90 : 6); // Don't run more than 90 variations of test - about 12 minutes
         return repos.subList(0, toIndex);
     }
 
@@ -452,6 +460,14 @@ public class CredentialsTest {
             return " " + name + ": '" + file.getPath() + "'";
         }
         return "";
+    }
+
+    private String show(String name, char value) {
+        return " " + name + ": '" + value + "'";
+    }
+
+    private boolean isWindows() {
+        return File.pathSeparatorChar == ';';
     }
 
     /* If not in a Jenkins job, then default to run all credentials tests.


### PR DESCRIPTION
The security fixes in git client plugin 2.4.4 shifted from preferring the system temporary directory (with default permissions on the files) to preferring a temporary directory adjacent to the workspace directory.  That change exposed the git client plugin credentials code (command line git, with all its complications) to the path name of the workspace, where previously the credentials code only used the path name to the system temporary directory.

This fixes the following bugs:

* [JENKINS-44041](https://issues.jenkins-ci.org/browse/JENKINS-44041) - Windows authenticated git checkout fails if '(' or ')' in path to workspace
* [JENKINS-43931](https://issues.jenkins-ci.org/browse/JENKINS-43931) - Windows authenticated git checkout fails if ' ' in path to workspace
* [JENKINS-44127](https://issues.jenkins-ci.org/browse/JENKINS-44127) - Authenticated git checkout fails if '%' in path to workspace (Windows & Linux)
* [JENKINS-44301](https://issues.jenkins-ci.org/browse/JENKINS-44301) - Authenticated git checkout fails if '%' in path to workspace (Windows & Linux) 

This has completed initial testing in my automated tests, and in my interactive tests, and will run through another 1-2 days of interactive testing before I actually release it.