### PR TITLE
Revert "Use jgit 4.5.3" - test JENKINS-39832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
-    <jgit.version>4.5.3.201708160445-r</jgit.version>
+    <jgit.version>4.5.2.201704071617-r</jgit.version>
     <jgit.javadoc.version>4.5.0.201609210915-r</jgit.javadoc.version>
   </properties>
 


### PR DESCRIPTION
JENKINS-39832 may be visible again due to the update to JGit 4.5.3.
This revert is a test which will be used in the staging environment
to confirm (or refute) that the change from JGit 4.5.2 to JGit 4.5.3
introduces "missing object exception" reports.

This reverts commit 4de8bb5a5e77e94e422828798d0bbb218a7840cc.