### PR TITLE
Bump plugin from 3.46 to 3.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.46</version>
+    <version>3.47</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Bumps plugin from 3.46 to 3.47.



## Use parent pom 3.47 - latest

Use the latest parent pom.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)