### PR TITLE
Do not assume that local repository is a full clone

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
@@ -21,7 +21,6 @@ import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
-import org.junit.After;
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -202,12 +201,15 @@ public class LegacyCompatibleGitAPIImplTest {
 
     @Test
     @Deprecated
-    public void testGetTagsOnCommit_tag_name() throws Exception {
+    public void testGetTagsOnCommit() throws Exception {
         repo = new File(".");
         LegacyCompatibleGitAPIImpl myGit = (LegacyCompatibleGitAPIImpl) Git.with(listener, env).in(repo).using(gitImpl).getClient();
-        String revName = "git-client-1.9.1";
-        List<Tag> result = myGit.getTagsOnCommit(revName);
-        assertFalse("Tag list empty for " + revName, result.isEmpty());
+        final String uniqueTagName = "testGetTagsOnCommit-" + UUID.randomUUID().toString();
+        final String tagMessage = "Tagged with " + uniqueTagName;
+        myGit.tag(uniqueTagName, tagMessage);
+        List<Tag> result = myGit.getTagsOnCommit(uniqueTagName);
+        myGit.deleteTag(uniqueTagName);
+        assertFalse("Tag list empty for " + uniqueTagName, result.isEmpty());
         assertEquals("Unexpected SHA1 for commit: " + result.get(0).getCommitMessage(), null, result.get(0).getCommitSHA1());
         assertEquals("Unexpected message for commit: " + result.get(0).getCommitSHA1(), null, result.get(0).getCommitMessage());
     }


### PR DESCRIPTION
Many continuous integration jobs will default to cloning a subset of the
remote repository because it reduces disc use and clone time and network
traffic.  This change allows the tests to run successfully even if they
are started from a shallow clone and which includes no tags.