### PR TITLE
Test for JENKINS-56257 in CLI git

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -508,7 +508,19 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 StandardCredentials cred = credentials.get(url.toPrivateString());
                 if (cred == null) cred = defaultCredentials;
-                addCheckedRemoteUrl(args, url.toPrivateASCIIString());
+                if (isAtLeastVersion(1,8,0,0)) {
+                    addCheckedRemoteUrl(args, url.toPrivateASCIIString());
+                } else {
+                    // CLI git 1.7.1 on CentOS 6 rejects URL encoded
+                    // repo URL. This is how git client behaved before
+                    // 2.8.5, with the addition of a safety check for
+                    // the remote URL string contents.
+                    //
+                    // CLI git 1.7.1 is unsupported by the git client
+                    // plugin, but we try to avoid removing
+                    // capabilities that worked previously.
+                    addCheckedRemoteUrl(args, url.toString());
+                }
 
                 if (refspecs != null)
                     for (RefSpec rs: refspecs)

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -362,7 +362,7 @@ public class CredentialsTest {
 
     @Test
     @Issue("JENKINS-50573")
-    public void testFetchWithCredentials() throws URISyntaxException, GitException, InterruptedException, MalformedURLException, IOException {
+    public void testFetchWithCredentials() throws Exception {
         assumeTrue(testPeriodNotExpired());
         File clonedFile = new File(repo, fileToCheck);
         git.init_().workspace(repo.getAbsolutePath()).execute();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.StringJoiner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -334,13 +335,11 @@ public class CredentialsTest {
 
     private String listDir(File dir) {
         File[] files = repo.listFiles();
-        StringBuilder fileList = new StringBuilder();
+        StringJoiner joiner = new StringJoiner(",");
         for (File file : files) {
-            fileList.append(file.getName());
-            fileList.append(',');
+            joiner.add(file.getName());
         }
-        fileList.deleteCharAt(fileList.length() - 1);
-        return fileList.toString();
+        return joiner.toString();
     }
 
     private void addCredential() throws IOException {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -381,7 +381,7 @@ public class CredentialsTest {
             subcmd.execute();
         }
         assertTrue("master: " + master + " not in repo", git.isCommitInRepo(master));
-        assertEquals("Master != HEAD", master, git.getRepository().getRef("master").getObjectId());
+        assertEquals("Master != HEAD", master, git.getRepository().findRef("master").getObjectId());
         assertEquals("Wrong branch", "master", git.getRepository().getBranch());
         assertTrue("No file " + fileToCheck + ", has " + listDir(repo), clonedFile.exists());
         /* prune opens a remote connection to list remote branches */


### PR DESCRIPTION
## [JENKINS-56257](https://issues.jenkins-ci.org/browse/JENKINS-56257) - Allow git URL with embedded username/password

It is generally a poor security practice to embed the username and password in the Git repository https URL, but there are cases where it may be the best solution for a specific problem.
Prior to git client plugin 2.8.5, username and password embedded in the repository URL were ignored or mangled.
This change adds automated tests to confirm that embedded usernanme and password now work.

See also [JENKINS-41066](https://issues.jenkins-ci.org/browse/JENKINS-41066)

Thanks to @ckrams for submitting the original proposal to fix this in #416

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)