### PR TITLE
Require Jenkins 2.107

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
 // build both versions, retry test failures
-buildPlugin(jenkinsVersions: [null, '2.150.1'],
+buildPlugin(jenkinsVersions: [null, '2.150.2'],
             findbugs: [run:true, archive:true, unstableTotalAll: '0'],
             failFast: false)

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   </scm>
 
   <properties>
-    <revision>3.0.0-beta6</revision>
+    <revision>3.0.0-beta7</revision>
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.107.3</jenkins.version>
     <java.level>8</java.level>
     <jgit.version>5.2.1.201812262042-r</jgit.version>
   </properties>


### PR DESCRIPTION
Test with the latest Jenkins LTS release, Jenkins 2.150.2.

Update the version number in the pom file for a future release