### PR TITLE
commons-codec is provided by jenkins-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.32</version>
+    <version>2.33</version>
+    <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -133,12 +134,12 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.2</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.10</version>
-      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>


### PR DESCRIPTION
I found that `workflow-job`, with a `test`-scoped dep on `git`, had `requireUpperBoundDeps` violations whereby `git-client` was asking for a newer version of `commons-codec` than `jenkins-core` actually bundled.

Since the dep was `provided`, it was not being bundled in `git-client.hpi` anyway (and even if it were, without `pluginFirstClassLoader` it would be ignored).

@reviewbybees