### PR TITLE
Fix submodule url regex [JENKINS-46054]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -141,8 +141,24 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     private StandardCredentials defaultCredentials;
     private StandardCredentials lfsCredentials;
 
+    /* git config --get-regex applies the regex to match keys, and returns all matches (including substring matches).
+     * Thus, a config call:
+     *   git config -f .gitmodules --get-regexp "^submodule\.([^ ]+)\.url"
+     * will report two lines of output if the submodule URL includes ".url":
+     *   submodule.modules/JENKINS-46504.url.path modules/JENKINS-46504.url
+     *   submodule.modules/JENKINS-46504.url.url https://github.com/MarkEWaite/JENKINS-46054.url
+     * The code originally used the same pattern for get-regexp and for output parsing.
+     * By using the same pattern in both places, it incorrectly took the first line
+     * of output as the URL of a submodule (when it is instead the path of a submodule).
+    */
+    private final static String SUBMODULE_REMOTE_PATTERN_CONFIG_KEY = "^submodule\\.([^ ]+)\\.url";
+
+    /* See comments for SUBMODULE_REMOTE_PATTERN_CONFIG_KEY to explain why this
+     * regular expression string adds the trailing space character as part of its match.
+     * Without the trailing whitespace character in the pattern, too many matches are found.
+     */
     /* Package protected for testing */
-    final static String SUBMODULE_REMOTE_PATTERN_STRING = "^submodule\\.(.*)\\.url";
+    final static String SUBMODULE_REMOTE_PATTERN_STRING = SUBMODULE_REMOTE_PATTERN_CONFIG_KEY + "\\b\\s";
 
     private void warnIfWindowsTemporaryDirNameHasSpaces() {
         if (!isWindows()) {
@@ -1092,7 +1108,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 try {
                     // We might fail if we have no modules, so catch this
                     // exception and just return.
-                    cfgOutput = launchCommand("config", "-f", ".gitmodules", "--get-regexp", SUBMODULE_REMOTE_PATTERN_STRING);
+                    cfgOutput = launchCommand("config", "-f", ".gitmodules", "--get-regexp", SUBMODULE_REMOTE_PATTERN_CONFIG_KEY);
                 } catch (GitException e) {
                     listener.error("No submodules found.");
                     return;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -141,6 +141,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     private StandardCredentials defaultCredentials;
     private StandardCredentials lfsCredentials;
 
+    /* Package protected for testing */
+    final static String SUBMODULE_REMOTE_PATTERN_STRING = "^submodule\\.(.*)\\.url";
+
     private void warnIfWindowsTemporaryDirNameHasSpaces() {
         if (!isWindows()) {
             return;
@@ -1089,7 +1092,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 try {
                     // We might fail if we have no modules, so catch this
                     // exception and just return.
-                    cfgOutput = launchCommand("config", "-f", ".gitmodules", "--get-regexp", "^submodule\\.(.*)\\.url");
+                    cfgOutput = launchCommand("config", "-f", ".gitmodules", "--get-regexp", SUBMODULE_REMOTE_PATTERN_STRING);
                 } catch (GitException e) {
                     listener.error("No submodules found.");
                     return;
@@ -1098,7 +1101,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 // Use a matcher to find each configured submodule name, and
                 // then run the submodule update command with the provided
                 // path.
-                Pattern pattern = Pattern.compile("^submodule\\.(.*)\\.url", Pattern.MULTILINE);
+                Pattern pattern = Pattern.compile(SUBMODULE_REMOTE_PATTERN_STRING, Pattern.MULTILINE);
                 Matcher matcher = pattern.matcher(cfgOutput);
                 while (matcher.find()) {
                     ArgumentListBuilder perModuleArgs = args.clone();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/SubmodulePatternStringTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/SubmodulePatternStringTest.java
@@ -1,0 +1,110 @@
+package org.jenkinsci.plugins.gitclient;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+public class SubmodulePatternStringTest {
+
+    private Pattern submoduleConfigPattern;
+    private String remoteName = "simple-name";
+
+    @Before
+    public void configure() {
+        // String patternString = "^submodule\\.([^ ]+)\\.url ";
+        String patternString = CliGitAPIImpl.SUBMODULE_REMOTE_PATTERN_STRING;
+        submoduleConfigPattern = Pattern.compile(patternString, Pattern.MULTILINE);
+    }
+
+    @Issue("46054")
+    @Test
+    public void urlEmbeddedInRepoURL() {
+        String repoUrl = "file://gitroot/thirdparty.url.repo.git";
+        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
+        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
+        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
+        assertThat(matcher.group(1), is(remoteName));
+    }
+
+    @Issue("46054")
+    @Test
+    public void urlEmbeddedInRepoURLsubmoduleEmbeddedDot() {
+        String repoUrl = "https://mark.url:some%20pass.urlify@gitroot/repo.git";
+        remoteName = "simple.name";
+        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
+        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
+        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
+        assertThat(matcher.group(1), is(remoteName));
+    }
+
+    @Issue("46054")
+    @Test
+    public void urlEmbeddedInSubmoduleRepoNameEndsWithURL() {
+        String repoUrl = "https://gitroot/repo.url";
+        remoteName = "simple.name";
+        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
+        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
+        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
+        assertThat(matcher.group(1), is(remoteName));
+    }
+
+    @Issue("46054")
+    @Test
+    public void urlEmbeddedInSubmoduleRepoNameEndsWithURLSpace() {
+        String repoUrl = "https://gitroot/repo.url ";
+        remoteName = "simple.name";
+        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
+        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
+        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
+        assertThat(matcher.group(1), is(remoteName));
+    }
+
+    @Issue("46054")
+    @Test
+    public void urlEmbeddedInSubmoduleNameAndRepoNameEndsWithURL() {
+        String repoUrl = "https://gitroot/repo.url.git";
+        remoteName = "simple.name.url";
+        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
+        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
+        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
+        assertThat(matcher.group(1), is(remoteName));
+    }
+
+    @Issue("46054")
+    @Test
+    public void urlExploratoryTestFailureCase() {
+        /* See https://github.com/MarkEWaite/JENKINS-46054.url/ */
+        String repoUrl = "https://github.com/MarkEWaite/JENKINS-46054.url";
+        remoteName = "modules/JENKINS-46504.url";
+        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
+        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
+        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
+        assertThat(matcher.group(1), is(remoteName));
+    }
+
+    @Issue("46054")
+    @Test
+    public void remoteNameIncludesSubmodule() {
+        /* See https://github.com/MarkEWaite/JENKINS-46054.url/ */
+        String repoUrl = "https://github.com/MarkEWaite/JENKINS-46054.url";
+        remoteName = "submodule.JENKINS-46504.url";
+        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
+        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
+        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
+        assertThat(matcher.group(1), is(remoteName));
+    }
+
+    @Issue("46054")
+    @Test
+    public void urlEmbeddedInRepoNameEndsWithURLEmptyRemoteName() {
+        String repoUrl = "https://github.com/MarkEWaite/JENKINS-46054.url.git";
+        remoteName = "";
+        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
+        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
+        assertFalse("Unexpected match found for '" + submoduleConfigOutput + "'", matcher.find());
+    }
+}


### PR DESCRIPTION
[JENKINS-46054](https://issues.jenkins-ci.org/browse/JENKINS-46054) reports that submodules whose URL includes the text `.url` cannot be cloned or updated into a Jenkins workspace.

The `git config` output parsing regular expression incorrectly extended across a space character when a space character is not valid in the name of a git remote.

This pair of changes writes tests for the problem and fixes the problem.