### PR TITLE
Run tests in parallel to reduce overall execution time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
     <jgit.version>5.5.0.201909110433-r</jgit.version>
+    <forkCount>1C</forkCount>
   </properties>
 
   <dependencies>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -86,9 +86,6 @@ public class CredentialsTest {
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
-    @Rule
-    public TestRule timeout = new DisableOnDebug(Timeout.seconds(17));
-
     private int logCount;
     private LogHandler handler;
     private LogTaskListener listener;


### PR DESCRIPTION
The timeout setting in `CredentialsTest` has to be removed because due to parallel running tests individual methods may run slower.