### PR TITLE
[JENKINS-53933] set file permissions to allow use of openssh on windows

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIWindowsFilePermissionsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIWindowsFilePermissionsTest.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.plugins.gitclient;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.UserPrincipal;
+import java.nio.file.attribute.UserPrincipalLookupService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+public class CliGitAPIWindowsFilePermissionsTest {
+
+    private CliGitAPIImpl cliGit;
+    private File file;
+    private AclFileAttributeView fileAttributeView;
+    private UserPrincipal userPrincipal;
+
+    @Before
+    public void beforeEach() throws Exception {
+        assumeTrue(isWindows());
+        cliGit = new CliGitAPIImpl("git", new File("."), null, null);
+        file = cliGit.createTempFile("permission", ".suff");
+        Path path = Paths.get(file.toURI());
+        fileAttributeView = Files.getFileAttributeView(path, AclFileAttributeView.class);
+        assertNotNull(fileAttributeView);
+        userPrincipal = fileAttributeView.getOwner();
+        assertNotNull(userPrincipal);
+    }
+
+    @Test
+    public void test_windows_file_permission_is_set_correctly() throws Exception {
+        cliGit.fixSshKeyOnWindows(file);
+        assertEquals(1, fileAttributeView.getAcl().size());
+        AclEntry aclEntry = fileAttributeView.getAcl().get(0);
+        assertTrue(aclEntry.flags().isEmpty());
+        assertEquals(CliGitAPIImpl.ACL_ENTRY_PERMISSIONS, aclEntry.permissions());
+        assertEquals(userPrincipal, aclEntry.principal());
+        assertEquals(AclEntryType.ALLOW, aclEntry.type());
+    }
+
+    @Test
+    public void test_windows_file_permission_are_incorrect() throws Exception {
+        // By default files include System and builtin administrators
+        assertNotSame(1, fileAttributeView.getAcl().size());
+        for (AclEntry entry : fileAttributeView.getAcl()) {
+            if (entry.principal().equals(userPrincipal)) {
+                assertNotSame(CliGitAPIImpl.ACL_ENTRY_PERMISSIONS, entry.permissions());
+            }
+        }
+    }
+
+    /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */
+    private boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
+}


### PR DESCRIPTION
## [JENKINS-53933](https://issues.jenkins-ci.org/browse/JENKINS-53933) - Set windows openssh permissions

Fixes open ssh client issues.
Cherrypick #371 and #406 into `stable-2.8`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
