### PR TITLE
Depend on Jenkins 2.107.3 and test 2.121.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
 // build both versions, retry test failures
-buildPlugin(jenkinsVersions: [null, '2.121.1'],
+buildPlugin(jenkinsVersions: [null, '2.121.3'],
             findbugs: [run:true, archive:true, unstableTotalAll: '0'],
             failFast: false)

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>2.5.2</version>
+      <version>3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
-    <jgit.version>5.1.1.201809181055-r</jgit.version>
+    <jgit.version>5.1.2.201810061102-r</jgit.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -21,7 +21,6 @@ import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitLockFailedException;
 import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
-import hudson.util.IOUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -47,6 +46,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.time.FastDateFormat;
 import org.eclipse.jgit.api.AddNoteCommand;
 import org.eclipse.jgit.api.CommitCommand;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/Netrc.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/Netrc.java
@@ -2,11 +2,9 @@ package org.jenkinsci.plugins.gitclient;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.plugins.git.GitException;
-import hudson.util.IOUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;


### PR DESCRIPTION
Jenkins 2.121.3 is the most recent 2.121 release.

The Jenkins 2.138.1 release introduces a new requirement for instance-identity that needs more analysis before testing with 2.138.1

Jenkins 2.107 is a year newer than Jenkins 2.60.3 and is already superseded by two LTS releases.