### PR TITLE
[JENKINS-55875] Forcibly update git submodules

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1234,7 +1234,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 submoduleInit();
 
                 ArgumentListBuilder args = new ArgumentListBuilder();
-                args.add("submodule", "update");
+
+                // Force the update, in the same manner we force checkouts
+                args.add("submodule", "update", "--force");
                 if (recursive) {
                     args.add("--init", "--recursive");
                 }


### PR DESCRIPTION
This change resolves https://issues.jenkins-ci.org/browse/JENKINS-55875

Currently, submodules are not updated with `--force`. This means if there is a local change, then the checkout fails, causing the build to fail.

This can be worked round by cleaning the repository before every checkout, but this makes build jobs much slower, as they aren't able to be incrementally built, as the entire workspace has to be thrown away each time, or requires manual intervention.

Instead, this changes the checkout to be done forcefully, which matches how the checkout of the top level Git repository works.

This change should not have any harmful effects - it will only cause builds which were failing to now succeed.