### PR TITLE
Require Java 8 and Jenkins 2.121.1, allow JDK 11 compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.37</version>
+    <version>3.43</version>
     <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>git-client</artifactId>
-  <version>2.7.8-SNAPSHOT</version>
+  <version>2.8.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Jenkins Git client plugin</name>
@@ -45,8 +45,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
-    <jenkins.version>1.625.3</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.121.1</jenkins.version>
+    <java.level>8</java.level>
     <jgit.version>4.5.7.201904151645-r</jgit.version>
     <jgit.javadoc.version>4.5.0.201609210915-r</jgit.javadoc.version>
   </properties>
@@ -137,14 +137,8 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
-      <version>1.11</version>
+      <version>2.6</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -168,10 +162,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.1u2</version>
-      <scope>provided</scope>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -196,13 +189,6 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
@@ -224,25 +210,6 @@
         <extensions>true</extensions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <skip>${skipFindbugs}</skip>
-          <failOnError>false</failOnError>
-          <xmlOutput>true</xmlOutput>
-          <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-findbugs</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemProperties>
@@ -257,21 +224,8 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4.2.jenkins-1</version>
-        <configuration>
-          <rules>
-            <requireUpperBoundDeps>
-              <excludes combine.children="append">
-                <!-- core requests 1.4, sshd requests 1.2 -->
-                <exclude>org.jenkins-ci.modules:instance-identity</exclude>
-                <!-- core requests 1.4, sshd requests 1.1 -->
-                <exclude>org.jenkins-ci.modules:ssh-cli-auth</exclude>
-              </excludes>
-            </requireUpperBoundDeps>
-          </rules>
-        </configuration>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -223,10 +223,6 @@
           </systemProperties>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
@@ -90,9 +90,13 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
      * When sent to remote, switch to the proxy.
      *
      * @return a {@link java.lang.Object} object.
+     * @throws java.io.ObjectStreamException if current channel is null
      */
-    protected Object writeReplace() {
-        return remoteProxyFor(Channel.current().export(GitClient.class, this));
+    protected Object writeReplace() throws java.io.ObjectStreamException {
+        Channel currentChannel = Channel.current();
+        if (currentChannel == null)
+            throw new java.io.WriteAbortedException("No current channel", new java.lang.NullPointerException());
+        return remoteProxyFor(currentChannel.export(GitClient.class, this));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -9,7 +9,7 @@ import java.io.Writer;
  * Command builder for generating changelog in the format {@code GitSCM} expects.
  *
  * <p>
- * The output format is that of <tt>git-whatchanged</tt>, which looks something like this:
+ * The output format is that of <code>git-whatchanged</code>, which looks something like this:
  *
  * <pre>
  * commit dadaf808d99c4c23c53476b0c48e25a181016300

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -232,7 +232,7 @@ public interface GitClient {
 
     /**
      * Checks out the specified commit/tag/branch into the workspace.
-     * (equivalent of <tt>git checkout <em>branch</em></tt>.)
+     * (equivalent of <code>git checkout <em>branch</em></code>.)
      *
      * @param ref A git object references expression (either a sha1, tag or branch)
      * @deprecated use {@link #checkout()} and {@link org.jenkinsci.plugins.gitclient.CheckoutCommand}
@@ -247,7 +247,7 @@ public interface GitClient {
      *
      * This will fail if the branch already exists.
      *
-     * @param ref A git object references expression. For backward compatibility, <tt>null</tt> will checkout current HEAD
+     * @param ref A git object references expression. For backward compatibility, <code>null</code> will checkout current HEAD
      * @param branch name of the branch to create from reference
      * @deprecated use {@link #checkout()} and {@link org.jenkinsci.plugins.gitclient.CheckoutCommand}
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
@@ -269,7 +269,7 @@ public interface GitClient {
      *
      * <ul>
      *     <li>The branch of the specified name <em>branch</em> exists and points to the specified <em>ref</em>
-     *     <li><tt>HEAD</tt> points to <em>branch</em>. IOW, the workspace is on the specified branch.
+     *     <li><code>HEAD</code> points to <em>branch</em>. In other words, the workspace is on the specified branch.
      *     <li>Both index and workspace are the same tree with <em>ref</em>.
      *         (no dirty files and no staged changes, although this method will not touch untracked files
      *         in the workspace.)
@@ -277,7 +277,7 @@ public interface GitClient {
      *
      * <p>
      * This method is preferred over the {@link #checkout(String, String)} family of methods, as
-     * this method is affected far less by the current state of the repository. The <tt>checkout</tt>
+     * this method is affected far less by the current state of the repository. The <code>checkout</code>
      * methods, in their attempt to emulate the "git checkout" command line behaviour, have too many
      * side effects. In Jenkins, where you care a lot less about throwing away local changes and
      * care a lot more about resetting the workspace into a known state, methods like this is more useful.
@@ -298,7 +298,7 @@ public interface GitClient {
      * Clone a remote repository
      *
      * @param url URL for remote repository to clone
-     * @param origin upstream track name, defaults to <tt>origin</tt> by convention
+     * @param origin upstream track name, defaults to <code>origin</code> by convention
      * @param useShallowClone option to create a shallow clone, that has some restriction but will make clone operation
      * @param reference (optional) reference to a local clone for faster clone operations (reduce network and local storage costs)
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
@@ -315,7 +315,7 @@ public interface GitClient {
 
     /**
      * Fetch commits from url which match any of the passed in
-     * refspecs. Assumes <tt>remote.remoteName.url</tt> has been set.
+     * refspecs. Assumes <code>remote.remoteName.url</code> has been set.
      *
      * @deprecated use {@link #fetch_()} and configure a {@link org.jenkinsci.plugins.gitclient.FetchCommand}
      * @param url a {@link org.eclipse.jgit.transport.URIish} object.
@@ -479,7 +479,7 @@ public interface GitClient {
     // --- manage tags
 
     /**
-     * Create (or update) a tag. If tag already exist it gets updated (equivalent to <tt>git tag --force</tt>)
+     * Create (or update) a tag. If tag already exist it gets updated (equivalent to <code>git tag --force</code>)
      *
      * @param tagName a {@link java.lang.String} object.
      * @param comment a {@link java.lang.String} object.
@@ -540,7 +540,7 @@ public interface GitClient {
     // --- manage refs
 
     /**
-     * Create (or update) a ref. The ref will reference HEAD (equivalent to <tt>git update-ref ... HEAD</tt>).
+     * Create (or update) a ref. The ref will reference HEAD (equivalent to <code>git update-ref ... HEAD</code>).
      *
      * @param refName the full name of the ref (e.g. "refs/myref"). Spaces will be replaced with underscores.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
@@ -549,7 +549,7 @@ public interface GitClient {
     void ref(String refName) throws GitException, InterruptedException;
 
     /**
-     * Check if a ref exists. Equivalent to comparing the return code of <tt>git show-ref</tt> to zero.
+     * Check if a ref exists. Equivalent to comparing the return code of <code>git show-ref</code> to zero.
      *
      * @param refName the full name of the ref (e.g. "refs/myref"). Spaces will be replaced with underscores.
      * @return True if the ref exists, false otherwse.
@@ -559,7 +559,7 @@ public interface GitClient {
     boolean refExists(String refName) throws GitException, InterruptedException;
 
     /**
-     * Deletes a ref. Has no effect if the ref does not exist, equivalent to <tt>git update-ref -d</tt>.
+     * Deletes a ref. Has no effect if the ref does not exist, equivalent to <code>git update-ref -d</code>.
      *
      * @param refName the full name of the ref (e.g. "refs/myref"). Spaces will be replaced with underscores.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
@@ -568,7 +568,7 @@ public interface GitClient {
     void deleteRef(String refName) throws GitException, InterruptedException;
 
     /**
-     * List refs with the given prefix. Equivalent to <tt>git for-each-ref --format="%(refname)"</tt>.
+     * List refs with the given prefix. Equivalent to <code>git for-each-ref --format="%(refname)"</code>.
      *
      * @param refPrefix the literal prefix any ref returned will have. The empty string implies all.
      * @return a set of refs, each beginning with the given prefix. Empty if none.
@@ -601,7 +601,7 @@ public interface GitClient {
     ObjectId getHeadRev(String remoteRepoUrl, String branch) throws GitException, InterruptedException;
 
     /**
-     * List references in a remote repository. Equivalent to <tt>git ls-remote [--heads] [--tags] &lt;repository&gt; [&lt;refs&gt;]</tt>.
+     * List references in a remote repository. Equivalent to <code>git ls-remote [--heads] [--tags] &lt;repository&gt; [&lt;refs&gt;]</code>.
      *
      * @param remoteRepoUrl
      *      Remote repository URL.
@@ -620,8 +620,8 @@ public interface GitClient {
     Map<String, ObjectId> getRemoteReferences(String remoteRepoUrl, String pattern, boolean headsOnly, boolean tagsOnly) throws GitException, InterruptedException;
 
     /**
-     * List symbolic references in a remote repository. Equivalent to <tt>git ls-remote --symref &lt;repository&gt;
-     * [&lt;refs&gt;]</tt>. Note: the response may be empty for multiple reasons
+     * List symbolic references in a remote repository. Equivalent to <code>git ls-remote --symref &lt;repository&gt;
+     * [&lt;refs&gt;]</code>. Note: the response may be empty for multiple reasons
      *
      * @param remoteRepoUrl Remote repository URL.
      * @param pattern       Only references matching the given pattern are displayed.
@@ -634,7 +634,7 @@ public interface GitClient {
     Map<String, String> getRemoteSymbolicReferences(String remoteRepoUrl, String pattern) throws GitException, InterruptedException;
 
     /**
-     * Retrieve commit object that is direct child for <tt>revName</tt> revision reference.
+     * Retrieve commit object that is direct child for <code>revName</code> revision reference.
      *
      * @param revName a commit sha1 or tag/branch refname
      * @throws hudson.plugins.git.GitException when no such commit / revName is found in repository.
@@ -711,7 +711,7 @@ public interface GitClient {
 
     /**
      * Run submodule update optionally recursively on all submodules
-     * (equivalent of <tt>git submodule update <em>--recursive</em></tt>.)
+     * (equivalent of <code>git submodule update <em>--recursive</em></code>.)
      *
      * @deprecated use {@link #submoduleUpdate()} and {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand}
      * @param recursive a boolean.
@@ -723,7 +723,7 @@ public interface GitClient {
     /**
      * Run submodule update optionally recursively on all submodules, with a specific
      * reference passed to git clone if needing to --init.
-     * (equivalent of <tt>git submodule update <em>--recursive</em> <em>--reference 'reference'</em></tt>.)
+     * (equivalent of <code>git submodule update <em>--recursive</em> <em>--reference 'reference'</em></code>.)
      *
      * @deprecated use {@link #submoduleUpdate()} and {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand}
      * @param recursive a boolean.
@@ -735,7 +735,7 @@ public interface GitClient {
 
     /**
      * Run submodule update optionally recursively on all submodules, optionally with remoteTracking submodules
-     * (equivalent of <tt>git submodule update <em>--recursive</em> <em>--remote</em></tt>.)
+     * (equivalent of <code>git submodule update <em>--recursive</em> <em>--remote</em></code>.)
      *
      * @deprecated use {@link #submoduleUpdate()} and {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand}
      * @param recursive a boolean.
@@ -747,7 +747,7 @@ public interface GitClient {
     /**
      * Run submodule update optionally recursively on all submodules, optionally with remoteTracking, with a specific
      * reference passed to git clone if needing to --init.
-     * (equivalent of <tt>git submodule update <em>--recursive</em> <em>--remote</em> <em>--reference 'reference'</em></tt>.)
+     * (equivalent of <code>git submodule update <em>--recursive</em> <em>--remote</em> <em>--reference 'reference'</em></code>.)
      *
      * @deprecated use {@link #submoduleUpdate()} and {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand}
      * @param recursive a boolean.
@@ -876,7 +876,7 @@ public interface GitClient {
      * For merge commit, this method reports one diff per each parent. This makes this method
      * behave differently from {@link #changelog()}.
      *
-     * @return The git show output, in <tt>raw</tt> format.
+     * @return The git show output, in <code>raw</code> format.
      * @param from a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @param to a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
@@ -900,7 +900,7 @@ public interface GitClient {
      * For merge commit, this method reports one diff per each parent. This makes this method
      * behave differently from {@link #changelog()}.
      *
-     * @return The git show output, in <tt>raw</tt> format.
+     * @return The git show output, in <code>raw</code> format.
      * @param from a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @param to a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @param useRawOutput a {java.lang.Boolean} object.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -131,6 +131,8 @@ import hudson.plugins.git.GitObject;
 import org.eclipse.jgit.api.RebaseCommand.Operation;
 import org.eclipse.jgit.api.RebaseResult;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * GitClient pure Java implementation using JGit.
  * Goal is to eventually get a full java implementation for GitClient
@@ -750,6 +752,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /** {@inheritDoc} */
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "Java 11 spotbugs error")
     public Map<String, ObjectId> getHeadRev(String url) throws GitException, InterruptedException {
         Map<String, ObjectId> heads = new HashMap<>();
         try (Repository repo = openDummyRepository();
@@ -804,6 +807,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     @Override
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "Java 11 spotbugs error")
     public Map<String, String> getRemoteSymbolicReferences(String url, String pattern)
             throws GitException, InterruptedException {
         Map<String, String> references = new HashMap<>();
@@ -902,6 +906,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /** {@inheritDoc} */
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "Java 11 spotbugs error")
     public ObjectId getHeadRev(String remoteRepoUrl, String branchSpec) throws GitException {
         try (Repository repo = openDummyRepository();
              final Transport tn = Transport.open(repo, new URIish(remoteRepoUrl))) {
@@ -1755,6 +1760,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "Java 11 spotbugs error")
     private Set<String> listRemoteBranches(String remote) throws NotSupportedException, TransportException, URISyntaxException {
         Set<String> branches = new HashSet<>();
         try (final Repository repo = getRepository()) {
@@ -2649,6 +2655,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /** {@inheritDoc} */
     @Deprecated
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "Java 11 spotbugs error")
     public void setRemoteUrl(String name, String url, String GIT_DIR) throws GitException, InterruptedException {
         try (Repository repo = new RepositoryBuilder().setGitDir(new File(GIT_DIR)).build()) {
             StoredConfig config = repo.getConfig();
@@ -2665,6 +2672,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return getConfig(GIT_DIR).getString("remote", name, "url");
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "Java 11 spotbugs error")
     private StoredConfig getConfig(String GIT_DIR) throws GitException {
         try (Repository repo = isBlank(GIT_DIR) ? getRepository() : new RepositoryBuilder().setWorkTree(new File(GIT_DIR)).build()) {
             return repo.getConfig();

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -8,10 +8,10 @@
 The Jenkins git client plugin provides an API to execute
 general-purpose git operations on a local or remote repository. Its
 primary use is from the
-<a href="https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin" target="_blank" unselectable="on">git-plugin</a>;
+<a href="https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin" target="_blank">git-plugin</a>;
 as such, it is also used by
-<a href="https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin" target="_blank" unselectable="on">gerrit-plugin</a>,
-<a href="https://wiki.jenkins-ci.org/display/JENKINS/Git+Parameter+Plugin" target="_blank" unselectable="on">git-parameter-plugin</a>,
+<a href="https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin" target="_blank">gerrit-plugin</a>,
+<a href="https://wiki.jenkins-ci.org/display/JENKINS/Git+Parameter+Plugin" target="_blank">git-parameter-plugin</a>,
 workflow and cloudbees validated merge plugins.
 
 <p>Plugin developers are encouraged to use
@@ -20,7 +20,7 @@ replacement for the legacy IGitAPI.
 
 <p>The plugin isolates this low-level git stuff from git-plugin, allowing
 alternate git implementations
-(like <a href="http://wiki.eclipse.org/JGit/User_Guide"  target="_blank" unselectable="on">JGit</a>).</p>
+(like <a href="http://wiki.eclipse.org/JGit/User_Guide"  target="_blank">JGit</a>).</p>
 
 <p>For backwards compatibility, this plugin uses API classes from the
 hudson.plugins.git package.</p>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -213,14 +213,6 @@ public abstract class GitAPITestCase extends TestCase {
           return null;
         }
 
-        String cmd(String args) throws IOException, InterruptedException {
-            return launchCommand(args.split(" "));
-        }
-
-        String cmd(boolean ignoreError, String args) throws IOException, InterruptedException {
-            return launchCommand(ignoreError, args.split(" "));
-        }
-
         String launchCommand(String... args) throws IOException, InterruptedException {
             return launchCommand(false, args);
         }
@@ -260,11 +252,15 @@ public abstract class GitAPITestCase extends TestCase {
         }
 
         void tag(String tag, boolean force) throws IOException, InterruptedException {
-            cmd("git tag" + (force ? " --force " : " ") + tag);
+            if (force) {
+                launchCommand("git", "tag", "--force", tag);
+            } else {
+                launchCommand("git", "tag", tag);
+            }
         }
 
         void commitEmpty(String msg) throws IOException, InterruptedException {
-            cmd("git commit --allow-empty -m " + msg);
+            launchCommand("git", "commit", "--allow-empty", "-m", msg);
         }
 
         /**
@@ -462,7 +458,7 @@ public abstract class GitAPITestCase extends TestCase {
 
     private void check_remote_url(final String repositoryName) throws InterruptedException, IOException {
         assertEquals("Wrong remote URL", localMirror(), w.git.getRemoteUrl(repositoryName));
-        String remotes = w.cmd("git remote -v");
+        String remotes = w.launchCommand("git", "remote", "-v");
         assertTrue("remote URL has not been updated", remotes.contains(localMirror()));
     }
 
@@ -777,8 +773,8 @@ public abstract class GitAPITestCase extends TestCase {
     @Deprecated
     public void test_getDefaultRemote() throws Exception {
         w.init();
-        w.cmd("git remote add origin https://github.com/jenkinsci/git-client-plugin.git");
-        w.cmd("git remote add ndeloof git@github.com:ndeloof/git-client-plugin.git");
+        w.launchCommand("git", "remote", "add", "origin", "https://github.com/jenkinsci/git-client-plugin.git");
+        w.launchCommand("git", "remote", "add", "ndeloof", "git@github.com:ndeloof/git-client-plugin.git");
         assertEquals("Wrong origin default remote", "origin", w.igit().getDefaultRemote("origin"));
         assertEquals("Wrong ndeloof default remote", "ndeloof", w.igit().getDefaultRemote("ndeloof"));
         /* CliGitAPIImpl and JGitAPIImpl return different ordered lists for default remote if invalid */
@@ -788,8 +784,8 @@ public abstract class GitAPITestCase extends TestCase {
 
     public void test_getRemoteURL() throws Exception {
         w.init();
-        w.cmd("git remote add origin https://github.com/jenkinsci/git-client-plugin.git");
-        w.cmd("git remote add ndeloof git@github.com:ndeloof/git-client-plugin.git");
+        w.launchCommand("git", "remote", "add", "origin", "https://github.com/jenkinsci/git-client-plugin.git");
+        w.launchCommand("git", "remote", "add", "ndeloof", "git@github.com:ndeloof/git-client-plugin.git");
         String remoteUrl = w.git.getRemoteUrl("origin");
         assertEquals("unexepected remote URL " + remoteUrl, "https://github.com/jenkinsci/git-client-plugin.git", remoteUrl);
     }
@@ -797,15 +793,15 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_getRemoteURL_local_clone() throws Exception {
         w = clone(localMirror());
         assertEquals("Wrong origin URL", localMirror(), w.git.getRemoteUrl("origin"));
-        String remotes = w.cmd("git remote -v");
+        String remotes = w.launchCommand("git", "remote", "-v");
         assertTrue("remote URL has not been updated", remotes.contains(localMirror()));
     }
 
     public void test_setRemoteURL() throws Exception {
         w.init();
-        w.cmd("git remote add origin https://github.com/jenkinsci/git-client-plugin.git");
+        w.launchCommand("git", "remote", "add", "origin", "https://github.com/jenkinsci/git-client-plugin.git");
         w.git.setRemoteUrl("origin", "git@github.com:ndeloof/git-client-plugin.git");
-        String remotes = w.cmd("git remote -v");
+        String remotes = w.launchCommand("git", "remote", "-v");
         assertTrue("remote URL has not been updated", remotes.contains("git@github.com:ndeloof/git-client-plugin.git"));
     }
 
@@ -814,7 +810,7 @@ public abstract class GitAPITestCase extends TestCase {
         String originURL = "https://github.com/jenkinsci/git-client-plugin.git";
         w.git.setRemoteUrl("origin", originURL);
         assertEquals("Wrong origin URL", originURL, w.git.getRemoteUrl("origin"));
-        String remotes = w.cmd("git remote -v");
+        String remotes = w.launchCommand("git", "remote", "-v");
         assertTrue("remote URL has not been updated", remotes.contains(originURL));
     }
 
@@ -876,7 +872,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals("content " + fileName, w.contentOf(fileName));
         assertEquals("content " + fileNameFace, w.contentOf(fileNameFace));
         assertEquals("content " + fileNameSwim, w.contentOf(fileNameSwim));
-        String status = w.cmd("git status");
+        String status = w.launchCommand("git", "status");
         assertTrue("unexpected status " + status, status.contains("working directory clean") || status.contains("working tree clean"));
 
         /* A few poorly placed tests of hudson.FilePath - testing JENKINS-22434 */
@@ -903,7 +899,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertFalse(fp2 + " not deleted", fp2.exists());
 
         String dirContents = Arrays.toString((new File(w.repoPath())).listFiles());
-        String finalStatus = w.cmd("git status");
+        String finalStatus = w.launchCommand("git", "status");
         assertTrue("unexpected final status " + finalStatus + " dir contents: " + dirContents, finalStatus.contains("working directory clean") || finalStatus.contains("working tree clean"));
     }
 
@@ -1071,11 +1067,11 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue("tag1 wasn't created", w.git.tagExists("tag1"));
         assertEquals("tag1 points to wrong commit", commit1, w.git.revParse("tag1"));
         w.git.push().ref("master").to(new URIish(bare.repoPath())).tags(false).execute();
-        assertFalse("tag1 pushed unexpectedly", bare.cmd("git tag").contains("tag1"));
+        assertFalse("tag1 pushed unexpectedly", bare.launchCommand("git", "tag").contains("tag1"));
 
         /* Push tag1 to bare repo */
         w.git.push().ref("master").to(new URIish(bare.repoPath())).tags(true).execute();
-        assertTrue("tag1 not pushed", bare.cmd("git tag").contains("tag1"));
+        assertTrue("tag1 not pushed", bare.launchCommand("git", "tag").contains("tag1"));
 
         /* Create a new commit, move tag1 to that commit, attempt push */
         w.touch("file1", "file1 content " + java.util.UUID.randomUUID().toString());
@@ -1114,7 +1110,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.tag("tag3");
         assertTrue("tag3 wasn't created", w.git.tagExists("tag3"));
         w.git.push().ref("master").to(new URIish(bare.repoPath())).execute();
-        assertFalse("tag3 was pushed", bare.cmd("git tag").contains("tag3"));
+        assertFalse("tag3 was pushed", bare.launchCommand("git", "tag").contains("tag3"));
 
         /* Add another tag to working repo and push tags to the bare repo */
         w.touch("file2", "file2 content " + java.util.UUID.randomUUID().toString());
@@ -1123,9 +1119,9 @@ public abstract class GitAPITestCase extends TestCase {
         w.tag("tag2");
         assertTrue("tag2 wasn't created", w.git.tagExists("tag2"));
         w.git.push().ref("master").to(new URIish(bare.repoPath())).tags(true).execute();
-        assertTrue("tag1 wasn't pushed", bare.cmd("git tag").contains("tag1"));
-        assertTrue("tag2 wasn't pushed", bare.cmd("git tag").contains("tag2"));
-        assertTrue("tag3 wasn't pushed", bare.cmd("git tag").contains("tag3"));
+        assertTrue("tag1 wasn't pushed", bare.launchCommand("git", "tag").contains("tag1"));
+        assertTrue("tag2 wasn't pushed", bare.launchCommand("git", "tag").contains("tag2"));
+        assertTrue("tag3 wasn't pushed", bare.launchCommand("git", "tag").contains("tag3"));
     }
 
     @Bug(19591)
@@ -1191,11 +1187,11 @@ public abstract class GitAPITestCase extends TestCase {
 
         /* Delete parent branch from w */
         w.git.checkout("master");
-        w.cmd("git branch -D parent");
+        w.launchCommand("git", "branch", "-D", "parent");
         assertEquals("Wrong branch count", 1, w.git.getBranches().size());
 
         /* Delete parent branch on bare repo*/
-        bare.cmd("git branch -D parent");
+        bare.launchCommand("git", "branch", "-D", "parent");
         // assertEquals("Wrong branch count", 1, bare.git.getBranches().size());
 
         /* Create parent/a branch in working repo */
@@ -1292,13 +1288,14 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals("Wrong count in " + remoteBranches, 4, remoteBranches.size());
 
         /* Remove branch1 from bare repo using original repo */
-        w.cmd("git push " + bare.repoPath() + " :branch1");
+        w.launchCommand("git", "push", bare.repoPath(),  ":branch1");
 
         RefSpec defaultRefSpec = new RefSpec("+refs/heads/*:refs/remotes/origin/*");
         List<RefSpec> refSpecs = new ArrayList<>();
         refSpecs.add(defaultRefSpec);
 
         /* Fetch without prune should leave branch1 in newArea */
+        newArea.launchCommand("git", "config", "fetch.prune", "false");
         newArea.git.fetch_().from(new URIish(bare.repo.toString()), refSpecs).execute();
         remoteBranches = newArea.git.getRemoteBranches();
         assertBranchesExist(remoteBranches, "origin/master", "origin/branch1", "origin/branch2", "origin/HEAD");
@@ -1327,12 +1324,12 @@ public abstract class GitAPITestCase extends TestCase {
         WorkingArea r = new WorkingArea();
         r.init();
         r.commitEmpty("init");
-        String sha1 = r.cmd("git rev-list --no-walk --max-count=1 HEAD");
+        String sha1 = r.launchCommand("git", "rev-list", "--no-walk", "--max-count=1", "HEAD");
 
         w.init();
-        w.cmd("git remote add origin " + r.repoPath());
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
         w.git.fetch(new URIish(r.repo.toString()), Collections.<RefSpec>emptyList());
-        assertTrue(sha1.equals(r.cmd("git rev-list --no-walk --max-count=1 HEAD")));
+        assertTrue(sha1.equals(r.launchCommand("git", "rev-list", "--no-walk", "--max-count=1", "HEAD")));
     }
 
     public void test_fetch_shallow() throws Exception {
@@ -1412,7 +1409,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.init();
         w.commitEmpty("init");
         w.git.branch("test");
-        String branches = w.cmd("git branch -l");
+        String branches = w.launchCommand("git", "branch", "-l");
         assertTrue("master branch not listed", branches.contains("master"));
         assertTrue("test branch not listed", branches.contains("test"));
     }
@@ -1441,7 +1438,7 @@ public abstract class GitAPITestCase extends TestCase {
         branches = w.git.getBranches();
         assertBranchesExist(branches, "master", "test", "another");
         assertEquals(3, branches.size());
-        String output = w.cmd("git branch -v --no-abbrev");
+        String output = w.launchCommand("git", "branch", "-v", "--no-abbrev");
         assertTrue("git branch -v --no-abbrev missing test commit msg: '" + output + "'", output.contains(testBranchCommitMessage));
         assertTrue("git branch -v --no-abbrev missing another commit msg: '" + output + "'", output.contains(anotherBranchCommitMessage));
         if (w.cgit().isAtLeastVersion(2, 13, 0, 0)) {
@@ -1463,8 +1460,8 @@ public abstract class GitAPITestCase extends TestCase {
         r.git.branch("another");
 
         w.init();
-        w.cmd("git remote add origin " + r.repoPath());
-        w.cmd("git fetch origin");
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
+        w.launchCommand("git", "fetch", "origin");
         Set<Branch> branches = w.git.getRemoteBranches();
         assertBranchesExist(branches, "origin/master", "origin/test", "origin/another");
         assertEquals(3, branches.size());
@@ -1479,8 +1476,8 @@ public abstract class GitAPITestCase extends TestCase {
         r.tag("yet_another");
 
         w.init();
-        w.cmd("git remote add origin " + r.repoPath());
-        w.cmd("git fetch origin");
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
+        w.launchCommand("git", "fetch", "origin");
         Set<String> local_tags = w.git.getTagNames("*test");
         Set<String> tags = w.git.getRemoteTagNames("*test");
         assertTrue("expected tag test not listed", tags.contains("test"));
@@ -1497,8 +1494,8 @@ public abstract class GitAPITestCase extends TestCase {
         r.tag("yet_another");
 
         w.init();
-        w.cmd("git remote add origin " + r.repoPath());
-        w.cmd("git fetch origin");
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
+        w.launchCommand("git", "fetch",  "origin");
         Set<String> allTags = w.git.getRemoteTagNames(null);
         assertTrue("tag 'test' not listed", allTags.contains("test"));
         assertTrue("tag 'another_test' not listed", allTags.contains("another_test"));
@@ -1520,7 +1517,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.commitEmpty("init");
         w.git.branch("test");
         w.git.deleteBranch("test");
-        String branches = w.cmd("git branch -l");
+        String branches = w.launchCommand("git", "branch", "-l");
         assertFalse("deleted test branch still present", branches.contains("test"));
         try {
             w.git.deleteBranch("test");
@@ -1563,8 +1560,8 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals("Annotated tag doesn't match queried commit SHA1", init, testTagCommit);
         assertEquals(init, w.git.revParse("test")); // SHA1 of commit identified by test tag
         assertEquals(init, w.git.revParse("refs/tags/test")); // SHA1 of commit identified by test tag
-        assertTrue("test tag not created", w.cmd("git tag").contains("test"));
-        String message = w.cmd("git tag -l -n1");
+        assertTrue("test tag not created", w.launchCommand("git", "tag").contains("test"));
+        String message = w.launchCommand("git", "tag", "-l", "-n1");
         assertTrue("unexpected test tag message : " + message, message.contains("this is a tag"));
         assertNull(w.git.getHeadRev(gitDir, "not-a-valid-tag")); // Confirm invalid tag returns null
     }
@@ -1575,7 +1572,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.tag("test");
         w.tag("another");
         w.git.deleteTag("test");
-        String tags = w.cmd("git tag");
+        String tags = w.launchCommand("git", "tag");
         assertFalse("deleted test tag still present", tags.contains("test"));
         assertTrue("expected tag not listed", tags.contains("another"));
         try {
@@ -1633,7 +1630,7 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_get_tag_message() throws Exception {
         w.init();
         w.commitEmpty("init");
-        w.tag("test -m this-is-a-test");
+        w.launchCommand("git", "tag", "test", "-m", "this-is-a-test");
         assertEquals("this-is-a-test", w.git.getTagMessage("test"));
     }
 
@@ -1652,7 +1649,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.init();
         w.commitEmpty("init");
         w.git.ref("refs/testing/testref");
-        assertTrue("test ref not created", w.cmd("git show-ref").contains("refs/testing/testref"));
+        assertTrue("test ref not created", w.launchCommand("git", "show-ref").contains("refs/testing/testref"));
     }
 
     public void test_delete_ref() throws Exception {
@@ -1661,7 +1658,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.ref("refs/testing/testref");
         w.git.ref("refs/testing/anotherref");
         w.git.deleteRef("refs/testing/testref");
-        String refs = w.cmd("git show-ref");
+        String refs = w.launchCommand("git", "show-ref");
         assertFalse("deleted test tag still present", refs.contains("refs/testing/testref"));
         assertTrue("expected tag not listed", refs.contains("refs/testing/anotherref"));
         w.git.deleteRef("refs/testing/testref");  // Double-deletes do nothing.
@@ -1707,7 +1704,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.add("file1");
         w.git.commit("commit1");
         w.tag("test");
-        String sha1 = w.cmd("git rev-parse HEAD").substring(0,40);
+        String sha1 = w.launchCommand("git", "rev-parse", "HEAD").substring(0,40);
         assertEquals(sha1, w.git.revParse(sha1).name());
         assertEquals(sha1, w.git.revParse("HEAD").name());
         assertEquals(sha1, w.git.revParse("test").name());
@@ -1753,10 +1750,10 @@ public abstract class GitAPITestCase extends TestCase {
 
         WorkingArea r = new WorkingArea();
         r.init(true);
-        w.cmd("git remote add origin " + r.repoPath());
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
 
         w.git.push("origin", "master");
-        String remoteSha1 = r.cmd("git rev-parse master").substring(0, 40);
+        String remoteSha1 = r.launchCommand("git", "rev-parse", "master").substring(0, 40);
         assertEquals(sha1.name(), remoteSha1);
     }
 
@@ -1778,7 +1775,7 @@ public abstract class GitAPITestCase extends TestCase {
         /* Push to bare repo */
         w.git.push("origin", "master");
         /* JGitAPIImpl revParse fails unexpectedly when used here */
-        ObjectId bareHead = w.git instanceof CliGitAPIImpl ? bare.head() : ObjectId.fromString(bare.cmd("git rev-parse master").substring(0, 40));
+        ObjectId bareHead = w.git instanceof CliGitAPIImpl ? bare.head() : ObjectId.fromString(bare.launchCommand("git", "rev-parse", "master").substring(0, 40));
         assertEquals("Heads don't match", workHead, bareHead);
         assertEquals("Heads don't match", w.git.getHeadRev(w.repoPath(), "master"), bare.git.getHeadRev(bare.repoPath(), "master"));
 
@@ -1794,8 +1791,8 @@ public abstract class GitAPITestCase extends TestCase {
         w.igit().push(origin, "master");
 
         /* JGitAPIImpl revParse fails unexpectedly when used here */
-        ObjectId workHead2 = w.git instanceof CliGitAPIImpl ? w.head() : ObjectId.fromString(w.cmd("git rev-parse master").substring(0, 40));
-        ObjectId bareHead2 = w.git instanceof CliGitAPIImpl ? bare.head() : ObjectId.fromString(bare.cmd("git rev-parse master").substring(0, 40));
+        ObjectId workHead2 = w.git instanceof CliGitAPIImpl ? w.head() : ObjectId.fromString(w.launchCommand("git", "rev-parse", "master").substring(0, 40));
+        ObjectId bareHead2 = w.git instanceof CliGitAPIImpl ? bare.head() : ObjectId.fromString(bare.launchCommand("git", "rev-parse", "master").substring(0, 40));
         assertEquals("Working SHA1 != bare SHA1", workHead2, bareHead2);
         assertEquals("Working SHA1 != bare SHA1", w.git.getHeadRev(w.repoPath(), "master"), bare.git.getHeadRev(bare.repoPath(), "master"));
     }
@@ -1808,11 +1805,11 @@ public abstract class GitAPITestCase extends TestCase {
         r.touch("file1");
         r.git.add("file1");
         r.git.commit("commit1");
-        r.cmd("git checkout -b other");
+        r.launchCommand("git", "checkout", "-b", "other");
 
         w.init();
-        w.cmd("git remote add origin " + r.repoPath());
-        w.cmd("git pull --depth=1 origin master");
+        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
+        w.launchCommand("git", "pull", "--depth=1", "origin", "master");
 
         w.touch("file2");
         w.git.add("file2");
@@ -1822,7 +1819,7 @@ public abstract class GitAPITestCase extends TestCase {
         try {
             w.git.push("origin", "master");
             assertTrue("git < 1.9.0 can push from shallow repository", w.cgit().isAtLeastVersion(1, 9, 0, 0));
-            String remoteSha1 = r.cmd("git rev-parse master").substring(0, 40);
+            String remoteSha1 = r.launchCommand("git", "rev-parse", "master").substring(0, 40);
             assertEquals(sha1.name(), remoteSha1);
         } catch (GitException e) {
             // expected for git cli < 1.9.0
@@ -1838,12 +1835,12 @@ public abstract class GitAPITestCase extends TestCase {
         w.commitEmpty("init");
 
         w.git.addNote("foo", "commits");
-        assertEquals("foo\n", w.cmd("git notes show"));
+        assertEquals("foo\n", w.launchCommand("git", "notes", "show"));
         w.git.appendNote("alpha\rbravo\r\ncharlie\r\n\r\nbar\n\n\nzot\n\n", "commits");
         // cgit normalizes CR+LF aggressively
         // it appears to be collpasing CR+LF to LF, then truncating duplicate LFs down to 2
         // note that CR itself is left as is
-        assertEquals("foo\n\nalpha\rbravo\ncharlie\n\nbar\n\nzot\n", w.cmd("git notes show"));
+        assertEquals("foo\n\nalpha\rbravo\ncharlie\n\nbar\n\nzot\n", w.launchCommand("git", "notes", "show"));
     }
 
     public void test_notes_append_first_note() throws Exception {
@@ -1853,12 +1850,12 @@ public abstract class GitAPITestCase extends TestCase {
         w.commitEmpty("init");
 
         w.git.appendNote("foo", "commits");
-        assertEquals("foo\n", w.cmd("git notes show"));
+        assertEquals("foo\n", w.launchCommand("git", "notes", "show"));
         w.git.appendNote("alpha\rbravo\r\ncharlie\r\n\r\nbar\n\n\nzot\n\n", "commits");
         // cgit normalizes CR+LF aggressively
         // it appears to be collpasing CR+LF to LF, then truncating duplicate LFs down to 2
         // note that CR itself is left as is
-        assertEquals("foo\n\nalpha\rbravo\ncharlie\n\nbar\n\nzot\n", w.cmd("git notes show"));
+        assertEquals("foo\n\nalpha\rbravo\ncharlie\n\nbar\n\nzot\n", w.launchCommand("git", "notes", "show"));
     }
 
     /**
@@ -1875,7 +1872,7 @@ public abstract class GitAPITestCase extends TestCase {
 
         /* Make reference to master ambiguous, verify it is reported ambiguous by rev-parse */
         w.tag("master"); // ref "master" is now ambiguous
-        String revParse = w.cmd("git rev-parse master");
+        String revParse = w.launchCommand("git", "rev-parse", "master");
         assertTrue("'" + revParse + "' does not contain 'ambiguous'", revParse.contains("ambiguous"));
         ObjectId masterTag = w.git.revParse("refs/tags/master");
         assertEquals("masterTag != head", w.head(), masterTag);
@@ -1890,8 +1887,8 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.commit("commit1-master");
         final ObjectId masterTip = w.head();
 
-        w.cmd("git branch branch1 " + masterTip.name());
-        w.cmd("git checkout branch1");
+        w.launchCommand("git", "branch", "branch1", masterTip.name());
+        w.launchCommand("git", "checkout", "branch1");
         w.touch("file1", "content1");
         w.git.add("file1");
         w.git.commit("commit1-branch1");
@@ -2091,14 +2088,14 @@ public abstract class GitAPITestCase extends TestCase {
         /* Really remove submodule remnant, use git command line double force */
         if (w.git instanceof CliGitAPIImpl) {
             if (!isWindows()) {
-                w.cmd("git clean -xffd");
+                w.launchCommand("git", "clean", "-xffd");
             } else {
                 try {
-                    w.cmd("git clean -xffd");
+                    w.launchCommand("git", "clean", "-xffd");
                 } catch (Exception e) {
                     /* Retry once (and only once) in case of Windows busy file behavior */
                     Thread.sleep(503); /* Wait 0.5 seconds for Windows */
-                    w.cmd("git clean -xffd");
+                    w.launchCommand("git", "clean", "-xffd");
                 }
             }
         }
@@ -2469,7 +2466,7 @@ public abstract class GitAPITestCase extends TestCase {
         checkoutTimeout = 1 + random.nextInt(60 * 24);
         w.git.checkout().ref("origin/master").branch("master").timeout(checkoutTimeout).execute();
 
-        String tagsBefore = w.cmd("git tag");
+        String tagsBefore = w.launchCommand("git", "tag");
         Set<String> tagNamesBefore = w.git.getTagNames(null);
         for (String tag : tagNamesBefore) {
             assertTrue(tag + " not in " + tagsBefore, tagsBefore.contains(tag));
@@ -2478,7 +2475,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.checkout().branch("tests/getSubmodules").ref("origin/tests/getSubmodules").timeout(checkoutTimeout).execute();
         w.git.submoduleUpdate().recursive(true).execute();
 
-        String tagsAfter = w.cmd("git tag");
+        String tagsAfter = w.launchCommand("git", "tag");
         Set<String> tagNamesAfter = w.git.getTagNames(null);
         for (String tag : tagNamesAfter) {
             assertTrue(tag + " not in " + tagsAfter, tagsAfter.contains(tag));
@@ -2703,7 +2700,7 @@ public abstract class GitAPITestCase extends TestCase {
         String expected = SystemUtils.IS_OS_WINDOWS || (area.git instanceof JGitAPIImpl && isJava6()) ? "false" : "";
         String symlinkValue = null;
         try {
-            symlinkValue = w.cmd(true, "git config core.symlinks").trim();
+            symlinkValue = w.launchCommand(true, "git", "config", "core.symlinks").trim();
         } catch (Exception e) {
             symlinkValue = e.getMessage();
         }
@@ -2744,7 +2741,7 @@ public abstract class GitAPITestCase extends TestCase {
     @NotImplementedInCliGit // Until submodule rename is fixed
     public void test_getSubmoduleUrl() throws Exception {
         w = clone(localMirror());
-        w.cmd("git checkout tests/getSubmodules");
+        w.launchCommand("git", "checkout", "tests/getSubmodules");
         w.git.submoduleInit();
 
         assertEquals("https://github.com/puppetlabs/puppetlabs-firewall.git", w.igit().getSubmoduleUrl("modules/firewall"));
@@ -2759,7 +2756,7 @@ public abstract class GitAPITestCase extends TestCase {
 
     public void test_setSubmoduleUrl() throws Exception {
         w = clone(localMirror());
-        w.cmd("git checkout tests/getSubmodules");
+        w.launchCommand("git", "checkout", "tests/getSubmodules");
         w.git.submoduleInit();
 
         String DUMMY = "/dummy";
@@ -2779,19 +2776,19 @@ public abstract class GitAPITestCase extends TestCase {
         WorkingArea ws2 = w.init();
 
         ws1.commitEmpty("c");
-        ws1.cmd("git remote add origin " + r.repoPath());
+        ws1.launchCommand("git", "remote", "add", "origin", r.repoPath());
 
-        ws1.cmd("git push origin master:b1");
-        ws1.cmd("git push origin master:b2");
-        ws1.cmd("git push origin master");
+        ws1.launchCommand("git", "push", "origin", "master:b1");
+        ws1.launchCommand("git", "push", "origin", "master:b2");
+        ws1.launchCommand("git", "push", "origin", "master");
 
-        ws2.cmd("git remote add origin " + r.repoPath());
-        ws2.cmd("git fetch origin");
+        ws2.launchCommand("git", "remote", "add", "origin", r.repoPath());
+        ws2.launchCommand("git", "fetch", "origin");
 
         // at this point both ws1&ws2 have several remote tracking branches
 
-        ws1.cmd("git push origin :b1");
-        ws1.cmd("git push origin master:b3");
+        ws1.launchCommand("git", "push", "origin", ":b1");
+        ws1.launchCommand("git", "push", "origin", "master:b3");
 
         ws2.git.prune(new RemoteConfig(new Config(),"origin"));
 
@@ -2808,7 +2805,7 @@ public abstract class GitAPITestCase extends TestCase {
         for (ObjectId id : w.git.revListAll()) {
             out.append(id.name()).append('\n');
         }
-        String all = w.cmd("git rev-list --all");
+        String all = w.launchCommand("git", "rev-list", "--all");
         assertEquals(all,out.toString());
     }
 
@@ -2826,7 +2823,7 @@ public abstract class GitAPITestCase extends TestCase {
         for (ObjectId id : oidList) {
             out.append(id.name()).append('\n');
         }
-        String all = w.cmd("git rev-list --all");
+        String all = w.launchCommand("git", "rev-list", "--all");
         assertEquals(all,out.toString());
     }
 
@@ -2848,7 +2845,7 @@ public abstract class GitAPITestCase extends TestCase {
                 out.append(id.name()).append('\n');
             }
 
-            String all = w.cmd("git rev-list --first-parent " + b.getName());
+            String all = w.launchCommand("git", "rev-list", "--first-parent",  b.getName());
             assertEquals(all,out.toString());
         }
     }
@@ -2862,7 +2859,7 @@ public abstract class GitAPITestCase extends TestCase {
             for (ObjectId id : w.git.revList(b.getName())) {
                 out.append(id.name()).append('\n');
             }
-            String all = w.cmd("git rev-list " + b.getName());
+            String all = w.launchCommand("git", "rev-list", b.getName());
             assertEquals(all,out.toString());
         }
     }
@@ -3157,7 +3154,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.commit("commit1-branch1");
         final ObjectId branch1 = w.head();
 
-        w.cmd("git branch branch2 master");
+        w.launchCommand("git", "branch", "branch2", "master");
         w.git.checkout("branch2");
         File f = w.touch("file2", "content2");
         w.git.add("file2");
@@ -3194,7 +3191,7 @@ public abstract class GitAPITestCase extends TestCase {
         if (!w.cgit().isAtLeastVersion(1, 7, 9, 0)) {
             return;
         }
-        w.cmd("git checkout --orphan newroot"); // Create an independent root
+        w.launchCommand("git", "checkout", "--orphan", "newroot"); // Create an independent root
         w.commitEmpty("init-on-newroot");
         final ObjectId newRootCommit = w.head();
         assertNull("Common root not expected", w.igit().mergeBase(newRootCommit, branch1));
@@ -3633,7 +3630,7 @@ public abstract class GitAPITestCase extends TestCase {
     }
 
     public void test_getHeadRev_remote() throws Exception {
-        String lsRemote = w.cmd("git ls-remote -h " + remoteMirrorURL + " refs/heads/master");
+        String lsRemote = w.launchCommand("git", "ls-remote", "-h", remoteMirrorURL, "refs/heads/master");
         ObjectId lsRemoteId = ObjectId.fromString(lsRemote.substring(0, 40));
         check_headRev(remoteMirrorURL, lsRemoteId);
     }
@@ -3673,7 +3670,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.commit("commit1-branch1");
         final ObjectId branch1 = w.head();
 
-        w.cmd("git branch branch.2 master");
+        w.launchCommand("git", "branch", "branch.2", "master");
         w.git.checkout("branch.2");
         File f = w.touch("file.2", "content2");
         w.git.add("file.2");
@@ -3833,14 +3830,14 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_describe() throws Exception {
         w.init();
         w.commitEmpty("first");
-        w.tag("-m test t1");
+        w.launchCommand("git", "tag", "-m", "test", "t1");
         w.touch("a");
         w.git.add("a");
         w.git.commit("second");
-        assertThat(w.cmd("git describe").trim(), sharesPrefix(w.git.describe("HEAD")));
+        assertThat(w.launchCommand("git", "describe").trim(), sharesPrefix(w.git.describe("HEAD")));
 
-        w.tag("-m test2 t2");
-        assertThat(w.cmd("git describe").trim(), sharesPrefix(w.git.describe("HEAD")));
+        w.launchCommand("git", "tag", "-m", "test2", "t2");
+        assertThat(w.launchCommand("git", "describe").trim(), sharesPrefix(w.git.describe("HEAD")));
     }
 
     public void test_getAllLogEntries() throws Exception {
@@ -3879,7 +3876,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.commitEmpty("c1");
         ObjectId c1 = w.head();
 
-        w.cmd("git branch Z "+c1.name());
+        w.launchCommand("git", "branch", "Z", c1.name());
         w.git.checkout("Z");
         w.commitEmpty("T");
         ObjectId t = w.head();
@@ -3887,15 +3884,15 @@ public abstract class GitAPITestCase extends TestCase {
         ObjectId c2 = w.head();
         w.commitEmpty("Z");
 
-        w.cmd("git branch X "+c1.name());
+        w.launchCommand("git", "branch", "X", c1.name());
         w.git.checkout("X");
         w.commitEmpty("X");
 
-        w.cmd("git branch Y "+c1.name());
+        w.launchCommand("git", "branch", "Y", c1.name());
         w.git.checkout("Y");
         w.commitEmpty("c3");
         ObjectId c3 = w.head();
-        w.cmd("git merge --no-ff -m Y "+c2.name());
+        w.launchCommand("git", "merge", "--no-ff", "-m", "Y", c2.name());
 
         w.git.deleteBranch("master");
         assertEquals(3,w.git.getBranches().size());     // X, Y, and Z
@@ -3942,25 +3939,25 @@ public abstract class GitAPITestCase extends TestCase {
 
     public void test_checkout_null_ref() throws Exception {
         w = clone(localMirror());
-        String branches = w.cmd("git branch -l");
+        String branches = w.launchCommand("git", "branch", "-l");
         assertTrue("master branch not current branch in " + branches, branches.contains("* master"));
         final String branchName = "test-checkout-null-ref-branch-" + java.util.UUID.randomUUID().toString();
-        branches = w.cmd("git branch -l");
+        branches = w.launchCommand("git", "branch", "-l");
         assertFalse("test branch originally listed in " + branches, branches.contains(branchName));
         w.git.checkout(null, branchName);
-        branches = w.cmd("git branch -l");
+        branches = w.launchCommand("git", "branch", "-l");
         assertTrue("test branch not current branch in " + branches, branches.contains("* " + branchName));
     }
 
     public void test_checkout() throws Exception {
         w = clone(localMirror());
-        String branches = w.cmd("git branch -l");
+        String branches = w.launchCommand("git", "branch", "-l");
         assertTrue("master branch not current branch in " + branches, branches.contains("* master"));
         final String branchName = "test-checkout-branch-" + java.util.UUID.randomUUID().toString();
-        branches = w.cmd("git branch -l");
+        branches = w.launchCommand("git", "branch", "-l");
         assertFalse("test branch originally listed in " + branches, branches.contains(branchName));
         w.git.checkout("6b7bbcb8f0e51668ddba349b683fb06b4bd9d0ea", branchName); // git-client-1.6.0
-        branches = w.cmd("git branch -l");
+        branches = w.launchCommand("git", "branch", "-l");
         assertTrue("test branch not current branch in " + branches, branches.contains("* " + branchName));
         String sha1 = w.git.revParse("HEAD").name();
         String sha1Expected = "6b7bbcb8f0e51668ddba349b683fb06b4bd9d0ea";
@@ -4150,7 +4147,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.tag("t1");
 
         // delete the file from git
-        w.cmd("git rm foo");
+        w.launchCommand("git", "rm", "foo");
         w.git.commit("c2");
         assertFalse(w.file("foo").exists());
 
@@ -4362,7 +4359,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertFalse("added-file exists at commit1", w.file("added-file").exists());
         assertFalse("touched-file exists at commit1", w.file("added-file").exists());
 
-        w.cmd("git rm committed-file");
+        w.launchCommand("git", "rm", "committed-file");
         w.touch("added-file", "File 2 content " + java.util.UUID.randomUUID().toString());
         w.git.add("added-file");
         w.touch("touched-file", "File 3 content " + java.util.UUID.randomUUID().toString());
@@ -4489,7 +4486,7 @@ public abstract class GitAPITestCase extends TestCase {
         assert_longpaths(false);
         w.init();
         assert_longpaths(w, false);
-        w.cmd("git config core.longpaths true");
+        w.launchCommand("git", "config", "core.longpaths", "true");
         assert_longpaths(w, true);
         check_longpaths(true);
         assert_longpaths(w, true);
@@ -4501,7 +4498,7 @@ public abstract class GitAPITestCase extends TestCase {
         assert_longpaths(false);
         w.init();
         assert_longpaths(w, false);
-        w.cmd("git config core.longpaths false");
+        w.launchCommand("git", "config", "core.longpaths", "false");
         assert_longpaths(w, false);
         check_longpaths(false);
         assert_longpaths(w, false);


### PR DESCRIPTION
## Require Java 8 and Jenkins 2.121.1, allow JDK 11 compile

Just enough changes to allow Java 8, Java 11, and Jenkins 2.121.1.

Match with the changes made in git plugin 3.8.0 so that both git plugin and git client plugin require Java 8 and at least Jenkins 2.121.1, and they both can compile with Java 11.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No findbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)