### PR TITLE
Exclude jsr305 from plugin packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,6 @@
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
-      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -176,6 +175,18 @@
       <version>2.1.13</version>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.138.1</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,12 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## [JENKINS-47449](https://issues.jenkins-ci.org/browse/JENKINS-47449) - Do not package jsr305 in git-client hpi

The spotbugs annotation has a transitive dependency on jsr305.  Since the spotbugs dependency is optional, it is not included in the hpi file. However, its transitive dependency is included in the hpi file.  We don't need to include jsr305, so exclude it in the pom.

Switch to use the BOM for the test dependencies as well, consistent with git plugin use of BOM.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)