### PR TITLE
Narrow branch name matching test for fewer collisions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -3376,7 +3376,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals("heads is " + heads, heads.get("refs/heads/master"), master1);
         ObjectId getSubmodules1 = w.git.getHeadRev(localMirror(), "X/g*[b]m*dul*"); // matches tests/getSubmodules
         assertEquals("heads is " + heads, heads.get("refs/heads/tests/getSubmodules"), getSubmodules1);
-        ObjectId getSubmodules = w.git.getHeadRev(localMirror(), "N/*od*");
+        ObjectId getSubmodules = w.git.getHeadRev(localMirror(), "N/*et*mod*");
         assertEquals("heads is " + heads, heads.get("refs/heads/tests/getSubmodules"), getSubmodules);
     }
 


### PR DESCRIPTION
The previous test started failing when I submitted a pull request
from a branch that contained the letters "od".  That's too common
a character sequence to fail a test.

Ultimately this needs a better way of testing than using a local
mirror.  The local mirror creates a useful and interesting history,
but the same types of useful and interesting history could be
placed into a sample repository, or could be created by the test,
without the ongoing risk of a newly created branch causing a test
failure due to pattern matching.