### PR TITLE
Use parent pom 3.46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.45</version>
+    <version>3.46</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
+    <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
     <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
     <jgit.version>4.5.7.201904151645-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.1.8</version>
+      <version>3.1.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Use parent pom 3.46

Update pom to use latest parent and to update two other dependencies

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)