### PR TITLE
Test with Jenkins 2.190.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,8 @@ def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build b
 
 // build recommended configurations
 subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                      ],
-                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.176.3' : '2.164.1', javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.176.3' : '2.164.1', javaLevel: '8' ]
+                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.190.2' : '2.164.1', javaLevel: '8' ],
+                        [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.190.2' : '2.164.1', javaLevel: '8' ]
                       ]
 
 buildPlugin(configurations: subsetConfiguration, failFast: false)

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.1.9</version>
+      <version>3.1.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>trilead-api</artifactId>
+      <version>1.0.1</version>
+      <exclusions>
+        <exclusion><!-- Provided by trilead-api plugin, do not bundle transient dependency in jar -->
+          <groupId>net.i2p.crypto</groupId>
+          <artifactId>eddsa</artifactId>
+        </exclusion>
+      </exclusions>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
       <version>2.6</version>
@@ -158,6 +170,30 @@
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency><!-- Jenkins 2.190.1 requires this newer version -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>1.7.26</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency><!-- Jenkins 2.190.1 requires this newer version -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.26</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency><!-- Jenkins 2.190.1 requires this newer version -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>1.7.26</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency><!-- Jenkins 2.190.1 requires this newer version -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>1.7.26</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Test with Jenkins 2.190.1

Jenkins 2.190.1 is the most recent long term support release.  Test with that release instead of 2.176.x.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of Changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)

## Additional Comments

Intentionally depends on an older version of trilead-api so that it will not break compatibility with Jenkins 2.138.x.  The trilead-api 1.0.2 and 1.0.3 releases require Jenkins 2.150.1.  The trilead-api plugin 1.0.4 and 1.0.5 releases require Jenkins 2.184.