### PR TITLE
[JENKINS-53933] set file permissions to allow use of openssh on windows

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -46,13 +46,20 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
+import java.nio.file.attribute.UserPrincipalLookupService;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -127,6 +134,29 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * ssh configurations).
      */
     private static final boolean CALL_SETSID;
+
+    /**
+     * Needed file permission for OpenSSH client that is made by Windows,
+     * this will remove unwanted users and inherited permissions
+     * which is required when the git client is using the SSH to clone
+     *
+     * The ssh client that the git client ships ignores file permission on Windows
+     * Which the PowerShell team at Microsoft decided to fix in their port of OpenSSH
+     */
+    static final EnumSet<AclEntryPermission> ACL_ENTRY_PERMISSIONS = EnumSet.of(
+        AclEntryPermission.READ_DATA,
+        AclEntryPermission.WRITE_DATA,
+        AclEntryPermission.APPEND_DATA,
+        AclEntryPermission.READ_NAMED_ATTRS,
+        AclEntryPermission.WRITE_NAMED_ATTRS,
+        AclEntryPermission.EXECUTE,
+        AclEntryPermission.READ_ATTRIBUTES,
+        AclEntryPermission.WRITE_ATTRIBUTES,
+        AclEntryPermission.DELETE,
+        AclEntryPermission.READ_ACL,
+        AclEntryPermission.SYNCHRONIZE
+    );
+
     static {
         acceptSelfSignedCertificates = Boolean.getBoolean(GitClient.class.getName() + ".untrustedSSL");
         CALL_SETSID = setsidExists() && USE_SETSID;
@@ -1869,8 +1899,60 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 w.println(s);
             }
         }
-        new FilePath(key).chmod(0400);
+        if (launcher.isUnix()) {
+            new FilePath(key).chmod(0400);
+        } else {
+            fixSshKeyOnWindows(key);
+        }
+
         return key;
+    }
+
+    /* package protected for testability */
+    void fixSshKeyOnWindows(File key) throws GitException {
+        if (launcher.isUnix()) return;
+
+        Path file = Paths.get(key.toURI());
+
+        AclFileAttributeView fileAttributeView = Files.getFileAttributeView(file, AclFileAttributeView.class);
+        if (fileAttributeView == null) return;
+
+        String username = getWindowsUserName(fileAttributeView);
+        if (StringUtils.isBlank(username)) return;
+
+        try {
+            UserPrincipalLookupService userPrincipalLookupService = file.getFileSystem().getUserPrincipalLookupService();
+            UserPrincipal userPrincipal = userPrincipalLookupService.lookupPrincipalByName(username);
+            AclEntry aclEntry = AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(userPrincipal)
+                .setPermissions(ACL_ENTRY_PERMISSIONS)
+                .build();
+            fileAttributeView.setAcl(Collections.singletonList(aclEntry));
+        } catch (IOException | UnsupportedOperationException e) {
+            throw new GitException("Error updating file permission for \"" + key.getAbsolutePath() + "\"");
+        }
+    }
+
+    /* package protected for testability */
+    String getWindowsUserName(AclFileAttributeView aclFileAttributeView) {
+        if (launcher.isUnix()) return "";
+
+        try {
+            return aclFileAttributeView.getOwner().getName();
+        } catch (IOException ignored) {
+            String username = System.getenv("USERNAME");
+            if (StringUtils.isBlank(username)) return "";
+
+            String domain = System.getenv("USERDOMAIN");
+            if (StringUtils.isNotBlank(domain) && !username.endsWith("$")) {
+                username = domain + "\\" + username;
+            } else if (username.endsWith("$")) {
+                username = "BUILTIN\\Administrators";
+            }
+
+            return username;
+        }
     }
 
     /* package protected for testability */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIWindowsFilePermissionsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIWindowsFilePermissionsTest.java
@@ -1,0 +1,78 @@
+package org.jenkinsci.plugins.gitclient;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.UserPrincipal;
+import java.nio.file.attribute.UserPrincipalLookupService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+public class CliGitAPIWindowsFilePermissionsTest {
+
+    private CliGitAPIImpl cliGit;
+    private File file;
+    private AclFileAttributeView fileAttributeView;
+    private UserPrincipal userPrincipal;
+    private String username;
+
+    @Before
+    public void beforeEach() throws Exception {
+        assumeTrue(isWindows());
+        cliGit = new CliGitAPIImpl("git", new File("."), null, null);
+        file = cliGit.createTempFile("permission", ".suff");
+        Path path = Paths.get(file.toURI());
+        fileAttributeView = Files.getFileAttributeView(path, AclFileAttributeView.class);
+        assertNotNull(fileAttributeView);
+        UserPrincipalLookupService userPrincipalLookupService = path.getFileSystem().getUserPrincipalLookupService();
+        assertNotNull(userPrincipalLookupService);
+        username = cliGit.getWindowsUserName(fileAttributeView);
+        assertNotNull(username);
+        userPrincipal = userPrincipalLookupService.lookupPrincipalByName(username);
+        assertNotNull(userPrincipal);
+        assertEquals(userPrincipal, fileAttributeView.getOwner());
+    }
+
+    @Test
+    public void test_windows_file_permission_is_set_correctly() throws Exception {
+        cliGit.fixSshKeyOnWindows(file);
+        assertEquals(1, fileAttributeView.getAcl().size());
+        AclEntry aclEntry = fileAttributeView.getAcl().get(0);
+        assertTrue(aclEntry.flags().isEmpty());
+        assertEquals(CliGitAPIImpl.ACL_ENTRY_PERMISSIONS, aclEntry.permissions());
+        assertEquals(userPrincipal, aclEntry.principal());
+        assertEquals(AclEntryType.ALLOW, aclEntry.type());
+    }
+
+    @Test
+    public void test_windows_file_permission_are_incorrect() throws Exception {
+        // By default files include System and builtin administrators
+        assertNotSame(1, fileAttributeView.getAcl().size());
+        for (AclEntry entry : fileAttributeView.getAcl()) {
+            if (entry.principal().equals(userPrincipal)) {
+                assertNotSame(CliGitAPIImpl.ACL_ENTRY_PERMISSIONS, entry.permissions());
+            }
+        }
+    }
+
+    @Test
+    public void test_windows_username_lookup() {
+        assertEquals(username, userPrincipal.getName());
+    }
+
+    /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */
+    private boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
+}


### PR DESCRIPTION
See [JENKINS-53933](https://issues.jenkins-ci.org/browse/JENKINS-53933)

~Please say if I messed up the import statements~ I did 🤭

Yay for tests! 🙌

Hopefully we can get this in before 4.0 release!
We have had success with this and using OpenSSH from Microsoft 😎