### PR TITLE
Stable 2.7 fix credentials test reporting failure

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -61,8 +61,8 @@ import org.junit.rules.Timeout;
 public class CredentialsTest {
 
     // Required for credentials use
-    @ClassRule
-    public static final JenkinsRule j = new JenkinsRule();
+    @Rule
+    public final JenkinsRule j = new JenkinsRule();
 
     private final String gitImpl;
     private final String gitRepoURL;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -350,7 +350,7 @@ public class CredentialsTest {
      * @return true if another test should be allowed to start
      */
     private boolean testPeriodNotExpired() {
-        return (System.currentTimeMillis() - firstTestStartTime) < ((180 - 120) * 1000L);
+        return (System.currentTimeMillis() - firstTestStartTime) < ((180 - 30) * 1000L);
     }
 
     @Test


### PR DESCRIPTION
I have a large collection of authentication data In my private test environment that I use to test the git client plugin authentication on multiple platforms and with both git implementations.  

The prior implementation tried to maximize the number of tests executed within the time limit by using a `ClassRule` based JenkinsRule.  The tests run correctly with the ClassRule, but the Jenkins based reporting of the results causes a spurious error.

Rather than attempt to resolve the spurious error, it is simpler to use a `Rule` instead of a `ClassRule`.  The `Rule` creates a JenkinsRule for every test case.  That is less efficient at runtime but gives the desired results in test reporting.