### PR TITLE
Improve Revision implementation and tests

### DIFF
--- a/src/main/java/hudson/plugins/git/Revision.java
+++ b/src/main/java/hudson/plugins/git/Revision.java
@@ -1,8 +1,7 @@
 package hudson.plugins.git;
 
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.collect.Iterables;
+import static java.util.stream.Collectors.joining;
+
 import hudson.Util;
 import org.eclipse.jgit.lib.ObjectId;
 import org.kohsuke.stapler.export.Exported;
@@ -22,7 +21,7 @@ import java.util.Collection;
 public class Revision implements java.io.Serializable, Cloneable {
     private static final long serialVersionUID = -7203898556389073882L;
 
-    ObjectId           sha1;
+    ObjectId sha1;
     Collection<Branch> branches;
 
     /**
@@ -94,37 +93,26 @@ public class Revision implements java.io.Serializable, Cloneable {
     }
 
     /**
-     * containsBranchName.
+     * Returns whether the revision contains the specified branch.
      *
-     * @param name a {@link java.lang.String} object.
-     * @return true if this repository is bare
+     * @param name the name of the branch
+     * @return whether the revision contains the branch
      */
     public boolean containsBranchName(String name) {
-        for (Branch b : branches) {
-            if (b.getName().equals(name)) {
-                return true;
-            }
-        }
-        return false;
+        return branches.stream().anyMatch(branch -> branch.getName().equals(name));
     }
 
-    /**
-     * toString.
-     *
-     * @return a {@link java.lang.String} object.
-     */
+    @Override
     public String toString() {
         final String revisionName = sha1 != null ? sha1.name() : "null";
         StringBuilder s = new StringBuilder("Revision " + revisionName + " (");
         if (branches != null) {
-            Joiner.on(", ").appendTo(s,
-                    Iterables.transform(branches, from -> Util.fixNull(from.getName())));
+            s.append(branches.stream().map(Branch::getName).map(Util::fixNull).collect(joining(", ")));
         }
         s.append(')');
         return s.toString();
     }
 
-    /** {@inheritDoc} */
     @Override
     public Revision clone() {
         Revision clone;
@@ -138,13 +126,11 @@ public class Revision implements java.io.Serializable, Cloneable {
         return clone;
     }
 
-    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return sha1 != null ? 31 + sha1.hashCode() : 1;
     }
 
-    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof Revision)) {

--- a/src/test/java/hudson/plugins/git/RevisionTest.java
+++ b/src/test/java/hudson/plugins/git/RevisionTest.java
@@ -8,33 +8,33 @@ import static org.junit.Assert.*;
 
 public class RevisionTest {
 
-    final String SHA1;
-    final ObjectId objectId;
-    final Revision revision1;
+    private final String sha1;
+    private final ObjectId objectId;
+    private final Revision revision1;
 
-    final Collection<Branch> emptyCollection;
-    final Revision revision2;
+    private final Collection<Branch> emptyCollection;
+    private final Revision revision2;
 
-    final String branchName;
-    final String SHA1a;
-    final Branch branch;
-    final Collection<Branch> branchCollection;
-    final Revision revisionWithBranches;
+    private final String branchName;
+    private final String sha1a;
+    private final Branch branch;
+    private final Collection<Branch> branchCollection;
+    private final Revision revisionWithBranches;
 
     public RevisionTest() {
-        this.SHA1 = "3725b67f3daa6621dd01356c96c08a1f85b90c61";
-        this.objectId = ObjectId.fromString(SHA1);
-        this.revision1 = new Revision(objectId);
+        sha1 = "3725b67f3daa6621dd01356c96c08a1f85b90c61";
+        objectId = ObjectId.fromString(sha1);
+        revision1 = new Revision(objectId);
 
-        this.emptyCollection = new ArrayList<>();
-        this.revision2 = new Revision(objectId, emptyCollection);
+        emptyCollection = new ArrayList<>();
+        revision2 = new Revision(objectId, emptyCollection);
 
-        this.branchName = "origin/tests/getSubmodules";
-        this.SHA1a = "9ac446c472a6433fe503d294ebb7d5691b590269";
-        this.branch = new Branch(branchName, ObjectId.fromString(this.SHA1a));
-        this.branchCollection = new ArrayList<>();
-        this.branchCollection.add(this.branch);
-        this.revisionWithBranches = new Revision(ObjectId.fromString(this.SHA1a), branchCollection);
+        branchName = "origin/tests/getSubmodules";
+        sha1a = "9ac446c472a6433fe503d294ebb7d5691b590269";
+        branch = new Branch(branchName, ObjectId.fromString(sha1a));
+        branchCollection = new ArrayList<>();
+        branchCollection.add(branch);
+        revisionWithBranches = new Revision(ObjectId.fromString(sha1a), branchCollection);
     }
 
     @Test
@@ -42,7 +42,7 @@ public class RevisionTest {
         assertEquals(revision1, revision1);
         assertNotEquals(revision1, null);
         assertNotEquals(null, revision1);
-        assertNotEquals(revision1, objectId);
+        assertNotEquals(objectId, revision1);
         assertEquals(revision1, revision2);
 
         revision2.setBranches(branchCollection);
@@ -53,57 +53,55 @@ public class RevisionTest {
 
     @Test
     public void testGetSha1() {
-        assertEquals(revision1.getSha1(), objectId);
-        assertEquals(revision2.getSha1(), objectId);
+        assertEquals(objectId, revision1.getSha1());
+        assertEquals(objectId, revision2.getSha1());
     }
 
     @Test
     public void testGetSha1String() {
-        assertEquals(revision1.getSha1String(), SHA1);
-        assertEquals(revision2.getSha1String(), SHA1);
+        assertEquals(sha1, revision1.getSha1String());
+        assertEquals(sha1, revision2.getSha1String());
     }
 
     @Test
     public void testSetSha1() {
-        final String newSHA1 = "b397392d6d00af263583edeaf8f7773a619d1cf8";
-        final ObjectId newObjectId = ObjectId.fromString(newSHA1);
+        String newSha1 = "b397392d6d00af263583edeaf8f7773a619d1cf8";
+        ObjectId newObjectId = ObjectId.fromString(newSha1);
         Revision rev = new Revision(objectId);
-        assertEquals(rev.getSha1(), objectId);
+        assertEquals(objectId, rev.getSha1());
+
         rev.setSha1(newObjectId);
-        assertEquals(rev.getSha1(), newObjectId);
-        assertEquals(rev.getSha1String(), newSHA1);
+        assertEquals(newObjectId, rev.getSha1());
+        assertEquals(newSha1, rev.getSha1String());
+
         rev.setSha1(null);
         assertNull(rev.getSha1());
-        assertEquals(rev.getSha1String(), "");
+        assertEquals("", rev.getSha1String());
     }
 
     @Test
     public void testGetBranches() {
-        Collection<Branch> branches = revision1.getBranches();
-        assertTrue(branches.isEmpty());
+        assertEquals(0, revision1.getBranches().size());
 
-        branches = revision2.getBranches();
-        assertTrue(branches.isEmpty());
+        assertEquals(0, revision2.getBranches().size());
 
-        branches = revisionWithBranches.getBranches();
-        assertFalse(branches.isEmpty());
+        Collection<Branch> branches = revisionWithBranches.getBranches();
         assertTrue(branches.contains(branch));
-        assertEquals(branches.size(), 1);
+        assertEquals(1, branches.size());
     }
 
     @Test
     public void testSetBranches() {
-        final String newSHA1 = "b397392d6d00af263583edeaf8f7773a619d1cf8";
-        final ObjectId newObjectId = ObjectId.fromString(newSHA1);
         Revision rev = new Revision(objectId);
+
         rev.setBranches(emptyCollection);
         Collection<Branch> branches = rev.getBranches();
-        assertTrue(branches.isEmpty());
+        assertEquals(0, branches.size());
+
         rev.setBranches(branchCollection);
         branches = rev.getBranches();
-        assertFalse(branches.isEmpty());
         assertTrue(branches.contains(branch));
-        assertEquals(branches.size(), 1);
+        assertEquals(1, branches.size());
     }
 
     @Test
@@ -119,12 +117,14 @@ public class RevisionTest {
         String mySHA1 = "aaaaaaaa72a6433fe503d294ebb7d5691b590269";
         Branch myBranch = new Branch(myBranchName, ObjectId.fromString(mySHA1));
         Collection<Branch> branches = new ArrayList<>();
-        Revision rev = new Revision(ObjectId.fromString(this.SHA1a), branches);
+        Revision rev = new Revision(ObjectId.fromString(sha1a), branches);
         assertFalse(rev.containsBranchName(myBranchName));
+
         branches.add(myBranch);
         rev.setBranches(branches);
         assertTrue(rev.containsBranchName(myBranchName));
         assertFalse(rev.containsBranchName(branchName));
+
         branches.add(branch);
         rev.setBranches(branches);
         assertTrue(rev.containsBranchName(branchName));
@@ -132,9 +132,9 @@ public class RevisionTest {
 
     @Test
     public void testToString() {
-        assertEquals("Revision " + SHA1 + " ()", revision1.toString());
-        assertEquals("Revision " + SHA1 + " ()", revision2.toString());
-        assertEquals("Revision " + SHA1a + " (" + branchName + ")", revisionWithBranches.toString());
+        assertEquals("Revision " + sha1 + " ()", revision1.toString());
+        assertEquals("Revision " + sha1 + " ()", revision2.toString());
+        assertEquals("Revision " + sha1a + " (" + branchName + ")", revisionWithBranches.toString());
     }
 
     @Test
@@ -152,18 +152,16 @@ public class RevisionTest {
     @Test
     public void testClone() {
         Revision revision1Clone = revision1.clone();
-        assertEquals(revision1Clone.getSha1(), objectId);
+        assertEquals(objectId, revision1Clone.getSha1());
 
         Revision revision2Clone = revision2.clone();
-        assertEquals(revision2Clone.getSha1String(), SHA1);
+        assertEquals(sha1, revision2Clone.getSha1String());
 
         Revision nullRevision = new Revision(null);
         Revision clonedRevision = nullRevision.clone();
-        assertEquals(clonedRevision, nullRevision);
+        assertEquals(nullRevision, clonedRevision);
 
-        Collection<Branch> branches = revisionWithBranches.getBranches();
         Revision revisionWithBranchesClone = revisionWithBranches.clone();
-        Collection<Branch> branchesCloned = revisionWithBranchesClone.getBranches();
         assertTrue(revisionWithBranchesClone.containsBranchName(branchName));
     }
 


### PR DESCRIPTION
implementation
* no Guava required
* use Java 8 features for improved clarity
* fix wrong Javadoc
* remove non-required {@inheritDoc}

tests
* reduce variable scope
* follow naming conventions
* fix parameter order when using assertEquals(expected, actual)
* remove unused variables
* misc minor improvements