### PR TITLE
[JENKINS-53279] Remove deprecated reference

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
@@ -1,11 +1,11 @@
 package org.jenkinsci.plugins.gitclient;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import hudson.FilePath;
 import hudson.ProxyConfiguration;
 import hudson.plugins.git.GitException;
 import hudson.remoting.Channel;
-import jenkins.model.Jenkins.MasterComputer;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
@@ -26,7 +26,7 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
     /** {@inheritDoc} */
     public <T> T withRepository(RepositoryCallback<T> callable) throws IOException, InterruptedException {
         try (Repository repo = getRepository()) {
-            return callable.invoke(repo, MasterComputer.localChannel);
+            return callable.invoke(repo, FilePath.localChannel);
         }
     }
 


### PR DESCRIPTION
This fixes an issue reporting missing ServletException on agent side, as
MasterComputer is pulling it, but FilePath isn't.