### PR TITLE
Use JGit 5.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
-    <jgit.version>5.5.0.201909110433-r</jgit.version>
+    <jgit.version>5.5.1.201910021850-r</jgit.version>
     <forkCount>1C</forkCount>
   </properties>
 


### PR DESCRIPTION
Fixes a performance issue when reading configuration and a bug in file system timestamp resolution.

See https://projects.eclipse.org/projects/technology.jgit/releases/5.5.1


## Use JGit 5.5.1

Do not rely on ArrayIndexOutOfBoundsException to detect end of input. Config#StringReader relied on ArrayIndexOutOfBoundsException to detect the end of the input. Creation of exception with (deep) stack trace can significantly degrade performance

WorkingTreeIterator: correctly handle different timestamp resolutions [forums 1100344](https://www.eclipse.org/forums/index.php/t/1100344/)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)