### PR TITLE
Add dryRun to push command

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2041,6 +2041,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public boolean force;
             public boolean tags;
             public Integer timeout;
+            public boolean dryRun;
 
             public PushCommand to(URIish remote) {
                 this.remote = remote;
@@ -2072,6 +2073,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public PushCommand dryRun(boolean dryRun) {
+                this.dryRun = dryRun;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 ArgumentListBuilder args = new ArgumentListBuilder();
                 args.add("push", remote.toPrivateASCIIString());
@@ -2086,6 +2092,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (tags) {
                     args.add("--tags");
+                }
+
+                if (dryRun) {
+                    args.add("--dry-run");
                 }
 
                 if (!isAtLeastVersion(1,9,0,0) && isShallowRepository()) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2306,6 +2306,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private boolean force;
             private boolean tags;
             private Integer timeout;
+            private boolean dryRun;
 
             @Override
             public PushCommand to(URIish remote) {
@@ -2343,6 +2344,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
+            public PushCommand dryRun(boolean dryRun) {
+                this.dryRun = dryRun;
+                return this;
+            }
+
+            @Override
             public void execute() throws GitException, InterruptedException {
                 ArgumentListBuilder args = new ArgumentListBuilder();
                 args.add("push", remote.toPrivateASCIIString());
@@ -2357,6 +2364,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (tags) {
                     args.add("--tags");
+                }
+
+                if (dryRun) {
+                    args.add("--dry-run");
                 }
 
                 if (!isAtLeastVersion(1,9,0,0) && isShallowRepository()) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1848,6 +1848,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public String refspec;
             public boolean force;
             public boolean tags;
+            public boolean dryRun;
 
             @Override
             public PushCommand to(URIish remote) {
@@ -1885,6 +1886,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
+            public PushCommand dryRun(boolean dryRun) {
+                this.dryRun = dryRun;
+                return this;
+            }
+
+            @Override
             public void execute() throws GitException, InterruptedException {
                 try (Repository repo = getRepository()) {
                     RefSpec ref = (refspec != null) ? new RefSpec(fixRefSpec(repo)) : Transport.REFSPEC_PUSH_ALL;
@@ -1895,7 +1902,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     org.eclipse.jgit.api.PushCommand pc = g.push().setRemote("org_jenkinsci_plugins_gitclient_JGitAPIImpl").setRefSpecs(ref)
                             .setProgressMonitor(new JGitProgressMonitor(listener))
                             .setCredentialsProvider(getProvider())
-                            .setForce(force);
+                            .setForce(force)
+                            .setDryRun(dryRun);
                     if(tags) {
                         pc.setPushTags();
                     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1815,6 +1815,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private String refspec;
             private boolean force;
             private boolean tags;
+            private boolean dryRun;
 
             @Override
             public PushCommand to(URIish remote) {
@@ -1852,6 +1853,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
+            public PushCommand dryRun(boolean dryRun) {
+                this.dryRun = dryRun;
+                return this;
+            }
+
+            @Override
             public void execute() throws GitException, InterruptedException {
                 try (Repository repo = getRepository()) {
                     RefSpec ref = (refspec != null) ? new RefSpec(fixRefSpec(repo)) : Transport.REFSPEC_PUSH_ALL;
@@ -1862,7 +1869,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     org.eclipse.jgit.api.PushCommand pc = g.push().setRemote("org_jenkinsci_plugins_gitclient_JGitAPIImpl").setRefSpecs(ref)
                             .setProgressMonitor(new JGitProgressMonitor(listener))
                             .setCredentialsProvider(getProvider())
-                            .setForce(force);
+                            .setForce(force)
+                            .setDryRun(dryRun);
                     if(tags) {
                         pc.setPushTags();
                     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1782,6 +1782,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public String refspec;
             public boolean force;
             public boolean tags;
+            public boolean dryRun;
 
             public PushCommand to(URIish remote) {
                 this.remote = remote;
@@ -1813,6 +1814,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            public PushCommand dryRun(boolean dryRun) {
+                this.dryRun = dryRun;
+                return this;
+            }
+
             public void execute() throws GitException, InterruptedException {
                 try (Repository repo = getRepository()) {
                     RefSpec ref = (refspec != null) ? new RefSpec(fixRefSpec(repo)) : Transport.REFSPEC_PUSH_ALL;
@@ -1823,7 +1829,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     org.eclipse.jgit.api.PushCommand pc = g.push().setRemote("org_jenkinsci_plugins_gitclient_JGitAPIImpl").setRefSpecs(ref)
                             .setProgressMonitor(new JGitProgressMonitor(listener))
                             .setCredentialsProvider(getProvider())
-                            .setForce(force);
+                            .setForce(force)
+                            .setDryRun(dryRun);
                     if(tags) {
                         pc.setPushTags();
                     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/PushCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/PushCommand.java
@@ -58,4 +58,12 @@ public interface PushCommand extends GitCommand {
      * @return a {@link org.jenkinsci.plugins.gitclient.PushCommand} object.
      */
     PushCommand timeout(Integer timeout);
+
+    /**
+     * dryRun.
+     *
+     * @param dryRun {@code true} if the push should be dry-run.
+     * @return a {@link org.jenkinsci.plugins.gitclient.PushCommand} object.
+     */
+    PushCommand dryRun(boolean dryRun);
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushSimpleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushSimpleTest.java
@@ -31,6 +31,14 @@ public class PushSimpleTest extends PushTest {
         workingGitClient.push().to(bad).ref(refSpec).execute();
     }
 
+    @Test
+    public void dryPushBadURIThrows() throws IOException, GitException, InterruptedException, URISyntaxException {
+        checkoutBranchAndCommitFile();
+        URIish bad = new URIish(bareURI.toString() + "-bad");
+        thrown.expect(GitException.class);
+        workingGitClient.push().to(bad).ref(refSpec).dryRun(true).execute();
+    }
+
     @Parameterized.Parameters(name = "{0} with {1}")
     public static Collection pushParameters() {
         List<Object[]> parameters = new ArrayList<>();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
@@ -6,6 +6,7 @@ import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.util.*;
 
+import com.google.common.collect.Lists;
 import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
@@ -97,8 +98,8 @@ public class PushTest {
     @Parameterized.Parameters(name = "{0} with {1} refspec {2}")
     public static Collection pushParameters() {
         List<Object[]> parameters = new ArrayList<>();
-        final String[] implementations = {"git", "jgit"};
-        final String[] goodRefSpecs = {
+        final List<String> implementations = Lists.newArrayList("git", "jgit");
+        final List<String> goodRefSpecs = Lists.newArrayList(
             "{0}",
             "HEAD",
             "HEAD:{0}",
@@ -106,17 +107,17 @@ public class PushTest {
             "refs/heads/{0}",
             "{0}:heads/{0}",
             "{0}:refs/heads/{0}"
-        };
-        final String[] badRefSpecs = {
+        );
+        final List<String> badRefSpecs = Lists.newArrayList(
             /* ":", // JGit fails with "ERROR: branch is currently checked out" */
             /* ":{0}", // CliGitAPIImpl will delete the remote branch with this refspec */
             "this/ref/does/not/exist",
             "src/ref/does/not/exist:dest/ref/does/not/exist"
-        };
+        );
 
-        Collections.shuffle(Arrays.asList(implementations));
-        Collections.shuffle(Arrays.asList(goodRefSpecs));
-        Collections.shuffle(Arrays.asList(badRefSpecs));
+        Collections.shuffle(implementations);
+        Collections.shuffle(goodRefSpecs);
+        Collections.shuffle(badRefSpecs);
 
         for (String implementation : implementations) {
             for (String branch : branchNames) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
@@ -4,10 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
 import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
@@ -83,6 +80,7 @@ public class PushTest {
         if (expectedException != null) {
             thrown.expect(expectedException);
         }
+        workingGitClient.push().to(bareURI).ref(refSpec).dryRun(true).execute();
         workingGitClient.push().to(bareURI).ref(refSpec).execute();
     }
 
@@ -116,9 +114,9 @@ public class PushTest {
             "src/ref/does/not/exist:dest/ref/does/not/exist"
         };
 
-        shuffleArray(implementations);
-        shuffleArray(goodRefSpecs);
-        shuffleArray(badRefSpecs);
+        Collections.shuffle(Arrays.asList(implementations));
+        Collections.shuffle(Arrays.asList(goodRefSpecs));
+        Collections.shuffle(Arrays.asList(badRefSpecs));
 
         for (String implementation : implementations) {
             for (String branch : branchNames) {
@@ -141,7 +139,6 @@ public class PushTest {
     public void createWorkingRepository() throws IOException, InterruptedException, URISyntaxException {
         hudson.EnvVars env = new hudson.EnvVars();
         TaskListener listener = StreamTaskListener.fromStderr();
-        List<RefSpec> refSpecs = new ArrayList<>();
         workingRepo = Files.createTempDir();
         workingGitClient = Git.with(listener, env).in(workingRepo).using(gitImpl).getClient();
         workingGitClient.clone_()
@@ -263,16 +260,5 @@ public class PushTest {
         assertNotEquals(bareFirstCommit, workingCommit);
 
         return workingCommit;
-    }
-
-    private static void shuffleArray(String[] ar) {
-        Random rnd = new Random();
-        for (int i = ar.length - 1; i > 0; i--) {
-            int index = rnd.nextInt(i + 1);
-            // Simple swap
-            String a = ar[index];
-            ar[index] = ar[i];
-            ar[i] = a;
-        }
     }
 }


### PR DESCRIPTION
I found it useful to check whether the push is well configured before the push itself. For example - Bad credentials.

A typical scenario may be:
1. Push with dry-run.
2. If dry-run succeed - Build something (Long time).
3. Push to git successfully.

Instead of:
1. Build something (Long time)
2. Try to push to git with bad credentials and fail.
3. Build again with good credentials. (Long time)
4. Push to git successfully.