### PR TITLE
Update parent pom and structs dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.9</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
* Update parent pom from 2.32 to 2.33
* Update structs dependency from 1.9 to 1.10 to match git plugin and reduce risk of transitive dependency problems for other git client consumers

@reviewbybees 