### PR TITLE
Avoid refering to now deprecated MasterComputer.localChannel to avoid loading classes over remoting

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
@@ -1,11 +1,10 @@
 package org.jenkinsci.plugins.gitclient;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.FilePath;
 import hudson.ProxyConfiguration;
 import hudson.plugins.git.GitException;
 import hudson.remoting.Channel;
-import jenkins.model.Jenkins.MasterComputer;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
@@ -26,7 +25,7 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
     /** {@inheritDoc} */
     public <T> T withRepository(RepositoryCallback<T> callable) throws IOException, InterruptedException {
         try (Repository repo = getRepository()) {
-            return callable.invoke(repo, MasterComputer.localChannel);
+            return callable.invoke(repo, FilePath.localChannel);
         }
     }
 


### PR DESCRIPTION
Investigating one another `java.lang.NoClassDefFoundError: Could not initialize class jenkins.model.Jenkins$MasterComputer` exceptions, I come across we do not have to load the class at all - if fact https://github.com/jenkinsci/jenkins/commit/0b27f364f99ec98cb616d4f0cfc0858ecf339852 discourage users from doing so.