### PR TITLE
[DO NOT MERGE] Extra logging for [JENKINS-48357] diagnosis

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2014,6 +2014,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             int status = p.start().joinWithTimeout(timeout != null ? timeout : TIMEOUT, TimeUnit.MINUTES, listener);
 
             String result = fos.toString(Charset.defaultCharset().toString());
+            listener.getLogger().println(" > FINISHED " + command + (timeout != null ? TIMEOUT_LOG_PREFIX + timeout : ""));
             if (status != 0) {
                 throw new GitException("Command \""+command+"\" returned status code " + status + ":\nstdout: " + result + "\nstderr: "+ err.toString(Charset.defaultCharset().toString()));
             }


### PR DESCRIPTION
I suspect that the git plugin is not the source of the [JENKINS-48357 problem](https://issues.jenkins-ci.org/browse/JENKINS-48357) that is causing Pipeline jobs to hang.

Log the completion of a command line git call in addition to the entry into a command line git call.

**Do not merge this pull request!**  

This will dramatically increase the log spam from the git plugin.  This is a pull request so that there is an easy way to obtain a build of the plugin.