### PR TITLE
Use JGit 4.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
-    <jgit.version>4.5.4.201711221230-r</jgit.version>
+    <jgit.version>v4.5.5.201812240535-r</jgit.version>
     <jgit.javadoc.version>4.5.0.201609210915-r</jgit.javadoc.version>
   </properties>
 


### PR DESCRIPTION
Upgrade from JGit 4.5.4 to JGit 4.5.5 to include the stale file handle improvements that were made in the git configuration file reader.