### PR TITLE
[JENKINS-47373] Set git configuration to avoid test failures.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -245,6 +245,8 @@ public abstract class GitAPITestCase extends TestCase {
 
         WorkingArea init() throws IOException, InterruptedException {
             git.init();
+            git.setAuthor("root", "root@mydomain.com");
+            git.setCommitter("root", "root@domain.com");
             return this;
         }
 


### PR DESCRIPTION
[JENKINS-47373](https://issues.jenkins-ci.org/browse/JENKINS-47373)

If tests are executed without setting local/global git configuration (i.e. neither .git/config either ~/.gitconfig correctly set), tests in class org.jenkinsci.plugins.gitclient.JGitApacheAPIImplTest fail. That configuration should be set before executing the test. (See JIRA for more details)

@reviewbybees specially @MarkEWaite 