### PR TITLE
Narrow jgit exclusion in credentials test

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -272,7 +272,7 @@ public class CredentialsTest {
                         if (skipIf.equals(implementation)) {
                             continue;
                         }
-                        if (implementation.startsWith("jgit") && skipIf.startsWith("jgit")) { // Treat jgitapache like jgit
+                        if (implementation.startsWith("jgit") && skipIf.equals("jgit")) { // Treat jgitapache like jgit
                             continue;
                         }
                     }


### PR DESCRIPTION
JGit 4.5 handles absence of username from the ssh URL differently than
JGit 4.11.

The ssh URL github.com:MarkEWaite/tasks.git with the username argument
"git" is handled correctly by JGit 4.11 and incorrectly by JGit 4.5.

JGit 4.5 handles conflicts between the username embedded in the ssh
URL and the username argument differently than JGit 4.11.

The ssh URL git@github.com:MarkEWaite/tasks.git with the username
argument "jenkins" is handled correctly by JGit 4.11 and incorrectly
by JGit 4.5.

JGit 4.5 honors the username argument instead of the username embedded
in the ssh URL.

JGit 4.11 honors the username embedded in the ssh URL instead of the
username argument.

Secure shell versions prior to OpenSSH 7.7 honored the username
embedded in the ssh URL instead of the username argument.  That is the
definitive behavior.

Git plugin changes have been made to cause OpenSSH 7.7 (and later) to
honor the username embedded in the ssh URL instead of the username
argument.  Those changes should keep consistent behavior across all
versions of OpenSSH and all supported versions of command line git.