### PR TITLE
[JENKINS-50394] Add ability for JenkinsRule tests to insert custom GitClient implementation

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitJenkinsRuleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitJenkinsRuleTest.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.EnvVars;
+import hudson.model.TaskListener;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class GitJenkinsRuleTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testMockClient() throws IOException, InterruptedException {
+        System.setProperty(Git.class.getName() + ".mockClient", MyMockGitClient.class.getName());
+        try {
+            Git git = new Git(null, null).in(new File(".")).using("Hello World");
+            final GitClient client = git.getClient();
+            assertThat(client, IsInstanceOf.instanceOf(MyMockGitClient.class));
+            MyMockGitClient c = (MyMockGitClient) client;
+            assertEquals("Hello World", c.exe);
+        } finally {
+            System.clearProperty(Git.class.getName() + ".mockClient");
+        }
+
+    }
+
+    public static class MyMockGitClient extends JGitAPIImpl {
+
+        final String exe;
+        final EnvVars env;
+
+        public MyMockGitClient(String exe, EnvVars env, File workspace, TaskListener listener) {
+            super(workspace, listener);
+            this.exe = exe;
+            this.env = env;
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitTest.java
@@ -1,12 +1,20 @@
 package org.jenkinsci.plugins.gitclient;
 
+import hudson.EnvVars;
 import hudson.FilePath;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+
+import hudson.model.TaskListener;
 import org.eclipse.jgit.lib.ObjectId;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;


### PR DESCRIPTION
As what is returned from Git.getClient

## [JENKINS-50394](https://issues.jenkins-ci.org/browse/JENKINS-50394) - When new commits are pushed to the repository while GitSCMSource is discovering branches then MissingObjectException

To be able to verify a fix for JENKINS-50394 I needed some way of detecting various phases in the descovery process of AbstractGitSCMSource, an easy way would be if I can use a custom "mocked" version of GitClient during the test that injects some more refs in the middle of the fetch/discoverBranches sequence.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [X] I have added tests that verify my changes
- [X] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [X] No Javadoc warnings were introduced with my changes
- [X] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [X] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

Added a guard so that this only activates during JenkinsRule tests so that normal production code won't be affected of able to be otherwise "persuaded".

Upstream to https://github.com/jenkinsci/git-plugin/pull/702