### PR TITLE
Add test that verifies invocation of ToolInstallers on master

### DIFF
--- a/src/test/java/hudson/plugins/git/GitToolResolverTest.java
+++ b/src/test/java/hudson/plugins/git/GitToolResolverTest.java
@@ -2,9 +2,11 @@ package hudson.plugins.git;
 
 import hudson.EnvVars;
 import hudson.model.TaskListener;
+import hudson.tools.AbstractCommandInstaller;
+import hudson.tools.BatchCommandInstaller;
 import hudson.tools.CommandInstaller;
 import hudson.tools.InstallSourceProperty;
-import hudson.util.StreamTaskListener;
+import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import static org.junit.Assert.*;
@@ -29,15 +31,28 @@ public class GitToolResolverTest {
 
     @Test
     public void shouldResolveToolsOnMaster() throws Exception {
-        TaskListener log = StreamTaskListener.fromStdout();
+        final String label = "master";
+        final String command = "echo Hello";
+        final String toolHome = "TOOL_HOME";
+        AbstractCommandInstaller installer;
+        String expectedSubstring;
+        if (isWindows()) {
+            installer = new BatchCommandInstaller(label, command, toolHome);
+            expectedSubstring = System.getProperty("java.io.tmpdir", "C:\\Temp");
+        } else {
+            installer = new CommandInstaller(label, command, toolHome);
+            expectedSubstring = toolHome;
+        }
         GitTool t = new GitTool("myGit", null, Collections.singletonList(
-                new InstallSourceProperty(Collections.singletonList(
-                        new CommandInstaller("master", "echo Hello", "TOOL_HOME")
-                ))));
+                new InstallSourceProperty(Collections.singletonList(installer))));
         t.getDescriptor().setInstallations(t);
 
         GitTool defaultTool = GitTool.getDefaultInstallation();
         GitTool resolved = (GitTool) defaultTool.translate(j.jenkins, new EnvVars(), TaskListener.NULL);
-        assertThat(resolved.getGitExe(), org.hamcrest.CoreMatchers.containsString("TOOL_HOME"));
+        assertThat(resolved.getGitExe(), org.hamcrest.CoreMatchers.containsString(expectedSubstring));
+    }
+
+    private boolean isWindows() {
+        return File.pathSeparatorChar == ';';
     }
 }

--- a/src/test/java/hudson/plugins/git/GitToolResolverTest.java
+++ b/src/test/java/hudson/plugins/git/GitToolResolverTest.java
@@ -1,0 +1,43 @@
+package hudson.plugins.git;
+
+import hudson.EnvVars;
+import hudson.model.TaskListener;
+import hudson.tools.CommandInstaller;
+import hudson.tools.InstallSourceProperty;
+import hudson.util.StreamTaskListener;
+import java.io.IOException;
+import java.util.Collections;
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class GitToolResolverTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private GitTool gitTool;
+
+    @Before
+    public void setUp() throws IOException {
+        GitTool.onLoaded();
+        gitTool = GitTool.getDefaultInstallation();
+    }
+
+    @Test
+    public void shouldResolveToolsOnMaster() throws Exception {
+        TaskListener log = StreamTaskListener.fromStdout();
+        GitTool t = new GitTool("myGit", null, Collections.singletonList(
+                new InstallSourceProperty(Collections.singletonList(
+                        new CommandInstaller("master", "echo Hello", "TOOL_HOME")
+                ))));
+        t.getDescriptor().setInstallations(t);
+
+        GitTool defaultTool = GitTool.getDefaultInstallation();
+        GitTool resolved = (GitTool) defaultTool.translate(j.jenkins, new EnvVars(), TaskListener.NULL);
+        assertThat(resolved.getGitExe(), org.hamcrest.CoreMatchers.containsString("TOOL_HOME"));
+    }
+}

--- a/src/test/java/hudson/plugins/git/GitToolTest.java
+++ b/src/test/java/hudson/plugins/git/GitToolTest.java
@@ -4,20 +4,14 @@ import hudson.EnvVars;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.slaves.DumbSlave;
-import hudson.tools.CommandInstaller;
-import hudson.tools.InstallSourceProperty;
 import hudson.tools.ToolDescriptor;
 import hudson.util.StreamTaskListener;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
-
 import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.plugins.gitclient.JGitApacheTool;
 import org.jenkinsci.plugins.gitclient.JGitTool;
 import static org.junit.Assert.*;
-
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -47,21 +41,6 @@ public class GitToolTest {
         TaskListener log = StreamTaskListener.fromStdout();
         GitTool newTool = gitTool.forNode(slave, log);
         assertEquals(gitTool.getGitExe(), newTool.getGitExe());
-    }
-
-    @Test
-    public void shouldResolveToolsOnMaster() throws Exception {
-        Assume.assumeTrue(!hudson.remoting.Launcher.isWindows());
-        TaskListener log = StreamTaskListener.fromStdout();
-        GitTool t = new GitTool("myGit", null, Collections.singletonList(
-                new InstallSourceProperty(Collections.singletonList(
-                        new CommandInstaller("master", "echo Hello", "TOOL_HOME")
-                ))));
-        t.getDescriptor().setInstallations(t);
-
-        GitTool defaultTool = GitTool.getDefaultInstallation();
-        GitTool resolved = (GitTool) defaultTool.translate(j.jenkins, new EnvVars(), TaskListener.NULL);
-        assertThat(resolved.getGitExe(), org.hamcrest.CoreMatchers.containsString("TOOL_HOME"));
     }
 
     @Test


### PR DESCRIPTION
Just an extra test, which verifies that Core Tool management logic is fine for Jenkins master node. 

https://github.com/jenkinsci/git-plugin/pull/605 is a related fix in the downstream plugin

@MarkEWaite @btk3000 @jenkinsci/code-reviewers 

