### PR TITLE
Fix test failure when running as root user

### DIFF
--- a/src/test/java/hudson/plugins/git/GitExceptionTest.java
+++ b/src/test/java/hudson/plugins/git/GitExceptionTest.java
@@ -20,6 +20,7 @@ import org.junit.rules.ExpectedException;
 import static org.junit.Assert.*;
 import org.junit.rules.TemporaryFolder;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assume.*;
 
 public class GitExceptionTest {
 
@@ -72,6 +73,7 @@ public class GitExceptionTest {
         if (isWindows()) {
             badDirectory = new File("\\\\badserver\\badshare\\bad\\dir");
         }
+        assumeFalse("running as root?", new File("/").canWrite());
         GitClient defaultClient = Git.with(TaskListener.NULL, new EnvVars()).in(badDirectory).using("git").getClient();
         assertNotNull(defaultClient);
         thrown.expect(GitException.class);
@@ -84,6 +86,7 @@ public class GitExceptionTest {
         if (isWindows()) {
             badDirectory = new File("\\\\badserver\\badshare\\bad\\dir");
         }
+        assumeFalse("running as root?", new File("/").canWrite());
         GitClient defaultClient = Git.with(TaskListener.NULL, new EnvVars()).in(badDirectory).using("jgit").getClient();
         assertNotNull(defaultClient);
         thrown.expect(JGitInternalException.class);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
@@ -92,9 +92,10 @@ public class FilePermissionsTest {
         Set<PosixFilePermission> expected = PosixFilePermissions.fromString(rwx);
         Path path = FileSystems.getDefault().getPath(file.getPath());
         PosixFileAttributes attrs = Files.getFileAttributeView(path, PosixFileAttributeView.class).readAttributes();
-        boolean expectExecutePerm = expected.contains(PosixFilePermission.OWNER_EXECUTE);
-        boolean actualExecutePerm = attrs.permissions().contains(PosixFilePermission.OWNER_EXECUTE);
-        assertEquals(fileName + " execute perm mismatch", expectExecutePerm, actualExecutePerm);
+        assertEquals(fileName + " OWNER_EXECUTE (execute) perm mismatch, expected: " + expected + ", was actually: " + attrs.permissions(),
+                     expected.contains(PosixFilePermission.OWNER_EXECUTE),
+                     attrs.permissions().contains(PosixFilePermission.OWNER_EXECUTE)
+                     );
     }
 
     @After
@@ -108,8 +109,11 @@ public class FilePermissionsTest {
         /* 0640 and 0740 are the only permissions to be tested */
         Integer[] permissionArray0640 = {0640};
         permissions.add(permissionArray0640);
-        Integer[] permissionArray0740 = {0740};
-        permissions.add(permissionArray0740);
+        /* When running as root, execute permission is NOT preserved, don't test it */
+        if (!(new File("/").canWrite())) {
+            Integer[] permissionArray0740 = {0740};
+            permissions.add(permissionArray0740);
+        }
         return permissions;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -461,8 +461,9 @@ public class GitClientTest {
     }
 
     @Test
-    public void testInitFailureNotWindows() throws Exception {
+    public void testInitFailureNotWindowsNotSuperUser() throws Exception {
         assumeFalse(isWindows());
+        assumeFalse("running as root?", new File("/").canWrite());
         String badDirName = "/this/directory/is/not/accessible";
         File badDir = new File(badDirName);
         GitClient badGitClient = Git.with(TaskListener.NULL, new EnvVars()).in(badDir).using(gitImplName).getClient();


### PR DESCRIPTION
## Fix test failure when running as root user

Test assumes it is running as an unprivileged user and relies on that for a failure case.  Fix that and release a new version so that the BOM can depend on a released version which includes passing tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)