### PR TITLE
Code coverage from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
-    <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
     <jgit.version>4.5.3.201708160445-r</jgit.version>
@@ -181,37 +180,6 @@
           <source>1.7</source>
           <target>1.7</target>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${jacoco-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>default-prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-report</id>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-check</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <rule>
-                </rule>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2417,7 +2417,7 @@ public abstract class GitAPITestCase extends TestCase {
 
         /* Confirm first checkout */
         String pomContent = w.contentOf("pom.xml");
-        assertTrue("Missing jacoco ref in master pom : " + pomContent, pomContent.contains("jacoco"));
+        assertTrue("Missing inceptionYear ref in master pom : " + pomContent, pomContent.contains("inceptionYear"));
         assertFalse("Found untracked file", w.file("untracked-file").exists());
 
         /* Modify the pom file by adding a comment */
@@ -2439,9 +2439,9 @@ public abstract class GitAPITestCase extends TestCase {
         }
         cmd.execute();
 
-        /* Tracked file should not contain added comment, nor the jacoco reference */
+        /* Tracked file should not contain added comment, nor the inceptionYear reference */
         pomContent = w.contentOf("pom.xml");
-        assertFalse("Found jacoco ref in 1.4.x pom : " + pomContent, pomContent.contains("jacoco"));
+        assertFalse("Found inceptionYear ref in 1.4.x pom : " + pomContent, pomContent.contains("inceptionYear"));
         assertFalse("Found comment in 1.4.x pom", pomContent.contains(comment));
         assertTrue("Missing untracked file", w.file("untracked-file").exists());
     }


### PR DESCRIPTION
Use the maven `enable-jacoco` profile as provided by the parent pom.  Since the parent pom already provides code coverage settings, there is no reason to duplicate those settings in the plugin

@reviewbybees 