### PR TITLE
Use JGit 5.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
-    <jgit.version>5.3.0.201903130848-r</jgit.version>
+    <jgit.version>5.3.1.201904271842-r</jgit.version>
   </properties>
 
   <dependencies>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2107,15 +2107,15 @@ public abstract class GitAPITestCase extends TestCase {
          */
         // w.git.checkout().ref(notSubRefName).execute();
         w.git.checkout().ref(notSubRefName).branch(notSubBranchName).deleteBranchIfExist(true).execute();
+        assertDirExists(ntpDir);
+        assertFileExists(ntpContributingFile);
+        assertFileContains(ntpContributingFile, contributingFileContentFromNonsubmoduleBranch);
         if (w.git instanceof CliGitAPIImpl) {
             /*
              * Transition from "with submodule" to "without submodule"
              * where the "without submodule" case includes the file
              * ntpContributingFile and the directory ntpDir.
              */
-            assertDirExists(ntpDir);
-            assertFileExists(ntpContributingFile);
-            assertFileContains(ntpContributingFile, contributingFileContentFromNonsubmoduleBranch);
             /* submodule dirs exist because git.clean() won't remove untracked submodules */
             assertDirExists(firewallDir);
             assertDirExists(sshkeysDir);
@@ -2126,15 +2126,11 @@ public abstract class GitAPITestCase extends TestCase {
              * where the "without submodule" case includes the file
              * ntpContributingFile and the directory ntpDir.
              *
-             * JGit 5.2.0 handles the transition from "with submodule"
-             * to "without submodule" differently than CLI git and
-             * differently than JGit versions prior to JGit 5.2.0.
-             * It does not checkout ntpDir or the ntpContributingFile.
+             * Prior to JGit 5.3.1 ntpDir was not available at this point.
              *
              * Prior to JGit 5.2.0 and the CheckoutCommand bug fix,
              * the ntpDir would remain along with ntpContributingFile.
              */
-            assertDirNotFound(ntpDir);
             /* firewallDir and sshKeysDir don't exist because JGit submodule update never created them */
             assertDirNotFound(firewallDir);
             assertDirNotFound(sshkeysDir);


### PR DESCRIPTION
## Use JGit 5.3.1

Several bug fixes from 5.3.0, including:

* 545162 Fix diff when deleted submodule is replaced by normal files
* 545920 Apache MINA sshd: fix cloning of large repositories
* ObjectUploadListener: Add callback interface which is invoked after object upload was completed.
* Fix GC to delete empty fanout directories after repacking
* 546190 Fix pack files scan when filesnapshot isn't modified
* Remember the cause for invalidating a packfile

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)