### PR TITLE
[JENKINS-45729] fix getRepository() to work with symref git files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -31,7 +31,7 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.lib.RepositoryBuilder;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
@@ -2516,11 +2516,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     @NonNull
     public Repository getRepository() throws GitException {
         try {
-            return FileRepositoryBuilder.create(new File(workspace, Constants.DOT_GIT));
+            return new RepositoryBuilder().setWorkTree(workspace).build();
         } catch (IOException e) {
-            throw new GitException("Failed to open Git repository " + workspace, e);
+            throw new GitException(e);
         }
     }
+
 
     /**
      * getWorkTree.


### PR DESCRIPTION
The current implementation of getRepository() fails to work if the
repository directory in question has a .git file (known as a symref)
which points to the real directory. This causes problems if you try to
directly open a submodule or worktree repository using the git client.

This happens because FileRepositoryBuilder.create() uses .setGitDir() to
set the git directory which expects only a proper git directory path.
Instead, set the worktree and have the RepositoryBuilder figure out
where the git directory is.

This implementation is identical to the JGit implementation, which is
a nice bonus.

Add additional tests for both CliGit and JGit which verify that a git
client can open a repository object properly for repositories
with .git symrefs.

Without this fix, the git plugin will fail to fetch and checkout
revisions of a working copy which use .git symref file to point to
its git meta directory, because it uses the withRepository in
order to obtain the git commit subject.