### PR TITLE
Include the results of the command in the log when it fails

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1967,7 +1967,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             String result = fos.toString(Charset.defaultCharset().toString());
             if (status != 0) {
-                throw new GitException("Command \""+command+"\" returned status code " + status + ":\nstdout: " + result + "\nstderr: "+ err.toString(Charset.defaultCharset().toString()));
+                String message = "Command \"" + command + "\" returned status code " + status + ":\nstdout: " + result + "\nstderr: " + err.toString(Charset.defaultCharset().toString());
+                listener.getLogger().println(message);
+                throw new GitException(message);
             }
 
             return result;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -377,6 +377,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 warnIfWindowsTemporaryDirNameHasSpaces();
 
+                //TODO: Catch and log here?
                 launchCommandWithCredentials(args, workspace, cred, url, timeout);
             }
         };
@@ -411,6 +412,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
         StandardCredentials cred = credentials.get(url);
         if (cred == null) cred = defaultCredentials;
+        //TODO: Catch and log here?
         launchCommandWithCredentials(args, workspace, cred, url);
     }
 
@@ -669,6 +671,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 args.add(fastForwardMode);
                 args.add(rev.name());
+                //TODO: Catch and log here?
                 launchCommand(args);
             }
         };
@@ -2286,6 +2289,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         }
                     }
                 } catch (GitException e) {
+                    //TODO: Log here?
                     if (Pattern.compile("index\\.lock").matcher(e.getMessage()).find()) {
                         throw new GitLockFailedException("Could not lock repository. Please try again", e);
                     } else {
@@ -2850,6 +2854,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         try {
             launchCommand("merge", refSpec);
         } catch (GitException e) {
+            //TODO: Log here?
             throw new GitException("Could not merge " + refSpec, e);
         }
     }


### PR DESCRIPTION
Proposed fix for JENKINS-47493.

Having the error in the exception is nice assuming someone can figure out where the exception renders, but most views of stage logs in Jenkins don't include the exception result at all. This patch causes it to log the stdout/stderr and status code to the log for the stage, so that it can be seen inline when it occurs.