### PR TITLE
Implement RECURSIVE_THEIRS merge strategy option

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -622,7 +622,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         args.add(strategy);    
                     }
                 }
-                
+
                 args.add(fastForwardMode);
                 args.add(rev.name());
                 launchCommand(args);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -575,7 +575,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 this.strategy = strategy.toString();
                 return this;
             }
-            
+
             public MergeCommand setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode fastForwardMode) {
                 this.fastForwardMode = fastForwardMode.toString();
                 return this;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -575,7 +575,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 this.strategy = strategy.toString();
                 return this;
             }
-
+            
             public MergeCommand setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode fastForwardMode) {
                 this.fastForwardMode = fastForwardMode.toString();
                 return this;
@@ -614,8 +614,15 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (strategy != null && !strategy.isEmpty() && !strategy.equals(MergeCommand.Strategy.DEFAULT.toString())) {
                     args.add("-s");
-                    args.add(strategy);
+                    if(strategy.equals(MergeCommand.Strategy.RECURSIVE_THEIRS.toString())) {
+                        args.add("recursive");
+                        args.add("--strategy-option");
+                        args.add("theirs");
+                    } else {
+                        args.add(strategy);    
+                    }
                 }
+                
                 args.add(fastForwardMode);
                 args.add(rev.name());
                 launchCommand(args);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1475,7 +1475,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         this.strategy = MergeStrategy.THEIRS;
                         return this;
                     }
-                    
+
                     listener.getLogger().println("[WARNING] JGit doesn't fully support merge strategies. This flag is ignored");
                 }
                 return this;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1471,6 +1471,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         this.strategy = MergeStrategy.SIMPLE_TWO_WAY_IN_CORE;
                         return this;
                     }
+                    if (strategy == MergeCommand.Strategy.RECURSIVE_THEIRS) {
+                        this.strategy = MergeStrategy.THEIRS;
+                        return this;
+                    }
+                    
                     listener.getLogger().println("[WARNING] JGit doesn't fully support merge strategies. This flag is ignored");
                 }
                 return this;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
@@ -35,7 +35,7 @@ public interface MergeCommand extends GitCommand {
 
     public enum Strategy {
         DEFAULT, RESOLVE, RECURSIVE, OCTOPUS, OURS, SUBTREE, RECURSIVE_THEIRS;
-        
+
         @Override
         public String toString() {
             return name().toLowerCase();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
@@ -34,8 +34,8 @@ public interface MergeCommand extends GitCommand {
     MergeCommand setStrategy(Strategy strategy);
 
     public enum Strategy {
-        DEFAULT, RESOLVE, RECURSIVE, OCTOPUS, OURS, SUBTREE;
-
+        DEFAULT, RESOLVE, RECURSIVE, OCTOPUS, OURS, SUBTREE, RECURSIVE_THEIRS;
+        
         @Override
         public String toString() {
             return name().toLowerCase();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
@@ -105,7 +105,7 @@ public class MergeCommandTest {
         assertTrue("Branch README missing on branch 1", readmeOne.exists());
         assertTrue("Master README missing on branch 1", readme.exists());
 
-        
+
         git.checkoutBranch("branch-2", "master");
         try (PrintWriter writer = new PrintWriter(readme, "UTF-8")) {
             writer.println("# Branch 2 README " + randomChar);


### PR DESCRIPTION
Hi,

as far as I know the current implementation of merge command does not support the parameter strategy-option for recursive merge strategy. I need to use recursive merge with the option theirs. Because JGit does not support the full set of features I implemented this feature as simple strategy RECURSIVE_THEIRS to support CLI and JGit implementation.  

Regards
Martin