### PR TITLE
Avoid test fails: 50 sec limit on credentials test

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -350,7 +350,7 @@ public class CredentialsTest {
      * @return true if another test should be allowed to start
      */
     private boolean testPeriodNotExpired() {
-        return (System.currentTimeMillis() - firstTestStartTime) < ((180 - 30) * 1000L);
+        return (System.currentTimeMillis() - firstTestStartTime) < ((180 - 130) * 1000L);
     }
 
     @Test


### PR DESCRIPTION
The junit test reporter plugin that reports test results during test execution will incorrectly report a test failure if the unit test XML file is kept open with incomplete content.  The credentials test leaves the content open for the duration of the test and that frequently fails due to the incomplete content in the open file.