### PR TITLE
[JENKINS-57326] JCasC support for GitTool and subtypes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <java.level>8</java.level>
     <jgit.version>4.5.7.201904151645-r</jgit.version>
     <jgit.javadoc.version>4.5.0.201609210915-r</jgit.javadoc.version>
-    <jcasc.version>1.29</jcasc.version>
+    <jcasc.version>1.30</jcasc.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <java.level>8</java.level>
     <jgit.version>4.5.7.201904151645-r</jgit.version>
     <jgit.javadoc.version>4.5.0.201609210915-r</jgit.javadoc.version>
+    <jcasc.version>1.29</jcasc.version>
   </properties>
 
   <repositories>
@@ -174,6 +175,20 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
+    </dependency>
+    <!-- JCasC compatibility -->
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/hudson/plugins/git/GitTool.java
+++ b/src/main/java/hudson/plugins/git/GitTool.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import static hudson.init.InitMilestone.EXTENSIONS_AUGMENTED;
-import java.util.logging.Level;
 
 /**
  * Information about Git installation. A GitTool is used to select

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitToolConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitToolConfigurator.java
@@ -1,0 +1,127 @@
+package org.jenkinsci.plugins.gitclient;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.plugins.git.GitTool;
+import hudson.tools.ToolProperty;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.Configurator;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Sequence;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Extension(optional = true)
+public class GitToolConfigurator extends BaseConfigurator<GitTool> {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "git";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Git";
+    }
+
+    @Override
+    public Class getTarget() {
+        return GitTool.class;
+    }
+
+    @Override
+    public boolean canConfigure(Class clazz) {
+        return clazz == GitTool.class;
+    }
+
+    @NonNull
+    @Override
+    public Class getImplementedAPI() {
+        return getTarget();
+    }
+
+    @NonNull
+    @Override
+    public List<Configurator<GitTool>> getConfigurators(ConfigurationContext context) {
+        return Collections.singletonList(this);
+    }
+
+    @NonNull
+    @Override
+    public List<Attribute<GitTool, ?>> getAttributes() {
+        Attribute<GitTool, String> name = new Attribute<>("name", String.class);
+        Attribute<GitTool, String> home = new Attribute<>("home", String.class);
+        Attribute<GitTool, ToolProperty> p = new Attribute<>("properties", ToolProperty.class);
+        p.multiple(true);
+        return Arrays.asList(name, home, p);
+    }
+
+    @Override
+    protected GitTool instance(Mapping mapping, ConfigurationContext context) throws ConfiguratorException {
+        final CNode mproperties = mapping.remove("properties");
+        final String name = mapping.getScalarValue("name");
+        if (JGitTool.MAGIC_EXENAME.equals(name)) {
+            mapping.remove("home"); //Ignored but could be added, so removing to not fail handleUnknown
+            return new JGitTool(instantiateProperties(mproperties, context));
+        } else if (JGitApacheTool.MAGIC_EXENAME.equals(name)) {
+            mapping.remove("home");  //Ignored but could be added, so removing to not fail handleUnknown
+            return new JGitApacheTool(instantiateProperties(mproperties, context));
+        } else {
+            if (mapping.get("home") == null) {
+                throw new ConfiguratorException(this, "Home required for cli git configuration.");
+            }
+            String home = mapping.getScalarValue("home");
+            return new GitTool(name, home, instantiateProperties(mproperties, context));
+        }
+    }
+
+    @Nonnull
+    private List<ToolProperty<?>> instantiateProperties(@CheckForNull CNode props, @Nonnull ConfigurationContext context) throws ConfiguratorException {
+        final Configurator<ToolProperty> configurator = context.lookupOrFail(ToolProperty.class);
+        List<ToolProperty<?>> toolProperties = new ArrayList<>();
+        if (props == null) {
+            return toolProperties;
+        }
+        if (props instanceof Sequence) {
+            Sequence s = (Sequence) props;
+            for (CNode cNode : s) {
+                toolProperties.add(configurator.configure(cNode, context));
+            }
+        } else {
+            toolProperties.add(configurator.configure(props, context));
+        }
+        return toolProperties;
+    }
+
+    @Override
+    public CNode describe(GitTool instance, ConfigurationContext context) throws Exception {
+        Mapping mapping = new Mapping();
+        if (instance instanceof JGitTool) {
+            mapping.put("name", JGitTool.MAGIC_EXENAME);
+        } else if (instance instanceof JGitApacheTool) {
+            mapping.put("name", JGitApacheTool.MAGIC_EXENAME);
+        } else {
+            mapping.put("name", instance.getName());
+            mapping.put("home", instance.getHome());
+        }
+        if (instance.getProperties() != null && !instance.getProperties().isEmpty()) {
+            final Configurator<ToolProperty> configurator = context.lookupOrFail(ToolProperty.class);
+            Sequence s = new Sequence(instance.getProperties().size());
+            for (ToolProperty<?> property : instance.getProperties()) {
+                s.add(configurator.describe(property, context));
+            }
+            mapping.put("properties", s);
+        }
+        return mapping;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitToolConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitToolConfigurator.java
@@ -19,9 +19,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Logger;
 
 @Extension(optional = true)
 public class GitToolConfigurator extends BaseConfigurator<GitTool> {
+
+    private static final Logger logger = Logger.getLogger(GitToolConfigurator.class.getName());
 
     @NonNull
     @Override
@@ -71,10 +74,14 @@ public class GitToolConfigurator extends BaseConfigurator<GitTool> {
         final CNode mproperties = mapping.remove("properties");
         final String name = mapping.getScalarValue("name");
         if (JGitTool.MAGIC_EXENAME.equals(name)) {
-            mapping.remove("home"); //Ignored but could be added, so removing to not fail handleUnknown
+            if (mapping.remove("home") != null) { //Ignored but could be added, so removing to not fail handleUnknown
+                logger.warning("property `home` is ignored for `" + JGitTool.MAGIC_EXENAME + "`");
+            }
             return new JGitTool(instantiateProperties(mproperties, context));
         } else if (JGitApacheTool.MAGIC_EXENAME.equals(name)) {
-            mapping.remove("home");  //Ignored but could be added, so removing to not fail handleUnknown
+            if (mapping.remove("home") != null) { //Ignored but could be added, so removing to not fail handleUnknown
+                logger.warning("property `home` is ignored for `" + JGitApacheTool.MAGIC_EXENAME + "`");
+            }
             return new JGitApacheTool(instantiateProperties(mproperties, context));
         } else {
             if (mapping.get("home") == null) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorJenkinsRuleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorJenkinsRuleTest.java
@@ -1,0 +1,118 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 Mark Waite.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.plugins.git.GitTool;
+import hudson.tools.InstallSourceProperty;
+import hudson.tools.ToolInstallation;
+import hudson.tools.ToolInstaller;
+import hudson.tools.ToolProperty;
+import hudson.tools.ZipExtractionInstaller;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Sequence;
+import java.util.ArrayList;
+import java.util.List;
+import static org.hamcrest.Matchers.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class GitToolConfiguratorJenkinsRuleTest {
+
+    private final GitToolConfigurator gitToolConfigurator;
+
+    public GitToolConfiguratorJenkinsRuleTest() {
+        gitToolConfigurator = new GitToolConfigurator();
+    }
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testDescribeGitToolEmptyProperties() throws Exception {
+        String gitName = "git-2.19.1-name";
+        String gitHome = "/opt/git-2.19.1/bin/git";
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+
+        // Intentionally empty properties passed to GitTool constructor
+        List<ToolProperty<ToolInstallation>> gitToolProperties = new ArrayList<>();
+
+        GitTool gitTool = new GitTool(gitName, gitHome, gitToolProperties);
+
+        CNode cNode = gitToolConfigurator.describe(gitTool, context);
+
+        assertThat(cNode, is(notNullValue()));
+        assertThat(cNode.getType(), is(CNode.Type.MAPPING));
+        Mapping cNodeMapping = cNode.asMapping();
+        assertThat(cNodeMapping.getScalarValue("name"), is(gitName));
+        assertThat(cNodeMapping.getScalarValue("home"), is(gitHome));
+    }
+
+    @Test
+    public void testDescribeGitTool() throws Exception {
+        String gitName = "git-2.19.1-name";
+        String gitHome = "/opt/git-2.19.1/bin/git";
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+
+        List<ToolProperty<ToolInstallation>> gitToolProperties = new ArrayList<>();
+        List<ToolInstaller> toolInstallers = new ArrayList<>();
+        ToolInstaller toolInstaller = new ZipExtractionInstaller("tool-label", "tool-url", "tool-subdir");
+        toolInstallers.add(toolInstaller);
+        InstallSourceProperty installSourceProperty = new InstallSourceProperty(toolInstallers);
+        gitToolProperties.add(installSourceProperty);
+
+        GitTool gitTool = new GitTool(gitName, gitHome, gitToolProperties);
+
+        CNode cNode = gitToolConfigurator.describe(gitTool, context);
+
+        assertThat(cNode, is(notNullValue()));
+        assertThat(cNode.getType(), is(CNode.Type.MAPPING));
+        Mapping cNodeMapping = cNode.asMapping();
+        assertThat(cNodeMapping.getScalarValue("name"), is(gitName));
+        assertThat(cNodeMapping.getScalarValue("home"), is(gitHome));
+
+        //         properties:
+        //          - installSource:
+        //              installers:
+        //                - zip:
+        //                    label: "tool-label"
+        //                    subdir: "tool-subdir"
+        //                    url: "tool-url"
+        Sequence propertiesSequence = cNodeMapping.get("properties").asSequence();                             // properties:
+        Mapping installSourceMapping = propertiesSequence.get(0).asMapping().get("installSource").asMapping(); //  - installSource:
+        Sequence installersSequence = installSourceMapping.get("installers").asSequence();                     //      installers:
+        Mapping zipMapping = installersSequence.get(0).asMapping().get("zip").asMapping();                     //        - zip:
+        assertThat(zipMapping.getScalarValue("label"), is("tool-label"));
+        assertThat(zipMapping.getScalarValue("subdir"), is("tool-subdir"));
+        assertThat(zipMapping.getScalarValue("url"), is("tool-url"));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorTest.java
@@ -84,8 +84,6 @@ public class GitToolConfiguratorTest {
     @Test
     public void testDescribeJGitTool() throws Exception {
         GitTool gitTool = new JGitTool();
-        Mapping jgitMapping = new Mapping();
-        jgitMapping.put("name", JGitTool.MAGIC_EXENAME);
         CNode cNode = gitToolConfigurator.describe(gitTool, NULL_CONFIGURATION_CONTEXT);
         assertThat(cNode, is(notNullValue()));
         assertThat(cNode.getType(), is(CNode.Type.MAPPING));
@@ -96,8 +94,6 @@ public class GitToolConfiguratorTest {
     @Test
     public void testDescribeJGitApacheTool() throws Exception {
         GitTool gitTool = new JGitApacheTool();
-        Mapping jgitMapping = new Mapping();
-        jgitMapping.put("name", JGitApacheTool.MAGIC_EXENAME);
         CNode cNode = gitToolConfigurator.describe(gitTool, NULL_CONFIGURATION_CONTEXT);
         assertThat(cNode, is(notNullValue()));
         assertThat(cNode.getType(), is(CNode.Type.MAPPING));
@@ -110,9 +106,6 @@ public class GitToolConfiguratorTest {
         String gitName = "git-name";
         String gitHome = "/opt/git-2.23.0/bin/git";
         GitTool gitTool = new GitTool(gitName, gitHome, null);
-        Mapping gitMapping = new Mapping();
-        gitMapping.put("name", gitName);
-        gitMapping.put("home", gitHome);
         CNode cNode = gitToolConfigurator.describe(gitTool, NULL_CONFIGURATION_CONTEXT);
         assertThat(cNode, is(notNullValue()));
         assertThat(cNode.getType(), is(CNode.Type.MAPPING));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorTest.java
@@ -146,9 +146,31 @@ public class GitToolConfiguratorTest {
     }
 
     @Test
+    public void testInstanceJGitToolWithHome() throws Exception {
+        Mapping mapping = new Mapping();
+        mapping.put("name", JGitTool.MAGIC_EXENAME);
+        mapping.put("home", "unused-value-for-home"); // Will log a message
+        ConfigurationContext context = new ConfigurationContext(null);
+        GitTool gitTool = gitToolConfigurator.instance(mapping, context);
+        assertThat(gitTool, is(instanceOf(JGitTool.class)));
+        assertThat(gitTool, is(not(instanceOf(JGitApacheTool.class))));
+    }
+
+    @Test
     public void testInstanceJGitApacheTool() throws Exception {
         Mapping mapping = new Mapping();
         mapping.put("name", JGitApacheTool.MAGIC_EXENAME);
+        ConfigurationContext context = new ConfigurationContext(null);
+        GitTool gitTool = gitToolConfigurator.instance(mapping, context);
+        assertThat(gitTool, is(instanceOf(JGitApacheTool.class)));
+        assertThat(gitTool, is(not(instanceOf(JGitTool.class))));
+    }
+
+    @Test
+    public void testInstanceJGitApacheToolWithHome() throws Exception {
+        Mapping mapping = new Mapping();
+        mapping.put("name", JGitApacheTool.MAGIC_EXENAME);
+        mapping.put("home", "unused-value-for-home"); // Will log a message
         ConfigurationContext context = new ConfigurationContext(null);
         GitTool gitTool = gitToolConfigurator.instance(mapping, context);
         assertThat(gitTool, is(instanceOf(JGitApacheTool.class)));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorTest.java
@@ -198,5 +198,4 @@ public class GitToolConfiguratorTest {
         Attribute<GitTool, ToolProperty> p = new Attribute<>("properties", ToolProperty.class);
         assertThat(gitToolAttributes, containsInAnyOrder(name, home, p));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorTest.java
@@ -1,0 +1,191 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 Mark Waite.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.plugins.git.GitTool;
+import hudson.tools.ToolProperty;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import java.util.List;
+import static org.hamcrest.Matchers.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class GitToolConfiguratorTest {
+
+    private final GitToolConfigurator gitToolConfigurator;
+
+    public GitToolConfiguratorTest() {
+        gitToolConfigurator = new GitToolConfigurator();
+    }
+
+    @Test
+    public void testGetName() {
+        assertThat(gitToolConfigurator.getName(), is("git"));
+    }
+
+    @Test
+    public void testGetDisplayName() {
+        assertThat(gitToolConfigurator.getDisplayName(), is("Git"));
+    }
+
+    @Test
+    public void testGetTarget() {
+        assertEquals("Wrong target class", gitToolConfigurator.getTarget(), GitTool.class);
+    }
+
+    @Test
+    public void testCanConfigure() {
+        assertTrue("Can't configure GitTool", gitToolConfigurator.canConfigure(GitTool.class));
+        assertFalse("Can configure GitToolConfigurator", gitToolConfigurator.canConfigure(GitToolConfigurator.class));
+    }
+
+    @Test
+    public void testGetImplementedAPI() {
+        assertEquals("Wrong implemented API", gitToolConfigurator.getImplementedAPI(), GitTool.class);
+    }
+
+    @Test
+    public void testGetConfigurators() {
+        ConfigurationContext ignoredContext = null;
+        assertThat(gitToolConfigurator.getConfigurators(ignoredContext), contains(gitToolConfigurator));
+    }
+
+    @Test
+    public void testDescribe() throws Exception {
+        ConfigurationContext ignoredContext = null;
+        GitTool nullGitTool = null;
+        assertThat(gitToolConfigurator.describe(nullGitTool, ignoredContext), is(new Mapping()));
+    }
+
+    @Test
+    public void testDescribeJGitTool() throws Exception {
+        GitTool gitTool = new JGitTool();
+        Mapping jgitMapping = new Mapping();
+        jgitMapping.put("name", JGitTool.MAGIC_EXENAME);
+        ConfigurationContext ignoredContext = null;
+        CNode cNode = gitToolConfigurator.describe(gitTool, ignoredContext);
+        assertThat(cNode, is(notNullValue()));
+        assertThat(cNode.getType(), is(CNode.Type.MAPPING));
+        Mapping cNodeMapping = cNode.asMapping();
+        assertThat(cNodeMapping.getScalarValue("name"), is(JGitTool.MAGIC_EXENAME));
+    }
+
+    @Test
+    public void testDescribeJGitApacheTool() throws Exception {
+        GitTool gitTool = new JGitApacheTool();
+        Mapping jgitMapping = new Mapping();
+        jgitMapping.put("name", JGitApacheTool.MAGIC_EXENAME);
+        ConfigurationContext ignoredContext = null;
+        CNode cNode = gitToolConfigurator.describe(gitTool, ignoredContext);
+        assertThat(cNode, is(notNullValue()));
+        assertThat(cNode.getType(), is(CNode.Type.MAPPING));
+        Mapping cNodeMapping = cNode.asMapping();
+        assertThat(cNodeMapping.getScalarValue("name"), is(JGitApacheTool.MAGIC_EXENAME));
+    }
+
+    @Test
+    public void testDescribeGitToolWithoutProperties() throws Exception {
+        String gitName = "git-name";
+        String gitHome = "/opt/git-2.23.0/bin/git";
+        GitTool gitTool = new GitTool(gitName, gitHome, null);
+        Mapping gitMapping = new Mapping();
+        gitMapping.put("name", gitName);
+        gitMapping.put("home", gitHome);
+        ConfigurationContext ignoredContext = null;
+        CNode cNode = gitToolConfigurator.describe(gitTool, ignoredContext);
+        assertThat(cNode, is(notNullValue()));
+        assertThat(cNode.getType(), is(CNode.Type.MAPPING));
+        Mapping cNodeMapping = cNode.asMapping();
+        assertThat(cNodeMapping.getScalarValue("name"), is(gitName));
+        assertThat(cNodeMapping.getScalarValue("home"), is(gitHome));
+    }
+
+    @Test
+    public void testInstance() throws Exception {
+        Mapping mapping = null;
+        ConfigurationContext context = new ConfigurationContext(null);
+        GitTool gitTool = gitToolConfigurator.instance(mapping, context);
+        assertThat(gitTool, is(instanceOf(GitTool.class)));
+        assertThat(gitTool.getName(), is("Default"));
+        assertThat(gitTool.getHome(), is(""));
+    }
+
+    @Test
+    public void testInstanceJGitTool() throws Exception {
+        Mapping mapping = new Mapping();
+        mapping.put("name", JGitTool.MAGIC_EXENAME);
+        ConfigurationContext context = new ConfigurationContext(null);
+        GitTool gitTool = gitToolConfigurator.instance(mapping, context);
+        assertThat(gitTool, is(instanceOf(JGitTool.class)));
+        assertThat(gitTool, is(not(instanceOf(JGitApacheTool.class))));
+    }
+
+    @Test
+    public void testInstanceJGitApacheTool() throws Exception {
+        Mapping mapping = new Mapping();
+        mapping.put("name", JGitApacheTool.MAGIC_EXENAME);
+        ConfigurationContext context = new ConfigurationContext(null);
+        GitTool gitTool = gitToolConfigurator.instance(mapping, context);
+        assertThat(gitTool, is(instanceOf(JGitApacheTool.class)));
+        assertThat(gitTool, is(not(instanceOf(JGitTool.class))));
+    }
+
+    @Test(expected = ConfiguratorException.class)
+    public void testInstanceGitToolWithoutHome() throws Exception {
+        Mapping mapping = new Mapping();
+        mapping.put("name", "testGitName"); // No home mapping defined
+        ConfigurationContext context = new ConfigurationContext(null);
+        gitToolConfigurator.instance(mapping, context);
+    }
+
+    @Test
+    public void testInstanceGitTool() throws Exception {
+        Mapping mapping = new Mapping();
+        String gitHome = "testGitHome";
+        String gitName = "testGitName";
+        mapping.put("home", gitHome);
+        mapping.put("name", gitName);
+        ConfigurationContext context = new ConfigurationContext(null);
+        GitTool gitTool = gitToolConfigurator.instance(mapping, context);
+        assertThat(gitTool, is(instanceOf(GitTool.class)));
+        assertThat(gitTool, is(not(instanceOf(JGitTool.class))));
+        assertThat(gitTool, is(not(instanceOf(JGitApacheTool.class))));
+        assertThat(gitTool.getHome(), is(gitHome));
+        assertThat(gitTool.getName(), is(gitName));
+    }
+
+    @Test
+    public void testGetAttributes() {
+        List<Attribute<GitTool, ?>> gitToolAttributes = gitToolConfigurator.getAttributes();
+        Attribute<GitTool, String> name = new Attribute<>("name", String.class);
+        Attribute<GitTool, String> home = new Attribute<>("home", String.class);
+        Attribute<GitTool, ToolProperty> p = new Attribute<>("properties", ToolProperty.class);
+        assertThat(gitToolAttributes, containsInAnyOrder(name, home, p));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.*;
 public class GitToolConfiguratorTest {
 
     private final GitToolConfigurator gitToolConfigurator;
+    private static final ConfigurationContext NULL_CONFIGURATION_CONTEXT = null;
 
     public GitToolConfiguratorTest() {
         gitToolConfigurator = new GitToolConfigurator();
@@ -71,15 +72,13 @@ public class GitToolConfiguratorTest {
 
     @Test
     public void testGetConfigurators() {
-        ConfigurationContext ignoredContext = null;
-        assertThat(gitToolConfigurator.getConfigurators(ignoredContext), contains(gitToolConfigurator));
+        assertThat(gitToolConfigurator.getConfigurators(NULL_CONFIGURATION_CONTEXT), contains(gitToolConfigurator));
     }
 
     @Test
     public void testDescribe() throws Exception {
-        ConfigurationContext ignoredContext = null;
         GitTool nullGitTool = null;
-        assertThat(gitToolConfigurator.describe(nullGitTool, ignoredContext), is(new Mapping()));
+        assertThat(gitToolConfigurator.describe(nullGitTool, NULL_CONFIGURATION_CONTEXT), is(new Mapping()));
     }
 
     @Test
@@ -87,8 +86,7 @@ public class GitToolConfiguratorTest {
         GitTool gitTool = new JGitTool();
         Mapping jgitMapping = new Mapping();
         jgitMapping.put("name", JGitTool.MAGIC_EXENAME);
-        ConfigurationContext ignoredContext = null;
-        CNode cNode = gitToolConfigurator.describe(gitTool, ignoredContext);
+        CNode cNode = gitToolConfigurator.describe(gitTool, NULL_CONFIGURATION_CONTEXT);
         assertThat(cNode, is(notNullValue()));
         assertThat(cNode.getType(), is(CNode.Type.MAPPING));
         Mapping cNodeMapping = cNode.asMapping();
@@ -100,8 +98,7 @@ public class GitToolConfiguratorTest {
         GitTool gitTool = new JGitApacheTool();
         Mapping jgitMapping = new Mapping();
         jgitMapping.put("name", JGitApacheTool.MAGIC_EXENAME);
-        ConfigurationContext ignoredContext = null;
-        CNode cNode = gitToolConfigurator.describe(gitTool, ignoredContext);
+        CNode cNode = gitToolConfigurator.describe(gitTool, NULL_CONFIGURATION_CONTEXT);
         assertThat(cNode, is(notNullValue()));
         assertThat(cNode.getType(), is(CNode.Type.MAPPING));
         Mapping cNodeMapping = cNode.asMapping();
@@ -116,8 +113,7 @@ public class GitToolConfiguratorTest {
         Mapping gitMapping = new Mapping();
         gitMapping.put("name", gitName);
         gitMapping.put("home", gitHome);
-        ConfigurationContext ignoredContext = null;
-        CNode cNode = gitToolConfigurator.describe(gitTool, ignoredContext);
+        CNode cNode = gitToolConfigurator.describe(gitTool, NULL_CONFIGURATION_CONTEXT);
         assertThat(cNode, is(notNullValue()));
         assertThat(cNode.getType(), is(CNode.Type.MAPPING));
         Mapping cNodeMapping = cNode.asMapping();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JcascTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JcascTest.java
@@ -1,0 +1,81 @@
+
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.plugins.git.GitTool;
+import hudson.tools.BatchCommandInstaller;
+import hudson.tools.InstallSourceProperty;
+import hudson.tools.ToolDescriptor;
+import hudson.tools.ToolInstallation;
+import hudson.tools.ToolProperty;
+import hudson.tools.ToolPropertyDescriptor;
+import hudson.tools.ZipExtractionInstaller;
+import hudson.util.DescribableList;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.hamcrest.collection.IsArrayContainingInAnyOrder.arrayContainingInAnyOrder;
+import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
+import static org.hamcrest.collection.IsIterableWithSize.iterableWithSize;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+public class JcascTest extends RoundTripAbstractTest {
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        final ToolDescriptor descriptor = (ToolDescriptor) restartableJenkinsRule.j.jenkins.getDescriptor(GitTool.class);
+        final ToolInstallation[] installations = descriptor.getInstallations();
+        assertThat(installations, arrayWithSize(4));
+        assertThat(installations, arrayContainingInAnyOrder(
+                allOf(
+                        instanceOf(JGitTool.class),
+                        hasProperty("name", equalTo(JGitTool.MAGIC_EXENAME))
+                ),
+                allOf(
+                        instanceOf(JGitApacheTool.class),
+                        hasProperty("name", equalTo(JGitApacheTool.MAGIC_EXENAME))
+                ),
+                allOf(
+                        instanceOf(GitTool.class),
+                        not(instanceOf(JGitTool.class)),
+                        not(instanceOf(JGitApacheTool.class)),
+                        hasProperty("name", equalTo("Default")),
+                        hasProperty("home", equalTo("git"))
+                ),
+                allOf(
+                        instanceOf(GitTool.class),
+                        not(instanceOf(JGitTool.class)),
+                        not(instanceOf(JGitApacheTool.class)),
+                        hasProperty("name", equalTo("optional")),
+                        hasProperty("home", equalTo("/opt/git/git"))
+                ))
+        );
+        final DescribableList<ToolProperty<?>, ToolPropertyDescriptor> properties = Arrays.stream(installations).filter(t -> t.getName().equals("optional")).findFirst().get().getProperties();
+        assertThat(properties, iterableWithSize(1));
+        final ToolProperty<?> property = properties.get(0);
+        assertThat(property, instanceOf(InstallSourceProperty.class));
+        assertThat(((InstallSourceProperty)property).installers,
+                containsInAnyOrder(
+                        allOf(
+                                instanceOf(BatchCommandInstaller.class),
+                                hasProperty("command", equalTo("echo \"got git\""))
+                        ),
+                        allOf(
+                                instanceOf(ZipExtractionInstaller.class),
+                                hasProperty("url", equalTo("file://some/path.zip"))
+                        )
+                )
+        );
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "installations = [JGitTool[jgit], GitTool[Default], JGitApacheTool[jgitapache], GitTool[optional]]";
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/gitclient/configuration-as-code.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/gitclient/configuration-as-code.yaml
@@ -1,0 +1,21 @@
+tool:
+  git:
+    installations:
+      - name: "jgit"
+        home: "jgit"
+      - home: "git"
+        name: "Default"
+      - name: "jgitapache"
+      - home: "/opt/git/git"
+        name: "optional"
+        properties:
+          - installSource:
+              installers:
+                - batchFile:
+                    command: "echo \"got git\""
+                    label: "test"
+                    toolHome: "/opt/git"
+                - zip:
+                    label: "win"
+                    subdir: "/opt/git"
+                    url: "file://some/path.zip"


### PR DESCRIPTION
## [JENKINS-57326](https://issues.jenkins-ci.org/browse/JENKINS-57326) - JCasC support for Git tool installers.

Different approach to #426 using a custom Configurator instead of trying to redesign the entire class structure.

## Checklist


- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [X] I have added tests that verify my changes
- [X] Unit tests pass locally with my changes
- [X] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [X] I have interactively tested my changes
- [X] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)