### PR TITLE
Log reference repo path improvements

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -538,7 +538,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                             File alternates = new File(workspace, ".git/objects/info/alternates");
                             try (PrintWriter w = new PrintWriter(alternates, Charset.defaultCharset().toString())) {
                                 String absoluteReference = objectsPath.getAbsolutePath().replace('\\', '/');
-                                listener.getLogger().println("Link to the reference repository " + absoluteReference);
+                                listener.getLogger().println("Using reference repository: " + reference);
                                 // git implementations on windows also use
                                 w.print(absoluteReference);
                             } catch (UnsupportedEncodingException ex) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1424,7 +1424,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                                 try {
                                     File alternates = new File(workspace, ".git/objects/info/alternates");
                                     String absoluteReference = objectsPath.getAbsolutePath().replace('\\', '/');
-                                    listener.getLogger().println("Link to the reference repository " + absoluteReference);
+                                    listener.getLogger().println("Using reference repository: " + reference);
                                     // git implementations on windows also use
                                     try (PrintWriter w = new PrintWriter(alternates, "UTF-8")) {
                                         // git implementations on windows also use

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -359,7 +359,7 @@ public class CredentialsTest {
         }
     }
 
-    @Test
+    // @Test
     public void testFetchWithCredentials() throws URISyntaxException, GitException, InterruptedException, MalformedURLException, IOException {
         File clonedFile = new File(repo, fileToCheck);
         String origin = "origin";
@@ -395,19 +395,18 @@ public class CredentialsTest {
         checkExpectedLogSubstring();
     }
 
-    // @Test
+    @Test
     public void testCloneWithCredentials() throws URISyntaxException, GitException, InterruptedException, MalformedURLException, IOException {
         File clonedFile = new File(repo, fileToCheck);
         String origin = "origin";
         List<RefSpec> refSpecs = new ArrayList<>();
         refSpecs.add(new RefSpec("+refs/heads/master:refs/remotes/" + origin + "/master"));
         addCredential(username, password, privateKey);
-        CloneCommand cmd = git.clone_().url(gitRepoURL).repositoryName(origin).refspecs(refSpecs);
+        CloneCommand cmd = git.clone_().url(gitRepoURL).repositoryName(origin).refspecs(refSpecs).reference(CURR_DIR.getAbsolutePath());
         if (gitImpl.equals("git")) {
             // Reduce network transfer
-            // Use a reference repository, JGit does not support reference repositories
             // Use shallow clone, JGit does not support shallow clone
-            cmd.shallow().depth(1).reference(CURR_DIR.getAbsolutePath());
+            cmd.shallow().depth(1);
         }
         cmd.execute();
         ObjectId master = git.getHeadRev(gitRepoURL, "master");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -159,6 +159,7 @@ public class CredentialsTest {
             addExpectedLogSubstring("> git fetch ");
             addExpectedLogSubstring("> git checkout -b master ");
         }
+         addExpectedLogSubstring("Using reference repository: ");
 
         assertTrue("Bad username, password, privateKey combo: '" + username + "', '" + password + "'",
                 (password == null || password.isEmpty()) ^ (privateKey == null || !privateKey.exists()));
@@ -171,13 +172,6 @@ public class CredentialsTest {
         assertThat(testedCredential, notNullValue());
         Fingerprint fingerprint = CredentialsProvider.getFingerprintOf(testedCredential);
         assertThat("Fingerprint should not be set", fingerprint, nullValue());
-
-        /* FetchWithCredentials does not log expected message */
-        /*
-         if (gitImpl.equals("jgit")) {
-         addExpectedLogSubstring("remote: Counting objects");
-         }
-         */
     }
 
     @After

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -601,6 +601,9 @@ public abstract class GitAPITestCase extends TestCase {
         assertBranchesExist(w.git.getBranches(), "master");
         assertAlternateFilePointsToLocalMirror();
         assertNoObjectsInRepository();
+        // Verify JENKINS-46737 expected log message is written
+        String messages = StringUtils.join(handler.getMessages(), ";");
+        assertTrue("Reference repo not logged in: " + messages, handler.containsMessageSubstring("Using reference repository: "));
     }
 
     private void assertNoObjectsInRepository() {


### PR DESCRIPTION
Add a test for reference repo path, and use a reference repo in the credentials tests for both CliGit and JGit.

Switch the credentials test to use CloneCommand rather than FetchCommand, since CloneCommand is the more commonly used and provides reference repository support which FetchCommand does not directly support reference repositories.