### PR TITLE
Add support for first-parent arg when fetching the list of changes from git

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -85,14 +85,15 @@ public interface ChangelogCommand extends GitCommand {
     ChangelogCommand includes(ObjectId rev);
 
     /**
-     * Sets the firstParent private variable to true
+     * Limits the changelog to only follow the first parent commit.  If there
+     * are merge commits in the changelog, only follow the first parent.
      */
     ChangelogCommand firstParent();
 
     /**
-     * Sets the firstParent private variable to boolean param
+     * Enable or disable the firstParent option in the calculation of the changelog.
      *
-     * @param firstParent a {@link java.lang.boolean} object.
+     * @param firstParent
      */
     ChangelogCommand firstParent(boolean firstParent);
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -87,13 +87,15 @@ public interface ChangelogCommand extends GitCommand {
     /**
      * Limits the changelog to only follow the first parent commit.  If there
      * are merge commits in the changelog, only follow the first parent.
+     * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
      */
     ChangelogCommand firstParent();
 
     /**
      * Enable or disable the firstParent option in the calculation of the changelog.
      *
-     * @param firstParent
+     * @param firstParent a boolean object determining if the changelog is limited to first parent commits or not
+     * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
      */
     ChangelogCommand firstParent(boolean firstParent);
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -85,6 +85,18 @@ public interface ChangelogCommand extends GitCommand {
     ChangelogCommand includes(ObjectId rev);
 
     /**
+     * Sets the firstParent private variable to true
+     */
+    ChangelogCommand firstParent();
+
+    /**
+     * Sets the firstParent private variable to boolean param
+     *
+     * @param firstParent a {@link java.lang.boolean} object.
+     */
+    ChangelogCommand firstParent(boolean firstParent);
+
+    /**
      * Sets the {@link java.io.OutputStream} that receives the changelog.
      *
      * This takes {@link java.io.Writer} and not {@link java.io.OutputStream} because the changelog is a textual format,

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1035,6 +1035,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             private Integer n = null;
             private Writer out = null;
+            private boolean firstParent;
 
             @Override
             public ChangelogCommand excludes(String rev) {
@@ -1056,6 +1057,15 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @Override
             public ChangelogCommand includes(ObjectId rev) {
                 return includes(rev.name());
+            }
+
+            public ChangelogCommand firstParent() {
+                return firstParent(true);
+            }
+
+            public ChangelogCommand firstParent(boolean firstParent) {
+                this.firstParent = firstParent;
+                return this;
             }
 
             @Override
@@ -1085,6 +1095,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     args.add(rev);
 
                 if (out==null)  throw new IllegalStateException();
+
+                if (firstParent) {
+                   args.add("--first-parent");
+                }
 
                 // "git whatchanged" std output gives us byte stream of data
                 // Commit messages in that byte stream are UTF-8 encoded.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1059,10 +1059,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return includes(rev.name());
             }
 
+            @Override
             public ChangelogCommand firstParent() {
                 return firstParent(true);
             }
 
+            @Override
             public ChangelogCommand firstParent(boolean firstParent) {
                 this.firstParent = firstParent;
                 return this;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1974,6 +1974,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @Override
             public RevListCommand firstParent(boolean firstParent) {
                 this.firstParent = firstParent;
+                if (firstParent) {
+                    listener.getLogger().println("[WARNING] JGit doesn't support --first-parent option. This flag is ignored!");
+                }
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1070,7 +1070,6 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private RevWalk walk = new RevWalk(or);
             private Writer out;
             private boolean hasIncludedRev = false;
-            private boolean firstParent;
 
             @Override
             public ChangelogCommand excludes(String rev) {
@@ -1118,7 +1117,6 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             public ChangelogCommand firstParent(boolean firstParent) {
-                this.firstParent = firstParent;
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1070,6 +1070,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private RevWalk walk = new RevWalk(or);
             private Writer out;
             private boolean hasIncludedRev = false;
+            private boolean firstParent;
 
             @Override
             public ChangelogCommand excludes(String rev) {
@@ -1110,6 +1111,15 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 } catch (IOException e) {
                     throw new GitException("Error: jgit includes() in " + workspace + " " + e.getMessage(), e);
                 }
+            }
+
+            public ChangelogCommand firstParent() {
+                return firstParent(true);
+            }
+
+            public ChangelogCommand firstParent(boolean firstParent) {
+                this.firstParent = firstParent;
+                return this;
             }
 
             @Override

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -4727,6 +4727,7 @@ public abstract class GitAPITestCase extends TestCase {
     /*
      * Verify that .firstParent() shows no changes when doing a merge
      */
+    @NotImplementedInJGit
     public void test_changelog_with_merge_commit_and_first_parent() throws Exception {
         w.init();
         w.commitEmpty("init");
@@ -4744,12 +4745,9 @@ public abstract class GitAPITestCase extends TestCase {
         String mergeMessage = "Merge message to be tested.";
         w.git.merge().setMessage(mergeMessage).setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF).setRevisionToMerge(w.git.getHeadRev(w.repoPath(), "branch-1")).execute();
 
-        if (w.git instanceof CliGitAPIImpl) {
-            // Only CliGit currently supports firstParent
-            StringWriter writer = new StringWriter();
-            w.git.changelog().firstParent().to(writer).execute();
-            assertThat(writer.toString(),isEmptyString());
-        }
+        StringWriter writer = new StringWriter();
+        w.git.changelog().firstParent().to(writer).execute();
+        assertThat(writer.toString(),isEmptyString());
     }
 
     /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */


### PR DESCRIPTION
This is the git-client-plugin side of the changes to implement https://issues.jenkins-ci.org/browse/JENKINS-50366.  There are changes in the git-plugin as well, I'll submitted a pull request there as well.