### PR TITLE
[JENKINS-55655] Use CLI git in Blue Ocean

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
@@ -49,6 +49,8 @@ public class FilePermissionsTest {
     @BeforeClass
     public static void createTestRepo() throws IOException, InterruptedException {
         if (isWindows()) return;
+        // Configure git client for unit test execution
+        hudson.Main.isUnitTest = true;
         repo = com.google.common.io.Files.createTempDir();
         Git.with(listener, new hudson.EnvVars()).in(repo).getClient().init();
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitTest.java
@@ -29,7 +29,7 @@ import org.junit.runners.Parameterized;
 public class GitTest {
 
     /* Default class of GitClient absent other modifiers */
-    private static final Class DEFAULT_CLASS = JGitAPIImpl.class;
+    private static final Class DEFAULT_CLASS = CliGitAPIImpl.class;
 
     /* A known commit from the git-client-plugin repository */
     private static ObjectId expectedCommit = null;
@@ -49,7 +49,7 @@ public class GitTest {
             {"git",           CliGitAPIImpl.class},
             {"jgit",          JGitAPIImpl.class  },
             {"jgitapache",    JGitAPIImpl.class  },
-            // {GitTool.DEFAULT, CliGitAPIImpl.class},
+            {GitTool.DEFAULT, CliGitAPIImpl.class},
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitTest.java
@@ -8,13 +8,14 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import hudson.model.TaskListener;
+import hudson.plugins.git.GitTool;
+
 import org.eclipse.jgit.lib.ObjectId;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
 
-import org.hamcrest.core.IsInstanceOf;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -27,67 +28,91 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class GitTest {
 
+    /* Default class of GitClient absent other modifiers */
+    private static final Class DEFAULT_CLASS = JGitAPIImpl.class;
+
     /* A known commit from the git-client-plugin repository */
-    private ObjectId expectedCommit = null;
+    private static ObjectId expectedCommit = null;
+
+    static {
+        Git git = new Git(null, null).using("git").in(new File("."));
+        try {
+            expectedCommit = git.getClient().revParse("HEAD");
+        } catch (IOException | InterruptedException e) {
+            fail("Exception computing SHA1 of HEAD commit " + e);
+        }
+    }
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection gitImplementation() {
         return Arrays.asList(new Object[][]{
-            {"git"},
-            {"jgit"}
+            {"git",           CliGitAPIImpl.class},
+            {"jgit",          JGitAPIImpl.class  },
+            {"jgitapache",    JGitAPIImpl.class  },
+            // {GitTool.DEFAULT, CliGitAPIImpl.class},
         });
     }
 
     private final String implementation;
+    private Class expectedClass;
 
-    public GitTest(String implementation) throws Exception {
+    public GitTest(String implementation, Class expectedClass) throws Exception {
         this.implementation = implementation;
-        Git git = new Git(null, null).using(implementation).in(new File("."));
-        expectedCommit = git.getClient().revParse("HEAD");
+        this.expectedClass = expectedClass;
+    }
+
+    @BeforeClass
+    public static void setMainIsUnitTest() {
+        // Configure git client for unit test execution
+        hudson.Main.isUnitTest = true;
     }
 
     @Test
     public void testWith() throws IOException, InterruptedException {
         Git git = Git.with(null, null);
-        assertTrue("Wrong default client type", git.getClient() instanceof JGitAPIImpl);
+        assertThat(git.getClient(), is(instanceOf(DEFAULT_CLASS)));
         assertTrue("Missing expected commit", git.getClient().isCommitInRepo(expectedCommit));
-        git = Git.with(null, null).using(implementation);
-        assertTrue("Wrong client type", implementation.equals("git") ? git.getClient() instanceof CliGitAPIImpl : git.getClient() instanceof JGitAPIImpl);
+    }
+
+    @Test
+    public void testWithUsing() throws IOException, InterruptedException {
+        Git git = Git.with(null, null).using(implementation);
+        assertThat(git.getClient(), is(instanceOf(expectedClass)));
         assertTrue("Missing expected commit", git.getClient().isCommitInRepo(expectedCommit));
     }
 
     @Test
     public void testIn_File() throws IOException, InterruptedException {
         Git git = new Git(null, null).in(new File("."));
-        assertTrue("Wrong client type", git.getClient() instanceof JGitAPIImpl);
+        assertThat(git.getClient(), is(instanceOf(DEFAULT_CLASS)));
         assertTrue("Missing expected commit", git.getClient().isCommitInRepo(expectedCommit));
     }
 
     @Test
     public void testIn_FileUsing() throws IOException, InterruptedException {
         Git git = new Git(null, null).in(new File(".")).using(implementation);
-        assertTrue("Wrong client type", implementation.equals("git") ? git.getClient() instanceof CliGitAPIImpl : git.getClient() instanceof JGitAPIImpl);
+        assertThat(git.getClient(), is(instanceOf(expectedClass)));
         assertTrue("Missing expected commit", git.getClient().isCommitInRepo(expectedCommit));
     }
 
     @Test
     public void testIn_FilePath() throws IOException, InterruptedException {
         Git git = new Git(null, null).in(new FilePath(new File(".")));
-        assertTrue("Wrong client type", git.getClient() instanceof JGitAPIImpl);
+        assertThat(git.getClient(), is(instanceOf(DEFAULT_CLASS)));
         assertTrue("Missing expected commit", git.getClient().isCommitInRepo(expectedCommit));
     }
 
     @Test
     public void testIn_FilePathUsing() throws IOException, InterruptedException {
         Git git = new Git(null, null).in(new File(".")).using(implementation);
-        assertTrue("Wrong client type", implementation.equals("git") ? git.getClient() instanceof CliGitAPIImpl : git.getClient() instanceof JGitAPIImpl);
+        assertThat(git.getClient(), is(instanceOf(expectedClass)));
         assertTrue("Missing expected commit", git.getClient().isCommitInRepo(expectedCommit));
     }
 
     @Test
     public void testUsing() throws IOException, InterruptedException {
         Git git = new Git(null, null).using(implementation);
-        assertTrue("Wrong client type", implementation.equals("git") ? git.getClient() instanceof CliGitAPIImpl : git.getClient() instanceof JGitAPIImpl);
+        assertThat(git.getClient(), is(instanceOf(expectedClass)));
         assertTrue("Missing expected commit", git.getClient().isCommitInRepo(expectedCommit));
     }
 


### PR DESCRIPTION
## [JENKINS-55655](https://issues.jenkins-ci.org/browse/JENKINS-55655) - Use CLI git in Blue Ocean

JENKINS-55655 reports that exe == null did not honor USE_CLI value.  Corrects code to match javadoc and to match most user expectations that command line git is the default implementation.

This change will require command line git be installed on a master that runs the Blue Ocean user interface when Blue Ocean performs git operations.  Previously, Blue Ocean would accidentally use JGit and did not require a command line git installation on the master.  

This will also allow Blue Ocean to access git repositories through a proxy as described in JENKINS-55655.

Blue Ocean users can return to the previous behavior with the property:

```
org.jenkinsci.plugins.gitclient.Git.USE_CLI=false
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

Intentionally chose to honor the setting of USE_CLI in fixing this bug rather than retaining bug compatibility with the previous implementation.
Assumes that almost all Jenkins installations that use git have command line git installed on the master.

Those Jenkins installations that do not have command line git installed on the master and cannot install command line git on the master will need to make that decision explicit by setting the property:

```
org.jenkinsci.plugins.gitclient.Git.USE_CLI=false
```