### PR TITLE
Reduce test configs 50%

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 #!groovy
 
 // build recommended configurations
-buildPlugin(configurations: buildPlugin.recommendedConfigurations(),
-            failFast: false)
+subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                      ],
+                        [ jdk: '8',  platform: 'linux',   jenkins: '2.164.1', javaLevel: '8' ],
+                        [ jdk: '11', platform: 'linux',   jenkins: '2.164.1', javaLevel: '8' ]
+                      ]
+
+buildPlugin(configurations: subsetConfiguration, failFast: false)


### PR DESCRIPTION
Faster build is valuable


## Reduce test configs by 50%

Accept that Java 11 on Windows is rare and Windows testing is slower.
Accept that Jenkins 2.164 and later are more common and more interesting.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)