### PR TITLE
GitExceptionTest failed when run as root

### DIFF
--- a/src/test/java/hudson/plugins/git/GitExceptionTest.java
+++ b/src/test/java/hudson/plugins/git/GitExceptionTest.java
@@ -18,6 +18,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 import org.junit.rules.TemporaryFolder;
 import static org.hamcrest.CoreMatchers.is;
 
@@ -55,23 +56,12 @@ public class GitExceptionTest {
     }
 
     @Test
-    public void initDefaultImplThrowsGitException() throws GitAPIException, IOException, InterruptedException {
-        File badDirectory = new File("/this/is/a/bad/dir");
-        if (isWindows()) {
-            badDirectory = new File("\\\\badserver\\badshare\\bad\\dir");
-        }
-        GitClient defaultClient = Git.with(TaskListener.NULL, new EnvVars()).in(badDirectory).using("Default").getClient();
-        assertNotNull(defaultClient);
-        thrown.expect(GitException.class);
-        defaultClient.init_().workspace(badDirectory.getAbsolutePath()).execute();
-    }
-
-    @Test
     public void initCliImplThrowsGitException() throws GitAPIException, IOException, InterruptedException {
         File badDirectory = new File("/this/is/a/bad/dir");
         if (isWindows()) {
             badDirectory = new File("\\\\badserver\\badshare\\bad\\dir");
         }
+        assumeFalse("running as root?", new File("/").canWrite());
         GitClient defaultClient = Git.with(TaskListener.NULL, new EnvVars()).in(badDirectory).using("git").getClient();
         assertNotNull(defaultClient);
         thrown.expect(GitException.class);
@@ -84,6 +74,7 @@ public class GitExceptionTest {
         if (isWindows()) {
             badDirectory = new File("\\\\badserver\\badshare\\bad\\dir");
         }
+        assumeFalse("running as root?", new File("/").canWrite());
         GitClient defaultClient = Git.with(TaskListener.NULL, new EnvVars()).in(badDirectory).using("jgit").getClient();
         assertNotNull(defaultClient);
         thrown.expect(JGitInternalException.class);


### PR DESCRIPTION
Discovered as part of https://github.com/jenkinsci/bom/pull/36, which runs this plugin’s tests under PCT in a Docker container running as root. (Would also see this if switching `linux` to `maven` in the `buildPlugin` config.)

Verified with

```sh
docker run -v ~/.m2:/var/maven/.m2 -ti --rm --name mvn -e MAVEN_CONFIG=/var/maven/.m2 -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven maven:3.6.1-jdk-8 mvn -Duser.home=/var/maven surefire:test -Dtest=GitExceptionTest
```