### PR TITLE
Assert exception if no changelog destination specified

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1138,6 +1138,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
              */
             @Override
             public void execute() throws GitException, InterruptedException {
+                if (out == null) {
+                    throw new IllegalStateException(); // Match CliGitAPIImpl
+                }
                 try (PrintWriter pw = new PrintWriter(out,false)) {
                     RawFormatter formatter= new RawFormatter();
                     if (!hasIncludedRev) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -44,6 +44,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -90,6 +91,9 @@ public class GitClientTest {
     private final boolean CLI_GIT_SUPPORTS_SUBMODULE_DEINIT;
     private final boolean CLI_GIT_SUPPORTS_SUBMODULE_RENAME;
     private final boolean CLI_GIT_SUPPORTS_SYMREF;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -308,6 +312,24 @@ public class GitClientTest {
             assertThat(ge.getMessage(), containsString(missingSHA1));
             assertThat(ge.getMessage(), containsString(" in " + repoRoot.getAbsolutePath()));
         }
+    }
+
+    @Test
+    public void testNullChangelogDestinationIncludes() throws Exception {
+        final ObjectId commitA = commitOneFile();
+        ChangelogCommand changelog = gitClient.changelog();
+        changelog.includes(commitA);
+        thrown.expect(IllegalStateException.class);
+        changelog.execute();
+    }
+
+    @Test
+    public void testNullChangelogDestinationExcludes() throws Exception {
+        final ObjectId commitA = commitOneFile();
+        ChangelogCommand changelog = gitClient.changelog();
+        changelog.excludes(commitA);
+        thrown.expect(IllegalStateException.class);
+        changelog.execute();
     }
 
     @Test


### PR DESCRIPTION
Previously the changelog through a different exception in JGit than in CliGit.  This includes a test for that exception, and makes JGit match CliGit.