### PR TITLE
JENKINS-55526 - reduce severity of reference repo warnings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -675,9 +675,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 if (reference != null && !reference.isEmpty()) {
                     File referencePath = new File(reference);
                     if (!referencePath.exists())
-                        listener.error("Reference path does not exist: " + reference);
+                        listener.getLogger().println("[WARNING] Reference path does not exist: " + reference);
                     else if (!referencePath.isDirectory())
-                        listener.error("Reference path is not a directory: " + reference);
+                        listener.getLogger().println("[WARNING] Reference path is not a directory: " + reference);
                     else {
                         // reference path can either be a normal or a base repository
                         File objectsPath = new File(referencePath, ".git/objects");
@@ -686,7 +686,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                             objectsPath = new File(referencePath, "objects");
                         }
                         if (!objectsPath.isDirectory())
-                            listener.error("Reference path does not contain an objects directory (no git repo?): " + objectsPath);
+                            listener.getLogger().println("[WARNING] Reference path does not contain an objects directory (not a git repo?): " + objectsPath);
                         else {
                             File alternates = new File(workspace, ".git/objects/info/alternates");
                             try (PrintWriter w = new PrintWriter(alternates, Charset.defaultCharset().toString())) {
@@ -1250,9 +1250,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 if ((ref != null) && !ref.isEmpty()) {
                     File referencePath = new File(ref);
                     if (!referencePath.exists())
-                        listener.error("Reference path does not exist: " + ref);
+                        listener.getLogger().println("[WARNING] Reference path does not exist: " + ref);
                     else if (!referencePath.isDirectory())
-                        listener.error("Reference path is not a directory: " + ref);
+                        listener.getLogger().println("[WARNING] Reference path is not a directory: " + ref);
                     else
                         args.add("--reference", ref);
                 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1425,9 +1425,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     if (reference != null && !reference.isEmpty()) {
                         File referencePath = new File(reference);
                         if (!referencePath.exists())
-                            listener.error("Reference path does not exist: " + reference);
+                            listener.getLogger().println("[WARNING] Reference path does not exist: " + reference);
                         else if (!referencePath.isDirectory())
-                            listener.error("Reference path is not a directory: " + reference);
+                            listener.getLogger().println("[WARNING] Reference path is not a directory: " + reference);
                         else {
                             // reference path can either be a normal or a base repository
                             File objectsPath = new File(referencePath, ".git/objects");
@@ -1436,7 +1436,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                                 objectsPath = new File(referencePath, "objects");
                             }
                             if (!objectsPath.isDirectory())
-                                listener.error("Reference path does not contain an objects directory (no git repo?): " + objectsPath);
+                                listener.getLogger().println("[WARNING] Reference path does not contain an objects directory (no git repo?): " + objectsPath);
                             else {
                                 try {
                                     File alternates = new File(workspace, ".git/objects/info/alternates");


### PR DESCRIPTION
The messages are only warnings, not errors.  Listing them as errors on the listener is incorrect.  They are not fatal.  If a reference repository is specified incorrectly, the message should alert the user because the clone will need more disc space and more time.  The clone does not fail when a reference repository is missing.