### PR TITLE
[JENKINS-45447] Add GitClient.getTags()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>2.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-server</artifactId>
       <version>1.7</version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>git-client</artifactId>
-  <version>2.6.1-SNAPSHOT</version>
+  <version>2.7.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Jenkins Git client plugin</name>

--- a/src/main/java/hudson/plugins/git/Branch.java
+++ b/src/main/java/hudson/plugins/git/Branch.java
@@ -1,6 +1,5 @@
 package hudson.plugins.git;
 
-import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 
@@ -37,7 +36,8 @@ public class Branch extends GitObject {
      * Returns branch name and SHA1 hash.
      * @return branch name and SHA1 hash
      */
-    public @Override String toString() {
-        return "Branch " + name + "(" + sha1 + ")";
+    @Override
+    public String toString() {
+        return "Branch " + name + "(" + getSHA1String() + ")";
     }
 }

--- a/src/main/java/hudson/plugins/git/Branch.java
+++ b/src/main/java/hudson/plugins/git/Branch.java
@@ -42,11 +42,26 @@ public class Branch extends GitObject {
         return "Branch " + name + "(" + getSHA1String() + ")";
     }
 
+    /**
+     * Returns a hash code value for the object. Considers sha1 and name in the
+     * calculation.
+     *
+     * @return a hash code value for this object.
+     */
     @Override
     public int hashCode() {
         return super.hashCode();
     }
 
+    /**
+     * Indicates whether some other object is "equal to" this one. Includes sha1
+     * and name in the comparison. Objects of subclasses of this object are not
+     * equal to objects of this class, even if they add no fields.
+     *
+     * @param obj the reference object with which to compare.
+     * @return true if this object is the same as the obj argument; false
+     * otherwise
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/src/main/java/hudson/plugins/git/Branch.java
+++ b/src/main/java/hudson/plugins/git/Branch.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git;
 
+import java.util.Objects;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 
@@ -39,5 +40,26 @@ public class Branch extends GitObject {
     @Override
     public String toString() {
         return "Branch " + name + "(" + getSHA1String() + ")";
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Branch other = (Branch) obj;
+        return Objects.equals(this.name, other.name)
+                && Objects.equals(this.sha1, other.sha1);
     }
 }

--- a/src/main/java/hudson/plugins/git/GitObject.java
+++ b/src/main/java/hudson/plugins/git/GitObject.java
@@ -5,6 +5,7 @@ import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * An object in a git repository. Includes the SHA1 and name of the
@@ -15,8 +16,8 @@ public class GitObject implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    ObjectId sha1;
-    String name;
+    final ObjectId sha1;
+    final String name;
 
     /**
      * Constructor for GitObject, a named SHA1 (tag, branch, etc.).
@@ -56,5 +57,44 @@ public class GitObject implements Serializable {
     @Exported(name="SHA1")
     public String getSHA1String() {
         return sha1 != null ? sha1.name() : null;
+    }
+
+    /**
+     * Returns a hash code value for the object. Considers sha1 and name in the
+     * calculation.
+     *
+     * @return a hash code value for this object.
+     */
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 97 * hash + Objects.hashCode(this.sha1);
+        hash = 97 * hash + Objects.hashCode(this.name);
+        return hash;
+    }
+
+    /**
+     * Indicates whether some other object is "equal to" this one. Includes sha1
+     * and name in the comparison. Objects of subclasses of this object are not
+     * equal to objects of this class, even if they add no fields.
+     *
+     * @param obj the reference object with which to compare.
+     * @return true if this object is the same as the obj argument; false
+     * otherwise
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final GitObject other = (GitObject) obj;
+        return Objects.equals(this.name, other.name)
+                && Objects.equals(this.sha1, other.sha1);
     }
 }

--- a/src/main/java/hudson/plugins/git/Tag.java
+++ b/src/main/java/hudson/plugins/git/Tag.java
@@ -59,11 +59,26 @@ public class Tag extends GitObject {
         this.commitSHA1 = commitSHA1;
     }
 
+    /**
+     * Returns a hash code value for the object. Considers sha1 and name in the
+     * calculation.
+     *
+     * @return a hash code value for this object.
+     */
     @Override
     public int hashCode() {
         return super.hashCode();
     }
 
+    /**
+     * Indicates whether some other object is "equal to" this one. Includes sha1
+     * and name in the comparison. Objects of subclasses of this object are not
+     * equal to objects of this class, even if they add no fields.
+     *
+     * @param obj the reference object with which to compare.
+     * @return true if this object is the same as the obj argument; false
+     * otherwise
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/src/main/java/hudson/plugins/git/Tag.java
+++ b/src/main/java/hudson/plugins/git/Tag.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git;
 
+import java.util.Objects;
 import org.eclipse.jgit.lib.ObjectId;
 
 /**
@@ -56,5 +57,26 @@ public class Tag extends GitObject {
      */
     public void setCommitSHA1(String commitSHA1) {
         this.commitSHA1 = commitSHA1;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Tag other = (Tag) obj;
+        return Objects.equals(this.name, other.name)
+                && Objects.equals(this.sha1, other.sha1);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -19,6 +19,7 @@ import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitLockFailedException;
+import hudson.plugins.git.GitObject;
 import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
@@ -2994,5 +2995,57 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
         }
         return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<GitObject> getTags() throws GitException, InterruptedException {
+        ArgumentListBuilder args = new ArgumentListBuilder("show-ref", "--tags", "-d");
+        String result;
+        try {
+            result = launchCommandIn(args, workspace);
+        } catch (GitException ge) {
+            /* If no tags, then git show-ref --tags -d returns non-zero */
+            result = "";
+        }
+
+        /*
+        Output shows SHA1 and tag with (optional) marker for annotated tags
+        7ac27f7a051e1017da9f7c45ade8f091dbe6f99d refs/tags/git-3.6.4
+        7b5856ef2b4d35530a06d6482d0f4e972769d89b refs/tags/git-3.6.4^{}
+         */
+        String[] output = result.split("[\\n\\r]");
+        if (output.length == 0 || (output.length == 1 && output[0].isEmpty())) {
+            return new HashSet<>();
+        }
+        Pattern pattern = Pattern.compile("(\\p{XDigit}{40})\\s+refs/tags/([^\\^]*)(\\^\\{\\})?");
+        Map<String, ObjectId> tagMap = new HashMap<>();
+        for (String line : output) {
+            Matcher matcher = pattern.matcher(line);
+            if (!matcher.find()) {
+                // Log the surprise and skip the line
+                String message = MessageFormat.format(
+                        "git show-ref --tags -d output not matched in line: {0}",
+                        line);
+                listener.getLogger().println(message);
+                continue;
+            }
+            String sha1String = matcher.group(1);
+            String tagName = matcher.group(2);
+            String trailingText = matcher.group(3);
+            boolean isPeeledRef = false;
+            if (trailingText != null && trailingText.equals("^{}")) { // Line ends with '^{}'
+                isPeeledRef = true;
+            }
+            /* Prefer peeled ref if available (for tag commit), otherwise take first tag reference seen */
+            if (isPeeledRef || !tagMap.containsKey(tagName)) {
+                tagMap.put(tagName, ObjectId.fromString(sha1String));
+            }
+        }
+        Set<GitObject> tags = new HashSet<>(tagMap.size());
+        for (Map.Entry<String, ObjectId> entry : tagMap.entrySet()) {
+            tags.add(new GitObject(entry.getKey(), entry.getValue()));
+        }
+        return tags;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -3014,11 +3014,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         7ac27f7a051e1017da9f7c45ade8f091dbe6f99d refs/tags/git-3.6.4
         7b5856ef2b4d35530a06d6482d0f4e972769d89b refs/tags/git-3.6.4^{}
          */
-        String[] output = result.split("[\\n\\r]");
+        String[] output = result.split("[\\n\\r]+");
         if (output.length == 0 || (output.length == 1 && output[0].isEmpty())) {
-            return new HashSet<>();
+            return Collections.EMPTY_SET;
         }
-        Pattern pattern = Pattern.compile("(\\p{XDigit}{40})\\s+refs/tags/([^\\^]*)(\\^\\{\\})?");
+        Pattern pattern = Pattern.compile("(\\p{XDigit}{40})\\s+refs/tags/([^^]+)(\\^\\{\\})?");
         Map<String, ObjectId> tagMap = new HashMap<>();
         for (String line : output) {
             Matcher matcher = pattern.matcher(line);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -946,4 +946,13 @@ public interface GitClient {
      * @throws java.lang.InterruptedException on thread interruption
      */
     List<Branch> getBranchesContaining(String revspec, boolean allBranches) throws GitException, InterruptedException;
+
+    /**
+     * Return name and object ID of all tags in current repository.
+     *
+     * @return set of tags in current repository
+     * @throws hudson.plugins.git.GitException on Git exceptions
+     * @throws java.lang.InterruptedException on thread interruption
+     */
+    Set<GitObject> getTags() throws GitException, InterruptedException;
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -10,11 +10,11 @@ import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitObject;
 import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.Tag;
-import hudson.remoting.Callable;
 import hudson.remoting.Channel;
 import hudson.remoting.RemoteOutputStream;
 import hudson.remoting.RemoteWriter;
@@ -879,5 +879,11 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     public List<Branch> getBranchesContaining(String revspec, boolean allBranches)
             throws GitException, InterruptedException {
         return getGitAPI().getBranchesContaining(revspec, allBranches);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<GitObject> getTags() throws GitException, InterruptedException {
+        return proxy.getTags();
     }
 }

--- a/src/test/java/hudson/plugins/git/BranchTest.java
+++ b/src/test/java/hudson/plugins/git/BranchTest.java
@@ -1,0 +1,64 @@
+package hudson.plugins.git;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectIdRef;
+import org.eclipse.jgit.lib.Ref;
+
+import org.junit.Test;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class BranchTest {
+
+    private final String branchSHA1;
+    private final String branchName;
+    private final ObjectId branchHead;
+    private final Branch branch;
+    private final String refPrefix;
+    private final Ref branchRef;
+    private final Branch branchFromRef;
+
+    public BranchTest() {
+        this.branchSHA1 = "fa71f704f9b90fa1f857d1623f3fe33fa2277ca9";
+        this.branchName = "origin/master";
+        this.branchHead = ObjectId.fromString(branchSHA1);
+        this.refPrefix = "refs/remotes/";
+        this.branchRef = new ObjectIdRef.PeeledNonTag(Ref.Storage.NEW, refPrefix + branchName, branchHead);
+        this.branch = new Branch(branchName, branchHead);
+        this.branchFromRef = new Branch(branchRef);
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(branch.toString(), is(branchFromRef.toString()));
+    }
+
+    @Test
+    public void testToString_Contents() {
+        String expected = "Branch " + branchName + "(" + branchSHA1 + ")";
+        assertThat(branch.toString(), is(expected));
+    }
+
+    @Test
+    public void hashCodeContract() {
+        assertThat(branch, is(branchFromRef));
+        assertThat(branch.hashCode(), is(branchFromRef.hashCode()));
+    }
+
+    @Test
+    public void constructorRefArgStripped() {
+        Ref ref = new ObjectIdRef.PeeledNonTag(Ref.Storage.LOOSE, refPrefix + branchName, branchHead);
+        Branch strippedBranch = new Branch(ref);
+        assertThat(strippedBranch.getName(), is(branchName));
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(Branch.class)
+                .usingGetClass()
+                .withRedefinedSuperclass()
+                .verify();
+    }
+}

--- a/src/test/java/hudson/plugins/git/GitObjectTest.java
+++ b/src/test/java/hudson/plugins/git/GitObjectTest.java
@@ -9,6 +9,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import static org.junit.Assert.*;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 @RunWith(Parameterized.class)
 public class GitObjectTest {
 
@@ -54,5 +56,13 @@ public class GitObjectTest {
     @Test
     public void testGetSHA1String() {
         assertEquals(sha1String, gitObject.getSHA1String());
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(GitObject.class)
+                .usingGetClass()
+                .withRedefinedSubclass(Tag.class)
+                .verify();
     }
 }

--- a/src/test/java/hudson/plugins/git/TagTest.java
+++ b/src/test/java/hudson/plugins/git/TagTest.java
@@ -5,6 +5,8 @@ import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 public class TagTest {
     private final String tagName = "git-client-1.8.1";
     private final String tagSHA1String = "3725b67f3daa6621dd01356c96c08a1f85b90c61";
@@ -40,4 +42,12 @@ public class TagTest {
         assertEquals(mySHA1, tag.getCommitSHA1());
     }
 
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(Tag.class)
+                .withIgnoredFields("commitSHA1", "commitMessage")
+                .usingGetClass()
+                .withRedefinedSuperclass()
+                .verify();
+    }
 }


### PR DESCRIPTION
[JENKINS-45447](https://issues.jenkins-ci.org/browse/JENKINS-45447) reports that checkout of a freestyle  job with a wildcard in the branch name (and many other cases which invoke a more advanced branch selection mechanism) with many tags in the repository is dramatically slower than earlier releases.

[31fedce9c](https://github.com/jenkinsci/git-plugin/commit/31fedce9c41c9006c886835e03c9fe825d49aba6) commit added tag checks to the evaluation loop for branch names.  Unfortunately, tag evaluation needs both the tag name and the SHA1 of the commit identified by the tag.  The implementation used revParse() to compute that SHA1.  With many tags in the repository (bug report example was 60,000 tags), the checkout time was significant.

I found that even the number of tags in the git plugin repository could add as much as 5 seconds for the computation of SHA1 hashes which were then discarded very soon after the evaluation.

This commit adds a GitClient.getTags() method which collects all tag/SHA1 pairs in the current repository using a single git call.  That removes the per-call overhead for many rev-parse calls and is hoped to be sufficient to dramatically improve performance.  The git plugin will call that new method instead of calling GitClient.getTagNames() and then calling GitClient.revParse() for each tag name.

This pull request also makes the fields of the GitObject final.  They were previously package protected and could only be assigned through the constructor.

This pull request also adds an equals() and hashCode() method to GitObject, Tag, and Branch objects so that they can be used in a Set without inserting objects into the set which are identified as different objects, even though they have the same SHA1 and same name.

@reviewbybees 