### PR TITLE
JENKINS-43022 - Honor git credential path exclusion and inclusion

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitURIRequirementsBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitURIRequirementsBuilderTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.gitclient;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.HostnamePortRequirement;
 import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
+import com.cloudbees.plugins.credentials.domains.PathRequirement;
 import com.cloudbees.plugins.credentials.domains.SchemeRequirement;
 import org.junit.Test;
 
@@ -25,6 +26,7 @@ public class GitURIRequirementsBuilderTest {
         SchemeRequirement scheme = firstOrNull(list, SchemeRequirement.class);
         HostnameRequirement hostname = firstOrNull(list, HostnameRequirement.class);
         HostnamePortRequirement hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        PathRequirement path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ssh"));
@@ -33,12 +35,15 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("ssh://foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ssh"));
@@ -47,36 +52,81 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("ssh://bob@foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ssh"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
         list = GitURIRequirementsBuilder.fromUri("ssh://foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ssh"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
+        list = GitURIRequirementsBuilder.fromUri("git@foo.bar.com:/path/to/repo.git/").build();
+
+        scheme = firstOrNull(list, SchemeRequirement.class);
+        hostname = firstOrNull(list, HostnameRequirement.class);
+        hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
+
+        assertThat(scheme, notNullValue());
+        assertThat(scheme.getScheme(), is("ssh"));
+        assertThat(hostname, notNullValue());
+        assertThat(hostname.getHostname(), is("foo.bar.com"));
+        assertThat(hostnamePort.getPort(), is(22));
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
+        /* Use an scp URL with relative path.
+         * Git supports this style (command line and JGit), but the
+         * PathRequirement incorrectly prefixes a slash to the front of the
+         * relative URL. Unlikely to ever change that in PathRequirement due to
+         * the many other locations likely to depend on that prefix addition.
+         */
+        list = GitURIRequirementsBuilder.fromUri("git@foo.bar.com:path/to/repo.git").build();
+
+        scheme = firstOrNull(list, SchemeRequirement.class);
+        hostname = firstOrNull(list, HostnameRequirement.class);
+        hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
+
+        assertThat(scheme, notNullValue());
+        assertThat(scheme.getScheme(), is("ssh"));
+        assertThat(hostname, notNullValue());
+        assertThat(hostname.getHostname(), is("foo.bar.com"));
+        assertThat(hostnamePort.getPort(), is(22));
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git")); // Should be "path/to/repo.git"
 
         list = GitURIRequirementsBuilder.fromUri("git://foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("git"));
@@ -85,24 +135,30 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
         list = GitURIRequirementsBuilder.fromUri("git://foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("git"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
-        list = GitURIRequirementsBuilder.fromUri("http://bob@foo.bar.com:8080/path/to/repo.git/").build();
+        list = GitURIRequirementsBuilder.fromUri("http://bob:bobpass@foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("http"));
@@ -111,12 +167,15 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("http://foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("http"));
@@ -125,36 +184,45 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("http://bob@foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("http"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("http://foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("http"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("https://bob@foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("https"));
@@ -163,12 +231,15 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("https://foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("https"));
@@ -177,36 +248,45 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("https://bob@foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("https"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("https://foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path   = firstOrNull(list,PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("https"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("ftp://bob@foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ftp"));
@@ -215,12 +295,15 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("ftp://foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ftp"));
@@ -229,36 +312,45 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("ftp://bob@foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ftp"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("ftp://foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ftp"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("ftps://bob@foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ftps"));
@@ -267,12 +359,15 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("ftps://foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ftps"));
@@ -281,48 +376,60 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(8080));
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("ftps://bob@foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ftps"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("ftps://foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ftps"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
-        
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
+
         list = GitURIRequirementsBuilder.fromUri("rsync://foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("rsync"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
         list = GitURIRequirementsBuilder.fromUri("bob@foo.bar.com:/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ssh"));
@@ -331,12 +438,15 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(22));
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
         list = GitURIRequirementsBuilder.fromUri("bob@foo.bar.com:path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ssh"));
@@ -345,12 +455,15 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(22));
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
         list = GitURIRequirementsBuilder.fromUri("foo.bar.com:/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ssh"));
@@ -359,12 +472,15 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(22));
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
         list = GitURIRequirementsBuilder.fromUri("foo.bar.com:path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("ssh"));
@@ -373,53 +489,67 @@ public class GitURIRequirementsBuilderTest {
         assertThat(hostnamePort, notNullValue());
         assertThat(hostnamePort.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort.getPort(), is(22));
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
         list = GitURIRequirementsBuilder.fromUri("path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("file"));
         assertThat(hostname, nullValue());
         assertThat(hostnamePort, nullValue());
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
         list = GitURIRequirementsBuilder.fromUri("/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("file"));
         assertThat(hostname, nullValue());
         assertThat(hostnamePort, nullValue());
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
         list = GitURIRequirementsBuilder.fromUri("file:/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("file"));
         assertThat(hostname, nullValue());
         assertThat(hostnamePort, nullValue());
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
         list = GitURIRequirementsBuilder.fromUri("file://path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
         hostnamePort = firstOrNull(list, HostnamePortRequirement.class);
+        path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
         assertThat(scheme.getScheme(), is("file"));
         assertThat(hostname, nullValue());
         assertThat(hostnamePort, nullValue());
+        assertThat(path, notNullValue());
+        assertThat(path.getPath(), is("/path/to/repo.git/"));
 
     }
-    
+
     <T> T firstOrNull(List<? super T> list, Class<T> type) {
         for (Object i: list) {
             if (type.isInstance(i))


### PR DESCRIPTION
Tests scp URL form in GitURIRequirementsBuilderTest

Adds assertions for path.getPath(), including incorrect relative scp path.

Credentials PathRequirement incorrectly converts relative path to
absolute path.  Adapt the test to that error, since PathRequirement
is likely used in many other cases where the prefixing of a '/' to the
relative path is the expected and desired behavior.

Passed my interactive testing, and automated tests on multiple platforms.

Replaces #242