### PR TITLE
Fix JENKINS-48818 and keep JENKINS-46054 fixed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -144,22 +144,27 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /* git config --get-regex applies the regex to match keys, and returns all matches (including substring matches).
      * Thus, a config call:
-     *   git config -f .gitmodules --get-regexp "^submodule\.([^ ]+)\.url"
+     *   git config -f .gitmodules --get-regexp "^submodule\.(.+)\.url"
      * will report two lines of output if the submodule URL includes ".url":
      *   submodule.modules/JENKINS-46504.url.path modules/JENKINS-46504.url
      *   submodule.modules/JENKINS-46504.url.url https://github.com/MarkEWaite/JENKINS-46054.url
      * The code originally used the same pattern for get-regexp and for output parsing.
-     * By using the same pattern in both places, it incorrectly took the first line
-     * of output as the URL of a submodule (when it is instead the path of a submodule).
+     * By using the same pattern in both places, it incorrectly took some substrings
+     * as the submodule remote name, instead of taking the longest match.
+     * See SubmodulePatternStringTest for test cases.
     */
-    private final static String SUBMODULE_REMOTE_PATTERN_CONFIG_KEY = "^submodule\\.([^ ]+)\\.url";
+    private final static String SUBMODULE_REMOTE_PATTERN_CONFIG_KEY = "^submodule\\.(.+)\\.url";
 
-    /* See comments for SUBMODULE_REMOTE_PATTERN_CONFIG_KEY to explain why this
-     * regular expression string adds the trailing space character as part of its match.
-     * Without the trailing whitespace character in the pattern, too many matches are found.
+    /* See comments for SUBMODULE_REMOTE_PATTERN_CONFIG_KEY to explain
+     * why this regular expression string adds the trailing space
+     * characters and the sequence of non-space characters as part of
+     * its match.  The ending sequence of non-white-space characters
+     * is the repository URL in the output of the 'git config' command.
+     * Relies on repository URL not containing a whitespace character,
+     * per RFC1738.
      */
     /* Package protected for testing */
-    final static String SUBMODULE_REMOTE_PATTERN_STRING = SUBMODULE_REMOTE_PATTERN_CONFIG_KEY + "\\b\\s";
+    final static String SUBMODULE_REMOTE_PATTERN_STRING = SUBMODULE_REMOTE_PATTERN_CONFIG_KEY + "\\s+[^\\s]+$";
 
     private void warnIfWindowsTemporaryDirNameHasSpaces() {
         if (!isWindows()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -41,7 +41,6 @@ import org.eclipse.jgit.lib.Constants;
 
 import static org.hamcrest.Matchers.*;
 import org.junit.AfterClass;
-import org.junit.Ignore;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 import org.junit.Before;
@@ -1442,7 +1441,6 @@ public class GitClientTest {
 
     @Issue("JENKINS-46054")
     @Test
-    @Ignore
     public void testSubmoduleUrlEndsWithDotUrl() throws Exception {
         // Create a new repository that includes ".url" in directory name
         File baseDir = tempFolder.newFolder();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -41,6 +41,7 @@ import org.eclipse.jgit.lib.Constants;
 
 import static org.hamcrest.Matchers.*;
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 import org.junit.Before;
@@ -1441,6 +1442,7 @@ public class GitClientTest {
 
     @Issue("JENKINS-46054")
     @Test
+    @Ignore
     public void testSubmoduleUrlEndsWithDotUrl() throws Exception {
         // Create a new repository that includes ".url" in directory name
         File baseDir = tempFolder.newFolder();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/SubmodulePatternStringTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/SubmodulePatternStringTest.java
@@ -1,110 +1,81 @@
 package org.jenkinsci.plugins.gitclient;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.Issue;
 
+@RunWith(Parameterized.class)
 public class SubmodulePatternStringTest {
 
-    private Pattern submoduleConfigPattern;
-    private String remoteName = "simple-name";
+    private final String remoteName;
+    private final String submoduleConfigOutput;
+    private final Matcher matcher;
 
-    @Before
-    public void configure() {
-        // String patternString = "^submodule\\.([^ ]+)\\.url ";
-        String patternString = CliGitAPIImpl.SUBMODULE_REMOTE_PATTERN_STRING;
-        submoduleConfigPattern = Pattern.compile(patternString, Pattern.MULTILINE);
+    private static final Pattern SUBMODULE_CONFIG_PATTERN = Pattern.compile(CliGitAPIImpl.SUBMODULE_REMOTE_PATTERN_STRING, Pattern.MULTILINE);
+
+    public SubmodulePatternStringTest(String repoUrl, String remoteName)
+    {
+        this.remoteName = remoteName;
+        this.submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
+        this.matcher = SUBMODULE_CONFIG_PATTERN.matcher(submoduleConfigOutput);
+    }
+
+    /*
+     * Permutations of repository URLs and remote names with various
+     * protocols and remote names, permuted with various suffixes.
+     *
+     * Tests file, ssh (both forms), git, and https.
+     */
+    @Parameterized.Parameters(name = "{0}-{1}")
+    public static Collection repoAndRemote() {
+        List<Object[]> arguments = new ArrayList<>();
+        String[] repoUrls = {
+            "file://gitroot/thirdparty.url.repo",
+            "git://gitroot/repo",
+            "git@github.com:jenkinsci/JENKINS-46054",
+            "https://github.com/MarkEWaite/JENKINS-46054",
+            "https://mark.url:some%20pass.urlify@gitroot/repo",
+            "ssh://git.example.com/MarkEWaite/JENKINS-46054",
+        };
+        String[] remoteNames = {
+            "has space",
+            "has.url space",
+            "simple",
+            "simple.name",
+            "simple.url.name",
+        };
+        String [] suffixes = {
+            "",
+            ".git",
+            ".url",
+            ".url.git",
+        };
+        for (String repoUrlParam : repoUrls) {
+            for (String repoUrlSuffix : suffixes) {
+                for (String remoteNameParam : remoteNames) {
+                    for (String remoteNameSuffix : suffixes) {
+                        Object[] item = {repoUrlParam + repoUrlSuffix, remoteNameParam + remoteNameSuffix};
+                        arguments.add(item);
+                    }
+                }
+            }
+        }
+        return arguments;
     }
 
     @Issue("JENKINS-46054")
     @Test
-    public void urlEmbeddedInRepoURL() {
-        String repoUrl = "file://gitroot/thirdparty.url.repo.git";
-        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
-        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
+    public void urlFoundInSubmoduleConfigOutput() {
         assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
         assertThat(matcher.group(1), is(remoteName));
-    }
-
-    @Issue("JENKINS-46054")
-    @Test
-    public void urlEmbeddedInRepoURLsubmoduleEmbeddedDot() {
-        String repoUrl = "https://mark.url:some%20pass.urlify@gitroot/repo.git";
-        remoteName = "simple.name";
-        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
-        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
-        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
-        assertThat(matcher.group(1), is(remoteName));
-    }
-
-    @Issue("JENKINS-46054")
-    @Test
-    public void urlEmbeddedInSubmoduleRepoNameEndsWithURL() {
-        String repoUrl = "https://gitroot/repo.url";
-        remoteName = "simple.name";
-        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
-        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
-        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
-        assertThat(matcher.group(1), is(remoteName));
-    }
-
-    @Issue("JENKINS-46054")
-    @Test
-    public void urlEmbeddedInSubmoduleRepoNameEndsWithURLSpace() {
-        String repoUrl = "https://gitroot/repo.url ";
-        remoteName = "simple.name";
-        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
-        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
-        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
-        assertThat(matcher.group(1), is(remoteName));
-    }
-
-    @Issue("JENKINS-46054")
-    @Test
-    public void urlEmbeddedInSubmoduleNameAndRepoNameEndsWithURL() {
-        String repoUrl = "https://gitroot/repo.url.git";
-        remoteName = "simple.name.url";
-        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
-        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
-        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
-        assertThat(matcher.group(1), is(remoteName));
-    }
-
-    @Issue("JENKINS-46054")
-    @Test
-    public void urlExploratoryTestFailureCase() {
-        /* See https://github.com/MarkEWaite/JENKINS-46054.url/ */
-        String repoUrl = "https://github.com/MarkEWaite/JENKINS-46054.url";
-        remoteName = "modules/JENKINS-46504.url";
-        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
-        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
-        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
-        assertThat(matcher.group(1), is(remoteName));
-    }
-
-    @Issue("JENKINS-46054")
-    @Test
-    public void remoteNameIncludesSubmodule() {
-        /* See https://github.com/MarkEWaite/JENKINS-46054.url/ */
-        String repoUrl = "https://github.com/MarkEWaite/JENKINS-46054.url";
-        remoteName = "submodule.JENKINS-46504.url";
-        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
-        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
-        assertTrue("Match not found for '" + submoduleConfigOutput + "'", matcher.find());
-        assertThat(matcher.group(1), is(remoteName));
-    }
-
-    @Issue("JENKINS-46054")
-    @Test
-    public void urlEmbeddedInRepoNameEndsWithURLEmptyRemoteName() {
-        String repoUrl = "https://github.com/MarkEWaite/JENKINS-46054.url.git";
-        remoteName = "";
-        String submoduleConfigOutput = "submodule." + remoteName + ".url " + repoUrl;
-        Matcher matcher = submoduleConfigPattern.matcher(submoduleConfigOutput);
-        assertFalse("Unexpected match found for '" + submoduleConfigOutput + "'", matcher.find());
     }
 }


### PR DESCRIPTION
The initial fix for [JENKINS-46054](https://issues.jenkins-ci.org/browse/JENKINS-46054) - update fails if submodule remote name ends with '.url'. introduced [JENKINS-48818](https://issues.jenkins-ci.org/browse/JENKINS-48818), a more serious regression than the bug it fixed.  Submodule update now fails with remote names which contain a whitespace character.  In git client 3.6.4 and prior, submodule update worked, even with a remote name which contained a space character.

This change adds more tests and resolves the regression introduced in git client 3.7.0.  It was verified interactively with the [JENKINS-48818 test job](https://github.com/MarkEWaite/jenkins-bugs/blob/JENKINS-48818/Jenkinsfile) and the [JENKINS-46054 test job](https://github.com/MarkEWaite/jenkins-bugs/blob/JENKINS-46054/Jenkinsfile).  It is verified with automated unit tests in SubmodulePatternTest and with a functional test in GitClientTest.

@reviewbybees 