### PR TITLE
support non-heads refs in remote polling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2815,10 +2815,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     public ObjectId getHeadRev(String url, String branchSpec) throws GitException, InterruptedException {
         final String branchName = extractBranchNameFromBranchSpec(branchSpec);
         ArgumentListBuilder args = new ArgumentListBuilder("ls-remote");
-        if(branchName.startsWith("refs/tags/")) {
-            args.add("-t");
-        }
-        if(branchName.startsWith("refs/heads/")) {
+        if(!branchName.startsWith("refs/tags/") && !branchName.startsWith("refs/pull/")) {
             args.add("-h");
         }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2815,7 +2815,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     public ObjectId getHeadRev(String url, String branchSpec) throws GitException, InterruptedException {
         final String branchName = extractBranchNameFromBranchSpec(branchSpec);
         ArgumentListBuilder args = new ArgumentListBuilder("ls-remote");
-        if(!branchName.startsWith("refs/tags/")) {
+        if(branchName.startsWith("refs/tags/")) {
+            args.add("-t");
+        }
+        if(branchName.startsWith("refs/heads/")) {
             args.add("-h");
         }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2815,7 +2815,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     public ObjectId getHeadRev(String url, String branchSpec) throws GitException, InterruptedException {
         final String branchName = extractBranchNameFromBranchSpec(branchSpec);
         ArgumentListBuilder args = new ArgumentListBuilder("ls-remote");
-        if(!branchName.startsWith("refs/tags/") && !branchName.startsWith("refs/pull/")) {
+        if(!(branchName.startsWith("refs/tags/") || branchName.startsWith("refs/pull/"))) {
             args.add("-h");
         }
 


### PR DESCRIPTION
when trying to build github pull requests and using `refs/pull/{number}/(head|merge)` refs for that purpose, git plugin doesn't detect changes using remote polling because it only fetches `refs/heads` refs