### PR TITLE
Setting GIT_SSH_VARIANT=ssh to environment, solves [JENKINS-49111]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1652,6 +1652,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 env = new EnvVars(env);
                 env.put("GIT_SSH", ssh.getAbsolutePath());
+                env.put("GIT_SSH_VARIANT", "ssh");
                 env.put("SSH_ASKPASS", pass.getAbsolutePath());
 
                 // supply a dummy value for DISPLAY if not already present


### PR DESCRIPTION
Supports git client >= 2.16