### PR TITLE
Fixes issue with submodules url not found when starting  from fresh workspace clones

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1181,7 +1181,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * Get submodule URL
      */
     public @CheckForNull String getSubmoduleUrl(String name) throws GitException, InterruptedException {
-        String result = launchCommand( "config", "--get", "submodule."+name+".url" );
+        String result = launchCommand( "config", "-f", ".gitmodules", "--get", "submodule."+name+".url" );
         return StringUtils.trim(firstLine(result));
     }
 
@@ -1191,7 +1191,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * Set submodule URL
      */
     public void setSubmoduleUrl(String name, String url) throws GitException, InterruptedException {
-        launchCommand( "config", "submodule."+name+".url", url );
+        launchCommand( "config", "-f", ".gitmodules", "submodule."+name+".url", url );
     }
 
     /**


### PR DESCRIPTION
Since `getSubmodulePath` uses `-f .gitmodules` we should probably do the same on `getSubmoduleUrl`. This resolves the issue listed here https://issues.jenkins-ci.org/browse/JENKINS-38860

I'm not a java dev, or a Jenkins dev so this PR is provided AS IS and changes "Works for me".