### PR TITLE
use --no-walk when merely checking if a revision exists

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1898,6 +1898,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     {
         return new RevListCommand() {
             public boolean all;
+            public boolean nowalk;
             public boolean firstParent;
             public String refspec;
             public List<ObjectId> out;
@@ -1909,6 +1910,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @Override
             public RevListCommand all(boolean all) {
                 this.all = all;
+                return this;
+            }
+
+            public RevListCommand nowalk(boolean nowalk) {
+                this.nowalk = nowalk;
                 return this;
             }
 
@@ -1940,6 +1946,19 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 try (Repository repo = getRepository();
                      ObjectReader or = repo.newObjectReader();
                      RevWalk walk = new RevWalk(or)) {
+
+                    if (nowalk) {
+                        RevCommit c = walk.parseCommit(repo.resolve(refspec));
+                        out.add(c.copy());
+
+                        if (all) {
+                            for (Ref r : repo.getAllRefs().values()) {
+                                c = walk.parseCommit(r.getObjectId());
+                                out.add(c.copy());
+                            }
+                        }
+                        return;
+                    }
 
                     if (all)
                     {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RevListCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RevListCommand.java
@@ -28,6 +28,14 @@ public interface RevListCommand extends GitCommand {
     RevListCommand all(boolean all);
 
     /**
+     * nowalk.
+     *
+     * @param nowalk {@code true} to skip revision walk.
+     * @return a {@link org.jenkinsci.plugins.gitclient.RevListCommand} object.
+     */
+    RevListCommand nowalk(boolean nowalk);
+
+    /**
      * firstParent.
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.RevListCommand} object.

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -91,6 +91,7 @@ public class GitClientTest {
     private final boolean CLI_GIT_SUPPORTS_SUBMODULE_DEINIT;
     private final boolean CLI_GIT_SUPPORTS_SUBMODULE_RENAME;
     private final boolean CLI_GIT_SUPPORTS_SYMREF;
+    private final boolean CLI_GIT_SUPPORTS_REV_LIST_NO_WALK;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -114,6 +115,7 @@ public class GitClientTest {
         CLI_GIT_SUPPORTS_SUBMODULE_DEINIT = cliGitClient.isAtLeastVersion(1, 9, 0, 0);
         CLI_GIT_SUPPORTS_SUBMODULE_RENAME = cliGitClient.isAtLeastVersion(1, 9, 0, 0);
         CLI_GIT_SUPPORTS_SYMREF = cliGitClient.isAtLeastVersion(2, 8, 0, 0);
+        CLI_GIT_SUPPORTS_REV_LIST_NO_WALK = cliGitClient.isAtLeastVersion(1, 5, 3, 0);
 
         boolean gitLFSExists;
         try {
@@ -923,6 +925,23 @@ public class GitClientTest {
         List<ObjectId> resultB = new ArrayList<>();
         gitClient.revList_().to(resultB).reference("master").execute();
         assertThat(resultB, contains(commitB, commitA));
+    }
+
+    @Test
+    public void testRevListNoWalk() throws Exception {
+        assumeTrue(CLI_GIT_SUPPORTS_REV_LIST_NO_WALK);
+        ObjectId commitA = commitOneFile();
+        List<ObjectId> resultA = new ArrayList<>();
+        gitClient.revList_().to(resultA).reference(commitA.name()).nowalk(true).execute();
+        assertThat(resultA, contains(commitA));
+        assertEquals(resultA.size(), 1);
+
+        /* Make sure it's correct when there's more than one commit in the history */
+        ObjectId commitB = commitOneFile();
+        List<ObjectId> resultB = new ArrayList<>();
+        gitClient.revList_().to(resultB).reference(commitB.name()).nowalk(true).execute();
+        assertThat(resultB, contains(commitB));
+        assertEquals(resultB.size(), 1);
     }
 
     // @Test


### PR DESCRIPTION
When implementing isCommitInRepo() for the CLI git implementation we use
git rev-list, assuming that if this command fails then the commit
doesn't exist in the repository. This is technically correct.

However, git rev-list actually performs a complete revision walk, which
for large repositories can take a long time. For example, on the Linux
repository, git rev-list HEAD took around 30 seconds. This is entirely
due to the command producing an entire list of all revisions leading
back to the beginning of history.

But isCommitInRepo() doesn't even care about that! We can significantly
reduce the cost of this function in a number of ways. One, we could
re-implement this using various other git commands, such as git
cat-file. Or, we could ask rev-list not to actually walk the revisions.
This was added in git 1.5.3 (~2007).

Local testing found there to be minimal difference in "git cat-file -t
<id>" vs "git rev-list --no-walk <id>". Since the latter is mostly
already implemented, add support for "--no-walk" to the
RevListCommand.

This allows us to modify isCommitInRepo() to use the RevList_()
directly, and pass .nowalk(true) in order to avoid the unnecessary
revision walk.

For completeness, also implement the equivalent support in JGit. To do
so, simply use parseCommit() of the refspec provided to the command. If
all was set to true, we'll search all refs and include those as well.

Ultimately, this enables the command line implementation of the
gitClient to have a significantly faster test for whether a commit is in
a repository.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>