### PR TITLE
Use jgit 4.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
-    <jgit.version>4.5.2.201704071617-r</jgit.version>
+    <jgit.version>4.5.3.201708160445-r</jgit.version>
     <jgit.javadoc.version>4.5.0.201609210915-r</jgit.javadoc.version>
   </properties>
 


### PR DESCRIPTION
Fix exception handling for opening bitmap index files.

Unlikely to be detected in common Jenkins usage, but better to run the
current released version for those cases where it might be found.

See https://projects.eclipse.org/projects/technology.jgit/releases/4.5.3

@reviewbybees 