### PR TITLE
[JENKINS-45771] Ensure all command boolean options can be toggled, not just set once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>git-client</artifactId>
-  <version>2.4.7-SNAPSHOT</version>
+  <version>2.5.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Jenkins Git client plugin</name>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -438,7 +438,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public CloneCommand shared(boolean shared) {
-                this.shared = true;
+                this.shared = shared;
                 return this;
             }
 
@@ -2369,6 +2369,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 this.all = all;
                 return this;
             }
+            
             public RevListCommand firstParent() {
                 return firstParent(true);
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -433,12 +433,22 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             public CloneCommand shared() {
+                return shared(true);
+            }
+
+            @Override
+            public CloneCommand shared(boolean shared) {
                 this.shared = true;
                 return this;
             }
 
             public CloneCommand shallow() {
-                this.shallow = true;
+                return shallow(true);
+            }
+
+            @Override
+            public CloneCommand shallow(boolean shallow) {
+                this.shallow = shallow;
                 return this;
             }
 
@@ -1945,7 +1955,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             public PushCommand force() {
-                this.force = true;
+                return force(true);
+            }
+
+            @Override
+            public PushCommand force(boolean force) {
+                this.force = force;
                 return this;
             }
 
@@ -2346,12 +2361,21 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public List<ObjectId> out;
 
             public RevListCommand all() {
-                this.all = true;
-                return this;
+                return all(true);
             }
 
+            @Override
+            public RevListCommand all(boolean all) {
+                this.all = all;
+                return this;
+            }
             public RevListCommand firstParent() {
-                this.firstParent = true;
+                return firstParent(true);
+            }
+
+            @Override
+            public RevListCommand firstParent(boolean firstParent) {
+                this.firstParent = firstParent;
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -296,7 +296,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             public FetchCommand prune() {
-                this.prune = true;
+                return prune(true);
+            }
+
+            public FetchCommand prune(boolean prune) {
+                this.prune = prune;
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
@@ -32,16 +32,40 @@ public interface CloneCommand extends GitCommand {
      * shallow clone is controlled by the #depth method.
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
+     * @deprecated favour {@link #shallow(boolean)}
      */
+    @Deprecated
     CloneCommand shallow();
+
+    /**
+     * Only clone the most recent history, not preceding history.  Depth of the
+     * shallow clone is controlled by the #depth method.
+     *
+     * @param shallow boolean controlling whether the clone is shallow
+     * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
+     * @since 2.5.0
+     */
+    CloneCommand shallow(boolean shallow);
 
     /**
      * When the repository to clone is on the local machine, instead of using hard links, automatically setup
      * .git/objects/info/alternates to share the objects with the source repository
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
+     * @deprecated favour {@link #shared(boolean)}
      */
+    @Deprecated
     CloneCommand shared();
+
+    /**
+     * When the repository to clone is on the local machine, instead of using hard links, automatically setup
+     * .git/objects/info/alternates to share the objects with the source repository
+     *
+     * @param shared boolean controlling whether the clone is shared
+     * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
+     * @since 2.5.0
+     */
+    CloneCommand shared(boolean shared);
 
     /**
      * reference.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
@@ -25,8 +25,19 @@ public interface FetchCommand extends GitCommand {
      * prune.
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.FetchCommand} object.
+     * @deprecated favour {@link #prune(boolean)}
      */
+    @Deprecated
     FetchCommand prune();
+
+    /**
+     * prune.
+     *
+     * @param prune {@code true} if the fetch should prune.
+     * @return a {@link org.jenkinsci.plugins.gitclient.FetchCommand} object.
+     * @since 2.5.0
+     */
+    FetchCommand prune(boolean prune);
 
     /**
      * shallow.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -541,7 +541,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             public org.jenkinsci.plugins.gitclient.FetchCommand prune() {
-                shouldPrune = true;
+                return prune(true);
+            }
+
+            @Override
+            public org.jenkinsci.plugins.gitclient.FetchCommand prune(boolean prune) {
+                shouldPrune = prune;
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1324,7 +1324,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public CloneCommand shared(boolean shared) {
-                this.shared = true;
+                this.shared = shared;
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1307,11 +1307,23 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             public CloneCommand shallow() {
-                listener.getLogger().println("[WARNING] JGit doesn't support shallow clone. This flag is ignored");
+                return shallow(true);
+            }
+
+            @Override
+            public CloneCommand shallow(boolean shallow) {
+                if (shallow) {
+                    listener.getLogger().println("[WARNING] JGit doesn't support shallow clone. This flag is ignored");
+                }
                 return this;
             }
 
             public CloneCommand shared() {
+                return shared(true);
+            }
+
+            @Override
+            public CloneCommand shared(boolean shared) {
                 this.shared = true;
                 return this;
             }
@@ -1755,7 +1767,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             public PushCommand force() {
-                this.force = true;
+                return force(true);
+            }
+
+            @Override
+            public PushCommand force(boolean force) {
+                this.force = force;
                 return this;
             }
 
@@ -1858,12 +1875,22 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public List<ObjectId> out;
 
             public RevListCommand all() {
-                this.all = true;
+                return all(true);
+            }
+
+            @Override
+            public RevListCommand all(boolean all) {
+                this.all = all;
                 return this;
             }
 
             public RevListCommand firstParent() {
-                this.firstParent = true;
+                return firstParent(true);
+            }
+
+            @Override
+            public RevListCommand firstParent(boolean firstParent) {
+                this.firstParent = firstParent;
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/PushCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/PushCommand.java
@@ -32,8 +32,19 @@ public interface PushCommand extends GitCommand {
      * force.
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.PushCommand} object.
+     * @deprecated favour {@link #force(boolean)}
      */
+    @Deprecated
     PushCommand force();
+
+    /**
+     * force.
+     *
+     * @param force {@code true} if the push should be forced
+     * @return a {@link org.jenkinsci.plugins.gitclient.PushCommand} object.
+     * @since 2.5.0
+     */
+    PushCommand force(boolean force);
 
     /**
      * tags.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RevListCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RevListCommand.java
@@ -13,15 +13,37 @@ public interface RevListCommand extends GitCommand {
      * all.
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.RevListCommand} object.
+     * @deprecated favour {@link #all(boolean)}
      */
+    @Deprecated
     RevListCommand all();
+
+    /**
+     * all.
+     *
+     * @param all {@code true} to list all.
+     * @return a {@link org.jenkinsci.plugins.gitclient.RevListCommand} object.
+     * @since 2.5.0
+     */
+    RevListCommand all(boolean all);
 
     /**
      * firstParent.
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.RevListCommand} object.
+     * @deprecated favour {@link #firstParent(boolean)}
      */
+    @Deprecated
     RevListCommand firstParent();
+
+    /**
+     * firstParent.
+     *
+     * @param firstParent {@code true} to list first parent
+     * @return a {@link org.jenkinsci.plugins.gitclient.RevListCommand} object.
+     * @since 2.5.0
+     */
+    RevListCommand firstParent(boolean firstParent);
 
     /**
      * to.


### PR DESCRIPTION
Precursor to [JENKINS-45771](https://issues.jenkins-ci.org/browse/JENKINS-45771), we need the ability
to turn off shallow if another extension has turned it on.

@reviewbybees