### PR TITLE
Use parent pom 3.37

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.23.4</version>
+      <version>2.24.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.33</version>
+    <version>3.37</version>
     <relativePath />
   </parent>
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/SubmodulePatternStringTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/SubmodulePatternStringTest.java
@@ -45,6 +45,10 @@ public class SubmodulePatternStringTest {
             "https://github.com/MarkEWaite/JENKINS-46054",
             "https://mark.url:some%20pass.urlify@gitroot/repo",
             "ssh://git.example.com/MarkEWaite/JENKINS-46054",
+            // JENKINS-56175 notes that submodule URL's with spaces don't
+            // work in the git plugin. This test shows they don't work at
+            // one level. Other levels also have failures.
+            // "file://gitroot/has space",
         };
         String[] remoteNames = {
             "has space",
@@ -52,12 +56,15 @@ public class SubmodulePatternStringTest {
             "simple",
             "simple.name",
             "simple.url.name",
+            "url",
+            "modules/module.named.url"
         };
         String [] suffixes = {
             "",
             ".git",
             ".url",
             ".url.git",
+            ".git.url",
         };
         for (String repoUrlParam : repoUrls) {
             for (String repoUrlSuffix : suffixes) {


### PR DESCRIPTION
Update to the most recent plugin parent pom so that the latest parent pom improvements are available to the plugin.  That includes automatic creation of temporary directories with a space in the directory path.

Three tests needed adaptation for spaces in temporary directory paths due to [JENKINS-56175](https://issues.jenkins-ci.org/browse/JENKINS-56175), "Submodule with space in git URL won't update".  The tests avoid the bug rather than fixing the bug.  

My initial attempts to fix [JENKINS-56175](https://issues.jenkins-ci.org/browse/JENKINS-56175) failed during integration testing.  I don't want to spend time fixing that corner case when there are many much broader cases that need attention before the release of git client plugin 3.0.0 and git plugin 4.0.0.