### PR TITLE
[JENKINS-57326] make GitTool abstract to follow JCasC conventions

### DIFF
--- a/src/main/java/hudson/plugins/git/GitTool.java
+++ b/src/main/java/hudson/plugins/git/GitTool.java
@@ -1,31 +1,17 @@
 package hudson.plugins.git;
 
-import hudson.EnvVars;
-import hudson.Extension;
-import hudson.init.Initializer;
 import hudson.model.EnvironmentSpecific;
-import hudson.model.Node;
-import hudson.model.TaskListener;
+import hudson.model.Items;
 import hudson.slaves.NodeSpecific;
 import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.tools.ToolProperty;
-import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
-import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.gitclient.CLIGitTool;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.logging.Logger;
-
-import static hudson.init.InitMilestone.EXTENSIONS_AUGMENTED;
 
 /**
  * Information about Git installation. A GitTool is used to select
@@ -33,7 +19,7 @@ import static hudson.init.InitMilestone.EXTENSIONS_AUGMENTED;
  *
  * @author Jyrki Puttonen
  */
-public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, EnvironmentSpecific<GitTool> {
+public abstract class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, EnvironmentSpecific<GitTool> {
 
     /**
      * Constructor for GitTool.
@@ -42,7 +28,6 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
      * @param home Tool location (usually "git")
      * @param properties {@link java.util.List} of properties for this tool
      */
-    @DataBoundConstructor
     public GitTool(String name, String home, List<? extends ToolProperty<?>> properties) {
         super(name, home, properties);
     }
@@ -61,102 +46,22 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
         return getHome();
     }
 
-    private static GitTool[] getInstallations(DescriptorImpl descriptor) {
-        GitTool[] installations;
-        try {
-            installations = descriptor.getInstallations();
-        } catch (NullPointerException e) {
-            installations = new GitTool[0];
-        }
-        return installations;
-    }
-
     /**
      * Returns the default installation.
      *
      * @return default installation
+     * @deprecated see {@link CLIGitTool#getDefaultInstallation()}
      */
     public static GitTool getDefaultInstallation() {
-        Jenkins jenkinsInstance = Jenkins.getInstance();
-        DescriptorImpl gitTools = jenkinsInstance.getDescriptorByType(GitTool.DescriptorImpl.class);
-        GitTool tool = gitTools.getInstallation(GitTool.DEFAULT);
-        if (tool != null) {
-            return tool;
-        } else {
-            GitTool[] installations = gitTools.getInstallations();
-            if (installations.length > 0) {
-                return installations[0];
-            } else {
-                onLoaded();
-                return gitTools.getInstallations()[0];
-            }
-        }
-    }
-
-    public GitTool forNode(Node node, TaskListener log) throws IOException, InterruptedException {
-        return new GitTool(getName(), translateFor(node, log), Collections.<ToolProperty<?>>emptyList());
-    }
-
-    public GitTool forEnvironment(EnvVars environment) {
-        return new GitTool(getName(), environment.expand(getHome()), Collections.<ToolProperty<?>>emptyList());
-    }
-
-    @Override
-    public DescriptorImpl getDescriptor() {
-        Jenkins jenkinsInstance = Jenkins.getInstance();
-        if (jenkinsInstance == null) {
-            /* Throw AssertionError exception to match behavior of Jenkins.getDescriptorOrDie */
-            throw new AssertionError("No Jenkins instance");
-        }
-        return (DescriptorImpl) jenkinsInstance.getDescriptorOrDie(getClass());
-    }
-
-    @Initializer(after=EXTENSIONS_AUGMENTED)
-    public static void onLoaded() {
-        //Creates default tool installation if needed. Uses "git" or migrates data from previous versions
-
-        Jenkins jenkinsInstance = Jenkins.getInstance();
-        DescriptorImpl descriptor = (DescriptorImpl) jenkinsInstance.getDescriptor(GitTool.class);
-        GitTool[] installations = getInstallations(descriptor);
-
-        if (installations != null && installations.length > 0) {
-            //No need to initialize if there's already something
-            return;
-        }
-
-        String defaultGitExe = isWindows() ? "git.exe" : "git";
-        GitTool tool = new GitTool(DEFAULT, defaultGitExe, Collections.<ToolProperty<?>>emptyList());
-        descriptor.setInstallations(new GitTool[] { tool });
-        descriptor.save();
+        return CLIGitTool.getDefaultInstallation();
     }
 
 
-    @Extension @Symbol("git")
-    public static class DescriptorImpl extends ToolDescriptor<GitTool> {
+    public GitTool.DescriptorImpl getDescriptor() {
+        return (GitTool.DescriptorImpl) super.getDescriptor();
+    }
 
-        public DescriptorImpl() {
-            super();
-            load();
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "Git";
-        }
-
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-            setInstallations(req.bindJSONToList(clazz, json.get("tool")).toArray(new GitTool[0]));
-            save();
-            return true;
-        }
-
-        public FormValidation doCheckHome(@QueryParameter File value) {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
-            String path = value.getPath();
-
-            return FormValidation.validateExecutable(path);
-        }
+    public static abstract class DescriptorImpl extends ToolDescriptor<GitTool> {
 
         public GitTool getInstallation(String name) {
             for(GitTool i : getInstallations()) {
@@ -166,6 +71,7 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
             }
             return null;
         }
+
 
         /**
          * Misspelled method name. Please use #getApplicableDescriptors.
@@ -184,7 +90,7 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
         @SuppressWarnings("unchecked")
         public List<ToolDescriptor<? extends GitTool>> getApplicableDescriptors() {
             List<ToolDescriptor<? extends GitTool>> r = new ArrayList<>();
-            Jenkins jenkinsInstance = Jenkins.getInstance();
+            Jenkins jenkinsInstance = Jenkins.get();
             for (ToolDescriptor<?> td : jenkinsInstance.<ToolInstallation,ToolDescriptor<?>>getDescriptorList(ToolInstallation.class)) {
                 if (GitTool.class.isAssignableFrom(td.clazz)) { // This checks cast is allowed
                     r.add((ToolDescriptor<? extends GitTool>)td); // This is the unchecked cast
@@ -194,11 +100,13 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
         }
     }
 
-    private static final Logger LOGGER = Logger.getLogger(GitTool.class.getName());
+    static {
+        Items.XSTREAM2.aliasType(GitTool.class.getName(), CLIGitTool.class);
+    }
 
-    /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */
-    private static boolean isWindows() {
-        return File.pathSeparatorChar==';';
+    @Deprecated
+    public static void onLoaded() {
+        CLIGitTool.onLoaded();
     }
 }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CLIGitTool.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CLIGitTool.java
@@ -1,0 +1,138 @@
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.init.Initializer;
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitTool;
+import hudson.tools.ToolDescriptor;
+import hudson.tools.ToolInstallation;
+import hudson.tools.ToolProperty;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static hudson.init.InitMilestone.EXTENSIONS_AUGMENTED;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class CLIGitTool extends GitTool {
+
+    /**
+     * Constructor for CLIGitTool.
+     *
+     * @param name       Tool name (for example, "git")
+     * @param home       Tool location ("/usr/local/bin/git")
+     * @param properties {@link List} of properties for this tool
+     */
+    @DataBoundConstructor
+    public CLIGitTool(String name, String home, List<? extends ToolProperty<?>> properties) {
+        super(name, home, properties);
+    }
+
+    public GitTool forNode(Node node, TaskListener log) throws IOException, InterruptedException {
+        return new CLIGitTool(getName(), translateFor(node, log), Collections.<ToolProperty<?>>emptyList());
+    }
+
+    public GitTool forEnvironment(EnvVars environment) {
+        return new CLIGitTool(getName(), environment.expand(getHome()), Collections.<ToolProperty<?>>emptyList());
+    }
+
+    @Initializer(after=EXTENSIONS_AUGMENTED)
+    public static void onLoaded() {
+        //Creates default tool installation if needed. Uses "git" or migrates data from previous versions
+
+        Jenkins jenkinsInstance = Jenkins.get();
+        DescriptorImpl descriptor = (DescriptorImpl) jenkinsInstance.getDescriptor(GitTool.class);
+        GitTool[] installations = getInstallations(descriptor);
+
+        if (installations != null && installations.length > 0) {
+            //No need to initialize if there's already something
+            return;
+        }
+
+        String defaultGitExe = isWindows() ? "git.exe" : "git";
+        GitTool tool = new CLIGitTool(DEFAULT, defaultGitExe, Collections.<ToolProperty<?>>emptyList());
+        descriptor.setInstallations(new GitTool[] { tool });
+        descriptor.save();
+    }
+
+    private static GitTool[] getInstallations(DescriptorImpl descriptor) {
+        GitTool[] installations;
+        try {
+            installations = descriptor.getInstallations();
+        } catch (NullPointerException e) {
+            installations = new GitTool[0];
+        }
+        return installations;
+    }
+
+    public static GitTool getDefaultInstallation() {
+        Jenkins jenkinsInstance = Jenkins.get();
+        DescriptorImpl gitTools = jenkinsInstance.getDescriptorByType(DescriptorImpl.class);
+        GitTool tool = gitTools.getInstallation(GitTool.DEFAULT);
+        if (tool != null) {
+            return tool;
+        } else {
+            GitTool[] installations = gitTools.getInstallations();
+            if (installations.length > 0) {
+                return installations[0];
+            } else {
+                onLoaded();
+                return gitTools.getInstallations()[0];
+            }
+        }
+    }
+
+
+    @Extension
+    @Symbol("git")
+    public static class DescriptorImpl extends GitTool.DescriptorImpl {
+
+        public DescriptorImpl() {
+            super();
+            load();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Git";
+        }
+
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+            setInstallations(req.bindJSONToList(clazz, json.get("tool")).toArray(new GitTool[0]));
+            save();
+            return true;
+        }
+
+        public FormValidation doCheckHome(@QueryParameter File value) {
+            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            String path = value.getPath();
+
+            return FormValidation.validateExecutable(path);
+        }
+    }
+
+
+    private static final Logger LOGGER = Logger.getLogger(GitTool.class.getName());
+
+    /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */
+    private static boolean isWindows() {
+        return File.pathSeparatorChar==';';
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitApacheTool.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitApacheTool.java
@@ -1,11 +1,16 @@
 package org.jenkinsci.plugins.gitclient;
 
+import hudson.EnvVars;
 import hudson.Extension;
+import hudson.model.Node;
+import hudson.model.TaskListener;
 import hudson.plugins.git.GitTool;
+import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolProperty;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -24,18 +29,20 @@ public class JGitApacheTool extends GitTool {
         this(Collections.<ToolProperty<?>>emptyList());
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public GitTool.DescriptorImpl getDescriptor() {
-        return super.getDescriptor();
-    }
-
     @Extension @Symbol(MAGIC_EXENAME)
     public static class DescriptorImpl extends GitTool.DescriptorImpl {
         @Override
         public String getDisplayName() {
             return "JGit with Apache HTTP client";
         }
+    }
+
+    public GitTool forNode(Node node, TaskListener log) throws IOException, InterruptedException {
+        return this;
+    }
+
+    public GitTool forEnvironment(EnvVars environment) {
+        return this;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitTool.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitTool.java
@@ -1,11 +1,16 @@
 package org.jenkinsci.plugins.gitclient;
 
+import hudson.EnvVars;
 import hudson.Extension;
+import hudson.model.Node;
+import hudson.model.TaskListener;
 import hudson.plugins.git.GitTool;
+import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolProperty;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,12 +39,14 @@ public class JGitTool extends GitTool {
         this(Collections.<ToolProperty<?>>emptyList());
     }
 
-
-    /** {@inheritDoc} */
-    @Override
-    public GitTool.DescriptorImpl getDescriptor() {
-        return super.getDescriptor();
+    public GitTool forNode(Node node, TaskListener log) throws IOException, InterruptedException {
+        return this;
     }
+
+    public GitTool forEnvironment(EnvVars environment) {
+        return this;
+    }
+
 
     @Extension @Symbol("jgit")
     public static class DescriptorImpl extends GitTool.DescriptorImpl {

--- a/src/test/java/hudson/plugins/git/GitToolResolverTest.java
+++ b/src/test/java/hudson/plugins/git/GitToolResolverTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.Collections;
 import static org.junit.Assert.*;
 
+import org.jenkinsci.plugins.gitclient.CLIGitTool;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,7 +44,7 @@ public class GitToolResolverTest {
             installer = new CommandInstaller(label, command, toolHome);
             expectedSubstring = toolHome;
         }
-        GitTool t = new GitTool("myGit", null, Collections.singletonList(
+        GitTool t = new CLIGitTool("myGit", null, Collections.singletonList(
                 new InstallSourceProperty(Collections.singletonList(installer))));
         t.getDescriptor().setInstallations(t);
 


### PR DESCRIPTION
## [JENKINS-57326](https://issues.jenkins-ci.org/browse/JENKINS-57326) - support Configuration as Code plugin

GitTool is made abstract, so that JCasC will correctly detect a plugable extension and can also support JGit|JGitApache
Please note this changes the yaml structure used today to configure git tools installations.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix
- [x] Breaking change

## Further comments

Needs deep testing for upgrade compatibility, run time compatibility, and compile time compatibility with git client plugin consumers.