### PR TITLE
Update test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>2.4</version>
+      <version>3.1.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
-      <version>2.6</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Use latest released versions of:
* equalsverifier
* objenesis

Because these are purely test dependencies, they should not change the plugin packaging or plugin features.