### PR TITLE
Exclude ssh-cli-auth dep for Jenkins 2.176.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,9 +124,6 @@
       <artifactId>git-server</artifactId>
       <version>1.7</version>
       <scope>test</scope>
-      <exclusions>
-
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
@@ -139,6 +136,13 @@
       <artifactId>sshd</artifactId>
       <version>2.6</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Jenkins 2.176.1 requires a newer version -->
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>ssh-cli-auth</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Exclude ssh-cli-auth dep for Jenkins 2.176.1

Add an exclusion for a newer version of ssh-cli-auth required by Jenkins 2.176.1.  Allows compile and test with `mvn clean -Djenkins.version=2.176.1 verify`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)