### PR TITLE
Reduce credentials test verbosity

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -350,7 +350,7 @@ public class CredentialsTest {
      * @return true if another test should be allowed to start
      */
     private boolean testPeriodNotExpired() {
-        return (System.currentTimeMillis() - firstTestStartTime) < ((180 - 60) * 1000L);
+        return (System.currentTimeMillis() - firstTestStartTime) < ((180 - 120) * 1000L);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -106,10 +106,6 @@ public class CredentialsTest {
     private static long longestTestDuration = 0;
     private long currentTestStartTime = 0;
 
-    private static PrintStream log() {
-        return StreamTaskListener.fromStdout().getLogger();
-    }
-
     /* Windows refuses directory names with '*', '<', '>', '|', '?', and ':' */
     private final String SPECIALS_TO_CHECK = "%()`$&{}[]"
             + (isWindows() ? "" : "*<>:|?");
@@ -134,12 +130,6 @@ public class CredentialsTest {
             firstTestStartTime = System.currentTimeMillis();
         }
         currentTestStartTime = System.currentTimeMillis();
-        log().println(show("Repo", gitRepoUrl)
-                + show("spec", specialCharacter)
-                + show("impl", gitImpl)
-                + show("user", username)
-                + show("pass", password)
-                + show("key", privateKey));
     }
 
     @Before
@@ -162,7 +152,6 @@ public class CredentialsTest {
         logger.addHandler(handler);
         logger.setLevel(Level.ALL);
         listener = new hudson.util.LogTaskListener(logger, Level.ALL);
-        listener.getLogger().println(LOGGING_STARTED);
         git = Git.with(listener, new hudson.EnvVars()).in(repo).using(gitImpl).getClient();
 
         assertTrue("Bad username, password, privateKey combo: '" + username + "', '" + password + "'",
@@ -378,10 +367,8 @@ public class CredentialsTest {
         /* Fetch with remote name "origin" instead of remote URL */
         doFetch("origin");
         ObjectId master = git.getHeadRev(gitRepoURL, "master");
-        log().println("Checking out " + master.getName().substring(0, 8) + " from " + gitRepoURL);
         git.checkout().branch("master").ref(master.getName()).deleteBranchIfExist(true).execute();
         if (submodules) {
-            log().println("Initializing submodules from " + gitRepoURL);
             git.submoduleInit();
             SubmoduleUpdateCommand subcmd = git.submoduleUpdate().parentCredentials(useParentCreds);
             subcmd.execute();


### PR DESCRIPTION
Reduce credentials test verbosity to reduce spurious CI test failures due to 2 minutes of testing.  Reduce to 1 minute of testing.