### PR TITLE
Use jgit 4.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
-    <jgit.version>4.5.2.201704071617-r</jgit.version>
+    <jgit.version>4.5.3.201708160445-r</jgit.version>
     <jgit.javadoc.version>4.5.0.201609210915-r</jgit.javadoc.version>
   </properties>
 


### PR DESCRIPTION
Testing for [JENKINS-39832](https://issues.jenkins-ci.org/browse/JENKINS-39832) showed that the JGit change was unrelated to the missing object exception.

This reverts commit c90b3f32be6bb6921be634fbaee6ef74084e3bdb.