### PR TITLE
[JENKINS-52891] Always log the timeout for a CliGit command

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2102,11 +2102,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 /* GIT_SSH won't call the passphrase prompt script unless detached from controlling terminal */
                 args.prepend("setsid");
             }
-            listener.getLogger().println(" > " + command + (timeout != null ? TIMEOUT_LOG_PREFIX + timeout : ""));
+            int usedTimeout = timeout == null ? TIMEOUT : timeout;
+            listener.getLogger().println(" > " + command + TIMEOUT_LOG_PREFIX + usedTimeout);
             Launcher.ProcStarter p = launcher.launch().cmds(args.toCommandArray()).
                     envs(freshEnv).stdout(fos).stderr(err);
             if (workDir != null) p.pwd(workDir);
-            int status = p.start().joinWithTimeout(timeout != null ? timeout : TIMEOUT, TimeUnit.MINUTES, listener);
+            int status = p.start().joinWithTimeout(usedTimeout, TimeUnit.MINUTES, listener);
 
             String result = fos.toString(Charset.defaultCharset().toString());
             if (status != 0) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -478,6 +478,45 @@ public abstract class GitAPITestCase extends TestCase {
         }
     }
 
+    @NotImplementedInJGit
+    public void test_clone_default_timeout_logging() throws Exception {
+        w.git.clone_().url(localMirror()).repositoryName("origin").execute();
+
+        cloneTimeout = CliGitAPIImpl.TIMEOUT;
+        assertCloneTimeout();
+    }
+
+    @NotImplementedInJGit
+    public void test_fetch_default_timeout_logging() throws Exception {
+        w.git.clone_().url(localMirror()).repositoryName("origin").execute();
+
+        w.git.fetch_().from(new URIish("origin"), null).execute();
+
+        fetchTimeout = CliGitAPIImpl.TIMEOUT;
+        assertFetchTimeout();
+    }
+
+    @NotImplementedInJGit
+    public void test_checkout_default_timeout_logging() throws Exception {
+        w.git.clone_().url(localMirror()).repositoryName("origin").execute();
+
+        w.git.checkout().ref("origin/master").execute();
+
+        checkoutTimeout = CliGitAPIImpl.TIMEOUT;
+        assertCheckoutTimeout();
+    }
+
+    @NotImplementedInJGit
+    public void test_submodule_update_default_timeout_logging() throws Exception {
+        w.git.clone_().url(localMirror()).repositoryName("origin").execute();
+        w.git.checkout().ref("origin/tests/getSubmodules").execute();
+
+        w.git.submoduleUpdate().execute();
+
+        submoduleUpdateTimeout = CliGitAPIImpl.TIMEOUT;
+        assertSubmoduleUpdateTimeout();
+    }
+
     public void test_setAuthor() throws Exception {
         final String authorName = "Test Author";
         final String authorEmail = "jenkins@example.com";


### PR DESCRIPTION
[JENKINS-52891](https://issues.jenkins-ci.org/browse/JENKINS-52891)

A timeout is always used for a cli git command and therefore should always be logged.

Options a timeout may be set
- timeout parameter for some commands
- system property org.jenkinsci.plugins.gitclient.Git.timeOut
- default of 10 minutes

So far the timeout was only logged for commands where
a) it cannot be customized
b) it can and actually was customized

Category a) some commands with correct default timeout logging so far
    > git --version # timeout=10
    > git init ... # timeout=10
    > git config ... # timeout=10
    > git submodule init # timeout=10

Category b) commands with missing default timeout logging so far
    > git fetch ...
    > git checkout ...
    > git submodule update ...