### PR TITLE
Use plugin BOM for dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.49</version>
+    <version>3.50</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -147,17 +146,14 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.13</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jsch</artifactId>
-      <version>0.1.54.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.3-2.0</version>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>
@@ -178,7 +174,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.13</version>
     </dependency>
   </dependencies>
 
@@ -187,7 +182,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom</artifactId>
-        <version>2.138.1</version>
+        <version>2.138.2</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>git-client</artifactId>
-  <version>2.8.7-SNAPSHOT</version>
+  <version>2.9.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Jenkins Git client plugin</name>
@@ -45,7 +45,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
-    <jenkins.version>2.121.1</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
     <jgit.version>4.5.7.201904151645-r</jgit.version>
     <jgit.javadoc.version>4.5.0.201609210915-r</jgit.javadoc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git-server</artifactId>
-      <version>1.7</version>
+      <version>1.8</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Use plugin BOM for dependencies

Switches from internally maintaining a compilable version number for each component to specifically use the version provided by Jenkins plugin BOM 2.138.2.  Switches plugin version to 2.9.x as a result of that change of BOM.

Updates required Jenkins version from 2.121.1 to 2.138.4, matching the required Jenkins version of Git plugin 3.12.0 and later.

Strategy change is inspired by a desire to move users onto the most heavily tested plugin versions.  Users that don't want to update dependencies are welcome to choose to remain with older versions of this plugin.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)