### PR TITLE
Add dependabot config and update parent pom

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+
+update_configs:
+  - package_manager: "java:maven"
+    directory: "/"
+    update_schedule: "weekly"
+    target_branch: "stable-2.8"
+    default_reviewers:
+      - "MarkEWaite"
+    default_labels:
+      - "no-changelog"

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.47</version>
+    <version>3.48</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Add dependabot config and update parent pom

Dependabot has been quite helpful tracking dependency updates in the repository.  Configure it to propose changes to the stable branch which can then be merged to master.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)