### PR TITLE
WIP: test JTH 2.45 (with space in tmp dir path)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.32</version>
+    <version>3.33-20190110.085245-1</version>
     <relativePath />
   </parent>
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1369,7 +1369,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertThat(getBranchNames(remoteBranches), containsInAnyOrder("origin/master", "origin/branch1", "origin/branch2", "origin/HEAD"));
 
         /* Remove branch1 from bare repo using original repo */
-        w.cmd("git push " + bare.repoPath() + " :branch1");
+        w.launchCommand("git", "push", bare.repoPath(), ":branch1");
 
         List<RefSpec> refSpecs = Arrays.asList(new RefSpec("+refs/heads/*:refs/remotes/origin/*"));
 
@@ -1401,7 +1401,7 @@ public abstract class GitAPITestCase extends TestCase {
         String sha1 = r.cmd("git rev-list --no-walk --max-count=1 HEAD");
 
         w.init();
-        w.cmd("git remote add origin " + r.repoPath());
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
         w.git.fetch(new URIish(r.repo.toString()), Collections.<RefSpec>emptyList());
         assertTrue(sha1.equals(r.cmd("git rev-list --no-walk --max-count=1 HEAD")));
     }
@@ -1538,7 +1538,7 @@ public abstract class GitAPITestCase extends TestCase {
         r.git.branch("another");
 
         w.init();
-        w.cmd("git remote add origin " + r.repoPath());
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
         w.cmd("git fetch origin");
         Set<Branch> branches = w.git.getRemoteBranches();
         assertBranchesExist(branches, "origin/master", "origin/test", "origin/another");
@@ -1554,7 +1554,7 @@ public abstract class GitAPITestCase extends TestCase {
         r.tag("yet_another");
 
         w.init();
-        w.cmd("git remote add origin " + r.repoPath());
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
         w.cmd("git fetch origin");
         Set<String> local_tags = w.git.getTagNames("*test");
         Set<String> tags = w.git.getRemoteTagNames("*test");
@@ -1572,7 +1572,7 @@ public abstract class GitAPITestCase extends TestCase {
         r.tag("yet_another");
 
         w.init();
-        w.cmd("git remote add origin " + r.repoPath());
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
         w.cmd("git fetch origin");
         Set<String> allTags = w.git.getRemoteTagNames(null);
         assertTrue("tag 'test' not listed", allTags.contains("test"));
@@ -1836,7 +1836,7 @@ public abstract class GitAPITestCase extends TestCase {
 
         WorkingArea r = new WorkingArea();
         r.init(true);
-        w.cmd("git remote add origin " + r.repoPath());
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
 
         w.git.push("origin", "master");
         String remoteSha1 = r.cmd("git rev-parse master").substring(0, 40);
@@ -1894,7 +1894,7 @@ public abstract class GitAPITestCase extends TestCase {
         r.cmd("git checkout -b other");
 
         w.init();
-        w.cmd("git remote add origin " + r.repoPath());
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
         w.cmd("git pull --depth=1 origin master");
 
         w.touch("file2");
@@ -2909,13 +2909,13 @@ public abstract class GitAPITestCase extends TestCase {
         WorkingArea ws2 = w.init();
 
         ws1.commitEmpty("c");
-        ws1.cmd("git remote add origin " + r.repoPath());
+        ws1.launchCommand("git", "remote", "add", "origin", r.repoPath());
 
         ws1.cmd("git push origin master:b1");
         ws1.cmd("git push origin master:b2");
         ws1.cmd("git push origin master");
 
-        ws2.cmd("git remote add origin " + r.repoPath());
+        ws2.launchCommand("git", "remote", "add", "origin", r.repoPath());
         ws2.cmd("git fetch origin");
 
         // at this point both ws1&ws2 have several remote tracking branches


### PR DESCRIPTION
Following jenkinsci/plugin-pom#93, here is a test PR to see how jenkinsci/git-client-plugin unit tests behave when there is a space character in their temporary workdir path.

The first commit (9283c16) bumps `plugin-pom` to a SNAPSHOT version for testing, and the second commit (3cbdbe3) fixes numerous simple tests failures by replacing some `WorkingArea.cmd("git some command " + r.repoPath());` with `WorkingArea.launchCommand("git", "some", "command", r.repoPath());` (the former syntax assumes it is safe to split the command line by spaces, which is no more true).

After this second commit, at least on Linux and with a recent `git` version, the only remaining tests failures are related to submodules handling in the `CliGitAPIImpl`.  It seems to all boil down to the fix for [JENKINS-46504](https://issues.jenkins-ci.org/browse/JENKINS-46504) being based on the assumption that submodules URLs are properly escaped (as in RFC1738, with no space character - see comments for `CliGitAPIImpl.SUBMODULE_REMOTE_PATTERN_STRING`).  I don't think it is safe to assume so. Of course, I could modify test cases to make it true there and make the tests pass, but in reality, `git` seems to be perfectly happy with non-escaped URLs, and `git submodule add` does nothing by itself to enforce URL encoding, so I can imagine URLs with spaces are a pretty common case in the wild.
I'm not sure what the proper fix would be:
 - using `git config -f .gitmodules --get-regexp ... --name-only` would be the obvious solution for listing submodules, but this `--name-only` option has only been introduced in `git 2.6`.
 - playing with the parsing regexp themselves, I've been able to somehow improve the situation (I think), but there are still some fundamental ambiguities in the `git config --get-regexp` (as soon as you introduce the `".url "` substring, with a space, in either the submodule path or in its remote URL)
 - getting both `submodule.*.url` and `submodule.*.path`, and looking for pairs of keys, might be a solution to get an unambiguous list of submodules, but it sounds tedious.
 - maybe something with the `--null` option? (I've not tried it yet, but it looks like this option has been around longer than `--name-only`)
