### PR TITLE
[JENKINS-55284] Force update existing tags

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -397,6 +397,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 ArgumentListBuilder args = new ArgumentListBuilder();
                 args.add("fetch");
                 args.add(tags ? "--tags" : "--no-tags");
+                if (USE_FORCE_FETCH && isAtLeastVersion(2, 20, 0, 0)) {
+                    /* CLI git 2.20.0 fixed a long-standing bug that now requires --force to update existing tags */
+                    args.add("--force");
+                }
                 if (isAtLeastVersion(1,7,1,0))
                     args.add("--progress");
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1335,29 +1335,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue(sha1.equals(r.cmd("git rev-list --no-walk --max-count=1 HEAD")));
     }
 
-    public void test_fetch_with_updated_tag() throws Exception {
-        WorkingArea r = new WorkingArea();
-        r.init();
-        r.commitEmpty("init");
-        r.tag("t");
-        String sha1 = r.cmd("git rev-list --no-walk --max-count=1 t");
-
-        w.init();
-        w.cmd("git remote add origin " + r.repoPath());
-        w.git.fetch("origin", new RefSpec[] {null});
-        assertTrue(sha1.equals(r.cmd("git rev-list --no-walk --max-count=1 t")));
-
-        r.touch("file.txt");
-        r.git.add("file.txt");
-        r.git.commit("update");
-        r.tag("-d t");
-        r.tag("t");
-        sha1 = r.cmd("git rev-list --no-walk --max-count=1 t");
-        w.git.fetch("origin", new RefSpec[] {null});
-        assertTrue(sha1.equals(r.cmd("git rev-list --max-count=1 t")));
-
-    }
-
     public void test_fetch_shallow() throws Exception {
         w.init();
         w.git.setRemoteUrl("origin", localMirror());


### PR DESCRIPTION
Place the test in the GitClientTest parameterized test class so that it will be tested on all three implementations and will test with the intentionally randomized fetch parameters.