### PR TITLE
Use `git clean -ffdx` for git>=2.3.3

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -779,7 +779,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     public void clean() throws GitException, InterruptedException {
         reset(true);
-        launchCommand("clean", "-fdx");
+        launchCommand("clean", "-ffdx");
     }
 
     /** {@inheritDoc} */
@@ -1190,7 +1190,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     	if (recursive) {
             args.add("--recursive");
     	}
-    	args.add("git clean -fdx");
+    	args.add("git clean -ffdx");
 
     	launchCommand(args);
     }


### PR DESCRIPTION
This PR add the second -f to make sure the clean checkout has the same effect for git version before and after 2.3.3.

[git-clean 2.3.3 doc](https://git-scm.com/docs/git-clean/2.3.3):

> Git will refuse to delete directories with .git sub directory or file unless a second -f is given. This affects also git submodules where the storage area of the removed submodule under .git/modules/ is not removed until -f is given twice.