### PR TITLE
[JENKINS-55284] CLI git tag collision change

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -435,6 +435,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
         ArgumentListBuilder args = new ArgumentListBuilder();
         args.add("fetch", "-t");
+        if (isAtLeastVersion(2, 20, 0, 0)) {
+            /* CLI git 2.20.0 fixed a long-standing bug that now requires --force to update existing tags */
+            args.add("--force");
+        }
 
         if (remoteName == null)
             remoteName = getDefaultRemote();


### PR DESCRIPTION
Adapt plugin to CLI git 2.20.0 bug fix.

The git fetch behavior prior to git 2.20.0 was to update existing tags without requiring a --force.  The newer versions require --force to update existing tags.

Retain existing behavior for earlier versions, only use the --force option to fetch for new versions of command line git.

Fix [JENKINS-55284](https://issues.jenkins-ci.org/browse/JENKINS-55284) CLI git tag collision change.

@jenkinsci/code-reviewers 