### PR TITLE
Report better exception if filename not supported

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -865,7 +865,14 @@ public abstract class GitAPITestCase extends TestCase {
          */
         String fileName = "\uD835\uDD65-\u5c4f\u5e55\u622a\u56fe-\u0041\u030a-\u00c5-\u212b-fileName.xml";
         w.touch(fileName, "content " + fileName);
-        w.git.add(fileName);
+        try {
+            w.git.add(fileName);
+        } catch (GitException ge) {
+            // Exception should contain actual file name
+            // If mangled name is seen instead, throw a clear exception to indicate root cause
+            assertTrue("System locale does not support filename '" + fileName + "'", ge.getMessage().contains("?-????-A?-?-?-fileName.xml"));
+            throw ge; // Fail the test on exception even if the preceding assertion did not fail
+        }
         w.git.commit(fileName);
 
         /* JENKINS-27910 reported that certain cyrillic file names


### PR DESCRIPTION
When `LANG=C mvn -Dtest=CliGitAPIImplTest#test_clean test` fails, give a better message than the exception from "git add".

This is not foolproof, just an aid for diagnosing test failures when the locale is unable to support the filename in the test.

@darxriggs since you've been looking at tests recently on the plugin, I'd love to have you review this pull request.