### PR TITLE
Check for exceptions when updating submodules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.22.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <version>3.0.2</version>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -283,8 +283,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         this.listener = listener;
         this.gitExe = gitExe;
         this.environment = environment;
-        
-        if( isZos() && System.getProperty("ibm.system.encoding") != null ) { 
+
+        if( isZos() && System.getProperty("ibm.system.encoding") != null ) {
             this.encoding = Charset.forName(System.getProperty("ibm.system.encoding")).toString();
         } else {
             this.encoding = Charset.defaultCharset().toString();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1143,7 +1143,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private Map<String, String> submodBranch   = new HashMap<>();
             private Integer timeout;
             private Integer depth = 1;
-            private Integer threads = 1;
+            private int threads = 1;
 
             @Override
             public SubmoduleUpdateCommand recursive(boolean recursive) {
@@ -1194,7 +1194,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
-            public SubmoduleUpdateCommand threads(Integer threads) {
+            public SubmoduleUpdateCommand threads(int threads) {
                 this.threads = threads;
                 return this;
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2201,7 +2201,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
-            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand threads(Integer threads) {
+            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand threads(int threads) {
                 // TODO: I have no idea if JGit can update submodules in parallel
                 // It might work, or it might blow up horribly. This probably depends on
                 // whether JGit relies on any global/shared state. Since I have no

--- a/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
@@ -83,5 +83,5 @@ public interface SubmoduleUpdateCommand extends GitCommand {
      * @param threads number of threads to use for updating submodules in parallel
      * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
      */
-    SubmoduleUpdateCommand threads(Integer threads);
+    SubmoduleUpdateCommand threads(int threads);
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
@@ -78,7 +78,8 @@ public interface SubmoduleUpdateCommand extends GitCommand {
     SubmoduleUpdateCommand depth(Integer depth);
 
     /**
-     * Update submodules in parallel with the given number of threads.
+     * Update submodules in parallel with the given number of threads. Note that this parallelism only applies to the
+     * top-level submodules of a repository. Any submodules of those submodules will be updated serially.
      *
      * @param threads number of threads to use for updating submodules in parallel
      * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/cgit/GitCommandsExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/cgit/GitCommandsExecutor.java
@@ -1,0 +1,91 @@
+package org.jenkinsci.plugins.gitclient.cgit;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.ExceptionCatchingThreadFactory;
+import hudson.util.NamingThreadFactory;
+
+/**
+ * This executor can invoke multiple git commands in parallel using threads.
+ * <p>
+ * If threads = 1 the caller thread is used.
+ * If a git command fails, invocation of all running and not yet started commands is stopped.
+ */
+public class GitCommandsExecutor {
+
+    private final int threads;
+    private final TaskListener listener;
+
+    public GitCommandsExecutor(int threads, TaskListener listener) {
+        this.threads = Math.max(1, threads);
+        this.listener = listener;
+    }
+
+    public <T> void invokeAll(Collection<Callable<T>> commands) throws GitException, InterruptedException {
+        ExecutorService executorService = null;
+        try {
+            if (threads == 1) {
+                executorService = MoreExecutors.sameThreadExecutor();
+            } else {
+                ThreadFactory threadFactory = new ExceptionCatchingThreadFactory(new NamingThreadFactory(new DaemonThreadFactory(), GitCommandsExecutor.class.getSimpleName()));
+                executorService = Executors.newFixedThreadPool(threads, threadFactory);
+            }
+            invokeAll(executorService, commands);
+        } finally {
+            if (executorService != null) {
+                executorService.shutdownNow();
+                if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+                    listener.getLogger().println("[WARNING] Threads did not terminate properly");
+                }
+            }
+        }
+    }
+
+    private <T> void invokeAll(ExecutorService executorService, Collection<Callable<T>> commands) throws InterruptedException {
+        CompletionService<T> completionService = new ExecutorCompletionService<>(executorService);
+        Iterator<Callable<T>> remainingCommands = commands.iterator();
+        int nCommands = commands.size();
+
+        for (int i = 0; i < threads && i < nCommands; i++) {
+            submitRemainingCommand(completionService, remainingCommands);
+        }
+
+        for (int i = 0; i < nCommands; i++) {
+            checkResult(completionService.take());
+            submitRemainingCommand(completionService, remainingCommands);
+        }
+    }
+
+    private <T> void submitRemainingCommand(CompletionService<T> completionService, Iterator<Callable<T>> remainingCommands) {
+        if (remainingCommands.hasNext()) {
+            completionService.submit(remainingCommands.next());
+        }
+    }
+
+    private <T> void checkResult(Future<T> result) throws InterruptedException {
+        try {
+            result.get();
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof InterruptedException) {
+                throw (InterruptedException) new InterruptedException().initCause(cause);
+            } else {
+                throw new GitException(cause);
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/gitclient/cgit/package-info.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/cgit/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Git client API implementation with <a href="https://git-scm.com/">cgit</a>.
+ */
+package org.jenkinsci.plugins.gitclient.cgit;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2631,6 +2631,21 @@ public abstract class GitAPITestCase extends TestCase {
         assertFalse("shallow file existence: " + shallow, w.exists(shallow));
     }
 
+    @NotImplementedInJGit
+    public void test_submodule_update_with_error() throws Exception {
+        w.git.clone_().url(localMirror()).execute();
+        w.git.checkout().ref("origin/tests/getSubmodules").execute();
+        w.rm("modules/ntp");
+        w.touch("modules/ntp", "file that interferes with ntp submodule folder");
+
+        try {
+            w.git.submoduleUpdate().execute();
+            fail("Did not throw expected submodule update exception");
+        } catch (GitException e) {
+            assertThat(e.getMessage(), containsString("Command \"git submodule update modules/ntp\" returned status code 1"));
+        }
+    }
+
     public void test_submodule_update_shallow() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/cgit/GitCommandsExecutorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/cgit/GitCommandsExecutorTest.java
@@ -1,0 +1,268 @@
+package org.jenkinsci.plugins.gitclient.cgit;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.theInstance;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class GitCommandsExecutorTest {
+
+    private final int threads;
+    private final TaskListener listener;
+
+    public GitCommandsExecutorTest(int threads) {
+        this.threads = threads;
+        this.listener = mockTaskListener();
+    }
+
+    @After
+    public void verifyCorrectExecutorServiceShutdown() {
+        verifyZeroInteractions(listener);
+    }
+
+    @Parameters(name = "threads={0}")
+    public static Iterable<Integer> threadsParameter() {
+        return asList(1, 2, 100);
+    }
+
+    @Test
+    public void allCommandsSucceed() throws Exception {
+        List<Callable<String>> commands = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            commands.add(successfulCommand("some value"));
+        }
+
+        new GitCommandsExecutor(threads, listener).invokeAll(commands);
+
+        for (Callable<String> command : commands) {
+            verify(command).call();
+        }
+    }
+
+    @Test
+    public void allCommandsFail() throws Exception {
+        List<Callable<String>> commands = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            commands.add(erroneousCommand(new RuntimeException("some error")));
+        }
+
+        try {
+            new GitCommandsExecutor(threads, listener).invokeAll(commands);
+            fail("Expected an exception but none was thrown");
+        } catch (Exception e) {
+            assertThat(e, instanceOf(GitException.class));
+            assertThat(e.getMessage(), is("java.lang.RuntimeException: some error"));
+            assertThat(e.getCause(), instanceOf(RuntimeException.class));
+        }
+    }
+
+    @Test
+    public void firstCommandFails() throws Exception {
+        long commandExecutionTime = 60_000;
+        List<Callable<String>> commands = asList(
+                erroneousCommand(new RuntimeException("some error")),
+                successfulCommand("some value", commandExecutionTime),
+                successfulCommand("some value", commandExecutionTime)
+        );
+
+        long executionStartMillis = System.currentTimeMillis();
+        try {
+            new GitCommandsExecutor(threads, listener).invokeAll(commands);
+            fail("Expected an exception but none was thrown");
+        } catch (Exception e) {
+            assertThat(e, instanceOf(GitException.class));
+            assertThat(e.getMessage(), is("java.lang.RuntimeException: some error"));
+            assertThat(e.getCause(), instanceOf(RuntimeException.class));
+        }
+        long executionStopMillis = System.currentTimeMillis();
+
+        for (Callable<String> command : commands) {
+            if (commands.indexOf(command) < threads) {
+                verify(command).call();
+            } else {
+                verifyZeroInteractions(command);
+            }
+        }
+        assertThat(executionStopMillis - executionStartMillis, is(lessThan(commandExecutionTime)));
+    }
+
+    @Test
+    public void lastCommandFails() throws Exception {
+        List<Callable<String>> commands = asList(
+                successfulCommand("some value"),
+                successfulCommand("some value"),
+                erroneousCommand(new RuntimeException("some error"))
+        );
+
+        try {
+            new GitCommandsExecutor(threads, listener).invokeAll(commands);
+            fail("Expected an exception but none was thrown");
+        } catch (Exception e) {
+            assertThat(e, instanceOf(GitException.class));
+            assertThat(e.getMessage(), is("java.lang.RuntimeException: some error"));
+            assertThat(e.getCause(), instanceOf(RuntimeException.class));
+        }
+
+        for (Callable<String> command : commands) {
+            verify(command).call();
+        }
+    }
+
+    @Test
+    public void moreCommandsThanThreads() throws Exception {
+        List<Callable<String>> commands = new ArrayList<>();
+        for (int i = 0; i < threads + 1; i++) {
+            commands.add(successfulCommand("some value"));
+        }
+
+        new GitCommandsExecutor(threads, listener).invokeAll(commands);
+
+        for (Callable<String> command : commands) {
+            verify(command).call();
+        }
+    }
+
+    @Test
+    public void lessCommandsThanThreads() throws Exception {
+        List<Callable<String>> commands = new ArrayList<>();
+        for (int i = 0; i < threads - 1; i++) {
+            commands.add(successfulCommand("some value"));
+        }
+
+        new GitCommandsExecutor(threads, listener).invokeAll(commands);
+
+        for (Callable<String> command : commands) {
+            verify(command).call();
+        }
+    }
+
+    @Test
+    public void callerThreadWasInterrupted() throws Exception {
+        long commandExecutionTime = 60_000;
+        List<Callable<String>> commands = new ArrayList<>();
+        for (int i = 0; i < threads + 1; i++) {
+            commands.add(successfulCommand("some value", commandExecutionTime));
+        }
+
+        AtomicBoolean isCallerInterrupted = new AtomicBoolean(false);
+
+        Thread caller = new Thread(() -> {
+            try {
+                new GitCommandsExecutor(threads, listener).invokeAll(commands);
+            } catch (InterruptedException e) {
+                isCallerInterrupted.set(true);
+            }
+        });
+
+        long callerStartMillis = System.currentTimeMillis();
+        caller.start();
+        caller.interrupt();
+        caller.join();
+        long callerStopMillis = System.currentTimeMillis();
+
+        for (Callable<String> command : commands) {
+            if (commands.indexOf(command) < threads) {
+                verify(command).call();
+            } else {
+                verifyZeroInteractions(command);
+            }
+        }
+        assertThat(callerStopMillis - callerStartMillis, is(lessThan(commandExecutionTime)));
+        assertThat(isCallerInterrupted.get(), is(true));
+    }
+
+    @Test
+    public void commandWasInterrupted() throws Exception {
+        Exception commandException = new InterruptedException("some interrupt");
+        List<Callable<String>> commands = asList(erroneousCommand(commandException));
+
+        try {
+            new GitCommandsExecutor(threads, listener).invokeAll(commands);
+            fail("Expected an exception but none was thrown");
+        } catch (Exception e) {
+            assertThat(e, instanceOf(InterruptedException.class));
+            assertThat(e.getMessage(), is(nullValue()));
+            assertThat(e.getCause(), is(theInstance(commandException)));
+        }
+    }
+
+    @Test
+    public void commandHadGitProblem() throws Exception {
+        Exception commandException = new GitException("some error");
+        List<Callable<String>> commands = asList(erroneousCommand(commandException));
+
+        try {
+            new GitCommandsExecutor(threads, listener).invokeAll(commands);
+            fail("Expected an exception but none was thrown");
+        } catch (Exception e) {
+            assertThat(e, instanceOf(GitException.class));
+            assertThat(e.getMessage(), is("hudson.plugins.git.GitException: some error"));
+            assertThat(e.getCause(), is(theInstance(commandException)));
+        }
+    }
+
+    @Test
+    public void commandHadUnknownProblem() throws Exception {
+        Exception commandException = new RuntimeException("some error");
+        List<Callable<String>> commands = asList(erroneousCommand(commandException));
+
+        try {
+            new GitCommandsExecutor(threads, listener).invokeAll(commands);
+            fail("Expected an exception but none was thrown");
+        } catch (Exception e) {
+            assertThat(e, instanceOf(GitException.class));
+            assertThat(e.getMessage(), is("java.lang.RuntimeException: some error"));
+            assertThat(e.getCause(), is(theInstance(commandException)));
+        }
+    }
+
+    private TaskListener mockTaskListener() {
+        TaskListener listener = mock(TaskListener.class);
+        when(listener.getLogger()).thenReturn(mock(PrintStream.class));
+        return listener;
+    }
+
+    private Callable<String> successfulCommand(String value) throws Exception {
+        Callable<String> command = mock(Callable.class);
+        when(command.call()).thenReturn(value);
+        return command;
+    }
+
+    private Callable<String> successfulCommand(String value, long commandExecutionTime) throws Exception {
+        Callable<String> command = mock(Callable.class);
+        when(command.call()).then(invocation -> {
+            Thread.sleep(commandExecutionTime);
+            return value;
+        });
+        return command;
+    }
+
+    private Callable<String> erroneousCommand(Exception exception) throws Exception {
+        Callable<String> command = mock(Callable.class);
+        when(command.call()).thenThrow(exception);
+        return command;
+    }
+}


### PR DESCRIPTION
This PR fixes an error introduced in https://github.com/jenkinsci/git-client-plugin/pull/348 where exceptions arising in git submodule update commands would be mistakenly suppressed. A test case has been added to verify the new behavior is correct.

Also, another fix is included which provides proper names to the threads in the `ExecutorService` pool via the `NamingThreadFactory` class.