### PR TITLE
[JENKINS-30589] Get remote references consistent return in all implementations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2807,7 +2807,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         Map<String, ObjectId> references = new HashMap<>();
         String[] lines = result.split("\n");
         for (String line : lines) {
-            if (line.length() < 41) throw new GitException("unexpected ls-remote output " + line);
+            if (line.length() < 41) {
+                continue; // throw new GitException("unexpected ls-remote output " + line);
+            }
             String refName = line.substring(41);
             ObjectId refObjectId = ObjectId.fromString(line.substring(0, 40));
             if (refName.startsWith("refs/tags") && refName.endsWith("^{}")) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -864,6 +865,27 @@ public class GitClientTest {
         Map<String, ObjectId> expResult = null; // Working here
         Map<String, ObjectId> result = gitClient.getRemoteReferences(url, pattern, headsOnly, tagsOnly);
         assertEquals(expResult, result);
+    }
+
+    @Issue("JENKINS-30589")
+    @Test
+    public void testGetRemoteReferences_ReturnsEmptyMapIfNoTags() throws Exception {
+        String url = repoRoot.getAbsolutePath();
+        String pattern = "**";
+        boolean headsOnly = false;
+        boolean tagsOnly = true;
+        Map<String, ObjectId> result = gitClient.getRemoteReferences(url, pattern, headsOnly, tagsOnly);
+        assertThat(result, is(Collections.EMPTY_MAP));
+    }
+
+    @Test
+    public void testGetRemoteReferencesNonExistingPattern() throws Exception {
+        String url = repoRoot.getAbsolutePath();
+        String pattern = "non-existent-name";
+        boolean headsOnly = false;
+        boolean tagsOnly = false;
+        Map<String, ObjectId> result = gitClient.getRemoteReferences(url, pattern, headsOnly, tagsOnly);
+        assertThat(result, is(Collections.EMPTY_MAP));
     }
 
     @Test


### PR DESCRIPTION
[JENKINS-30589](https://issues.jenkins-ci.org/browse/JENKINS-30589) reports that the CliGitAPIImpl.getRemoteReferences throws a GitException if there are no matching remote references when the documentation says it should return an empty Map.

The first commit shows the failure in CliGitAPIImpl, and confirms that JGitAPIImpl behaves correctly (as defined in the javadoc for the GitClient.getRemoteReferences method).

The second commit fixes the CliGitAPIImpl implementation to not throw the exception.

The exception was originally placed in CliGitAPIImpl to diagnose unexpected content in the output of `git ls-remote`.  I believe there were cases when a line break control character was being returned in the output and that was causing the simple line break based parsing to fail.  Now, instead of failing immediately with an exception on those surprises, the surprising line will be ignored and the rest of the lines in the output will be parsed.