### PR TITLE
Update jsch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jsch</artifactId>
-      <version>0.1.54.1</version>
+      <version>0.1.54.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/jsch-plugin/commit/347d5c5af36232f2dd06b44d9afb4d216e302d0b and avoids a warning during tests.