### PR TITLE
Test with Jenkins 2.176.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,12 @@
 #!groovy
 
+Random random = new Random() // Randomize which Jenkins version is selected for more testing
+def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other
+
 // build recommended configurations
 subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                      ],
-                        [ jdk: '8',  platform: 'linux',   jenkins: '2.164.1', javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins: '2.164.1', javaLevel: '8' ]
+                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.176.3' : '2.164.1', javaLevel: '8' ],
+                        [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.176.3' : '2.164.1', javaLevel: '8' ]
                       ]
 
 buildPlugin(configurations: subsetConfiguration, failFast: false)


### PR DESCRIPTION
## Test with Jenkins 2.176.3

Improve test coverage by testing one configuration with 2.164 and one with 2.176.  Do not increase test time.  Accept that covering less than the full matrix may leave bugs undetected for a few iterations.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)