### PR TITLE
[JENKINS-44720] Add option for updating submodules in parallel

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2231,6 +2231,19 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
+            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand threads(Integer threads) {
+                // TODO: I have no idea if JGit can update submodules in parallel
+                // It might work, or it might blow up horribly. This probably depends on
+                // whether JGit relies on any global/shared state. Since I have no
+                // experience with JGit, I'm leaving this unimplemented for the time
+                // being. But if some brave soul wants to test this, feel free to provide
+                // an implementation similar to the one in the CliGitAPIImpl class using
+                // an ExecutorService.
+                listener.getLogger().println("[WARNING] JGit doesn't support updating submodules in parallel. This flag is ignored");
+                return this;
+            }
+
+            @Override
             public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand useBranch(String submodule, String branchname) {
                 return this;
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
@@ -76,4 +76,12 @@ public interface SubmoduleUpdateCommand extends GitCommand {
      * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
      */
     SubmoduleUpdateCommand depth(Integer depth);
+
+    /**
+     * Update submodules in parallel with the given number of threads.
+     *
+     * @param threads number of threads to use for updating submodules in parallel
+     * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
+     */
+    SubmoduleUpdateCommand threads(Integer threads);
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2634,6 +2634,23 @@ public abstract class GitAPITestCase extends TestCase {
     }
 
     @NotImplementedInJGit
+    public void test_submodule_update_with_threads() throws Exception {
+        w.init();
+        w.git.clone_().url(localMirror()).repositoryName("sub2_origin").execute();
+        w.git.checkout().branch("tests/getSubmodules").ref("sub2_origin/tests/getSubmodules").deleteBranchIfExist(true).execute();
+        w.git.submoduleInit();
+        w.git.submoduleUpdate().threads(3).execute();
+
+        assertTrue("modules/firewall does not exist", w.exists("modules/firewall"));
+        assertTrue("modules/ntp does not exist", w.exists("modules/ntp"));
+        // JGit submodule implementation doesn't handle renamed submodules
+        if (w.igit() instanceof CliGitAPIImpl) {
+            assertTrue("modules/sshkeys does not exist", w.exists("modules/sshkeys"));
+        }
+        assertFixSubmoduleUrlsThrows();
+    }
+
+    @NotImplementedInJGit
     public void test_trackingSubmoduleBranches() throws Exception {
         if (! ((CliGitAPIImpl)w.git).isAtLeastVersion(1,8,2,0)) {
             setTimeoutVisibleInCurrentTest(false);


### PR DESCRIPTION
This change uses an ExecutorService to optionally update submodules in
parallel. This can dramatically improving update times for
repositories with lots of submodules. Since the CliGitAPIImpl class
doesn't launch a single "git submodule update" command, but instead
launches one command per submodule, we can't use the "--jobs" CLI
argument for git, available since git 2.9.0.