### PR TITLE
Protect against ArrayIndexOutOfBoundsException (related to JENKINS-34309)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2049,7 +2049,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 // Split fields into branch name, SHA1, and rest of line
                 // Fields are separated by one or more spaces
                 String[] branchVerboseOutput = line.substring(2).split(" +", 3);
-                if (branchVerboseOutput[1].length() == 40) {
+                if (branchVerboseOutput.length > 1 && branchVerboseOutput[1].length() == 40) {
                     branches.add(new Branch(branchVerboseOutput[0], ObjectId.fromString(branchVerboseOutput[1])));
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2029,7 +2029,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @param fos output of "git branch -v --no-abbrev"
      * @return a {@link java.util.Set} object.
      */
-    private Set<Branch> parseBranches(String fos) {
+    /*package*/ Set<Branch> parseBranches(String fos) {
+        // JENKINS-34309 if the commit message contains line breaks,
+        // "git branch -v --no-abbrev" output will include CR (Carriage Return) characters.
+        // Replace all CR characters to avoid interpreting them as line endings
+        fos = fos.replaceAll("\\r", "");
+
         Set<Branch> branches = new HashSet<>();
         BufferedReader rdr = new BufferedReader(new StringReader(fos));
         String line;
@@ -2039,9 +2044,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     // Line must contain 2 leading characters, branch
                     // name (at least 1 character), a space, and 40
                     // character SHA1.
-                    // JENKINS-34309 found cases where a Ctrl-M was
-                    // inserted into the output of
-                    // "git branch -v --no-abbrev"
                     continue;
                 }
                 // Ignore leading 2 characters (marker for current branch)

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -1,9 +1,12 @@
 package org.jenkinsci.plugins.gitclient;
 
+import hudson.plugins.git.Branch;
+import org.apache.commons.lang.SystemUtils;
+
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import org.apache.commons.lang.SystemUtils;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -282,6 +285,18 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         }
 
         assertTrue("ssh.exe not found", w.cgit().getSSHExecutable().exists());
+    }
+
+    public void test_git_branch_with_line_breaks_and_long_strings() throws Exception {
+        String gitBranchOutput =
+                "* (HEAD detached at b297853)  b297853e667d5989801937beea30fcec7d1d2595 Commit message with line breaks\r very-long-string-with-more-than-44-characters\n" +
+                "  remotes/origin/master       e0d3f46c4fdb8acd068b6b127356931411d16e23 Commit message with line breaks\r very-long-string-with-more-than-44-characters and some more text\n" +
+                "  remotes/origin/develop      fc8996efc1066d9dae529e5187800f84995ca56f Single-line commit message\n";
+
+        setTimeoutVisibleInCurrentTest(false);
+        CliGitAPIImpl git = new CliGitAPIImpl("git", new File("."), listener, env);
+        Set<Branch> branches = git.parseBranches(gitBranchOutput);
+        assertTrue("\"git branch -a -v --no-abbrev\" output correctly parsed", branches.size() == 2);
     }
 
     @Override


### PR DESCRIPTION
If `git branch -v --no-abbrev` output contains a line like " very-long-string-with-more-than-44-characters\n", it will bypass the first `if` condition of the `while` block and will end up being split. However, since it will only contain 1 token (as there are no spaces after applying `substring(2)`), accessing `branchVerboseOutput[1]` results in ArrayIndexOutOfBoundsException. This fix is to avoid such exception and pre-validate the array size (should be greater than 1 in order to contain, at least, the branch name and the SHA1).