### PR TITLE
Use LTS 2.60.1 for plugin compat tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
 // build both versions
-buildPlugin(jenkinsVersions: [null, '2.46.3'], failFast: false)
+buildPlugin(jenkinsVersions: [null, '2.60.1'], failFast: false)
 
 // buildPlugin(failFast: false)


### PR DESCRIPTION
Long term support release 2.60.1 arrived today.  Ready for use, ready to test.