### PR TITLE
Use JGit's implementation of prune during fetch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
-    <jgit.version>5.1.0.201808281540-m3</jgit.version>
+    <jgit.version>5.0.3.201809091024-r</jgit.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
-    <jgit.version>5.0.2.201807311906-r</jgit.version>
+    <jgit.version>5.1.0.201808281540-m3</jgit.version>
   </properties>
 
   <dependencies>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1323,13 +1323,13 @@ public abstract class GitAPITestCase extends TestCase {
     }
 
     /**
-     * JGit 3.3.0 thru 3.6.0 "prune during fetch" prunes more remote
-     * branches than command line git prunes during fetch.  This test
-     * should be used to evaluate future versions of JGit to see if
-     * pruning behavior more closely emulates command line git.
-     *
-     * This has been fixed using a workaround.
+     * JGit 3.3.0 thru 4.5.4 "prune during fetch" prunes more remote
+     * branches than command line git prunes during fetch.  JGit 5.0.2
+     * fixes the problem.
+     * Refer to https://bugs.eclipse.org/bugs/show_bug.cgi?id=533549
+     * Refer to https://bugs.eclipse.org/bugs/show_bug.cgi?id=533806
      */
+    @Issue("JENKINS-26197")
     public void test_fetch_with_prune() throws Exception {
         WorkingArea bare = new WorkingArea();
         bare.init(true);


### PR DESCRIPTION
JGit 5.0.2 fixes the behavior of prune during fetch so that the alternative implementation is no longer required.  Unfortunately, JGit 5 also logs warnings that were not logged previously when it attempts to remove a directory that is not empty.

@darxriggs I'd love to have your review of the proposed change.