### PR TITLE
Exclude httpcore, since it's already in the httpcomponents API plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,11 @@
           <artifactId>httpclient</artifactId>
         </exclusion>
         <exclusion>
+          <!-- Provided by apache-httpcomponents-client-4-api -->
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
           <!-- Provided by Jenkins core -->
           <groupId>com.jcraft</groupId>
           <artifactId>jzlib</artifactId>


### PR DESCRIPTION
It seems httpcore slipped into the plugin, since `org.eclipse.jgit.http.apache` has a direct dependency on it. This excludes it again.