### PR TITLE
JENKINS-55948 - git parameter plugin calls fail with git client 3.x

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -1931,4 +1931,10 @@ public class GitClientTest {
         assertThat(tags, not(hasItems(updatedTag)));
         assertThat(tags, hasItems(tag));
     }
+
+    @Test
+    @Issue("JENKINS-55948")
+    public void testGitClientCalledFromGitParameterPlugin() throws Exception {
+        fail("JENKINS-55948 must be fixed before release of git client plugin 3.0.0");
+    }
 }


### PR DESCRIPTION
Fix JENKINS-55948 - git parameter plugin calls fail with git client 3.x

Need to identify the cause of the failure and fix it.