### PR TITLE
expand setsid path detection to /usr/local

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2856,7 +2856,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         if (File.pathSeparatorChar == ';') {
             return false;
         }
-        String[] prefixes = { "/usr/bin/", "/bin/", "/usr/sbin/", "/sbin/" };
+        String[] prefixes = { "/usr/local/bin/", "/usr/bin/", "/bin/", "/usr/local/sbin/", "/usr/sbin/", "/sbin/" };
         for (String prefix : prefixes) {
             File setsidFile = new File(prefix + "setsid");
             if (setsidFile.exists()) {


### PR DESCRIPTION
Following [JENKINS-20879] and [JENKINS-25194], I needed setsid support to use a git ssh passworded key on a Mac OSX node. This PR adds /usr/local/bin and /usr/local/sbin to the search path for the setsid binary. 

Problem is OSX does not have the setsid command by default. On recent versions of OSX you can't modify system directories like /usr/bin or /bin, even as root (due to SIP/rootless). Even after finding setsid for OSX and compiling it, git-client-plugin won't find the command because it could only go in /usr/local/bin. 

For anyone here from google, this is the basic setsid I used that saved me some time:
https://github.com/jerrykuch/ersatz-setsid