### PR TITLE
Fix testcase when cli git signs commit

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -3168,7 +3168,19 @@ public abstract class GitAPITestCase extends TestCase {
         String mergeMessage = "Merge message to be tested.";
         w.git.merge().setMessage(mergeMessage).setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF).setRevisionToMerge(w.git.getHeadRev(w.repoPath(), "branch1")).execute();
         // Obtain last commit message
-        String resultMessage = w.git.showRevision(w.head()).get(7).trim();
+        String resultMessage = "";
+        final List<String> content = w.git.showRevision(w.head());
+        if ("gpgsig -----BEGIN PGP SIGNATURE-----".equals(content.get(6).trim())) {
+            //Commit is signed so the commit message is after the signature
+            for (int i = 6; i < content.size(); i++) {
+                if(content.get(i).trim().equals("-----END PGP SIGNATURE-----")) {
+                    resultMessage = content.get(i+2).trim();
+                    break;
+                }
+            }
+        } else {
+            resultMessage = content.get(7).trim();
+        }
 
         assertEquals("Custom message merge failed. Should have set custom merge message.", mergeMessage, resultMessage);
     }


### PR DESCRIPTION
## Fix testcase when cli git signs commit

org.jenkinsci.plugins.gitclient.GitAPITestCase#test_merge_with_message assumed that the commit message was on line 7 of the revision output. But when cli git is globally configured to sign each commit then line 7 is the start of the gpg signature (an empty line)

This fix checks if there is such a signature in the revision output and instead assumes that the commit message is two lines below the end of the signature.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)