### PR TITLE
Switch from README.md to README.adoc in tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ If it fixes a bug or resolves a feature request, include a link to the issue.
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._
 
-- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
+- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
 - [ ] I have referenced the Jira issue related to my changes in one or more commit messages
 - [ ] I have added tests that verify my changes
 - [ ] Unit tests pass locally with my changes
@@ -15,7 +15,6 @@ _Put an `x` in the boxes that apply. You can also fill these out after creating 
 - [ ] No Javadoc warnings were introduced with my changes
 - [ ] No spotbugs warnings were introduced with my changes
 - [ ] I have interactively tested my changes
-- [ ] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)
 
 ## Types of changes
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -240,7 +240,7 @@ public class CredentialsTest {
                 String url = "https://github.com/jenkinsci/git-client-plugin.git";
                 /* Add URL if it matches the pattern */
                 if (URL_MUST_MATCH_PATTERN.matcher(url).matches()) {
-                    Object[] masterRepo = {implementation, url, username, null, DEFAULT_PRIVATE_KEY, null, "README.md", false, false, false};
+                    Object[] masterRepo = {implementation, url, username, null, DEFAULT_PRIVATE_KEY, null, "README.adoc", false, false, false};
                     repos.add(masterRepo);
                 }
             }
@@ -273,7 +273,7 @@ public class CredentialsTest {
                     }
 
                     if (fileToCheck == null) {
-                        fileToCheck = "README.md";
+                        fileToCheck = "README.adoc";
                     }
 
                     Boolean submodules = (Boolean) entry.get("submodules");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2437,7 +2437,7 @@ public abstract class GitAPITestCase extends TestCase {
 
     public void test_addSubmodule() throws Exception {
         String sub1 = "sub1-" + java.util.UUID.randomUUID().toString();
-        String readme1 = sub1 + File.separator + "README.md";
+        String readme1 = sub1 + File.separator + "README.adoc";
         w.init();
         assertFalse("submodule1 dir found too soon", w.file(sub1).exists());
         assertFalse("submodule1 file found too soon", w.file(readme1).exists());
@@ -3925,6 +3925,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue(paths.contains("src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java"));
         assertTrue(paths.contains("src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java"));
         // Previous implementation included other commits, and listed irrelevant changes
+        assertFalse(paths.contains("README.adoc"));
         assertFalse(paths.contains("README.md"));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
@@ -73,11 +73,11 @@ public class MergeCommandTest {
 
         // Create a master branch
         char randomChar = (char) ((new Random()).nextInt(26) + 'a');
-        readme = new File(repo, "README.md");
+        readme = new File(repo, "README.adoc");
         try (PrintWriter writer = new PrintWriter(readme, "UTF-8")) {
             writer.println("# Master Branch README " + randomChar);
         }
-        git.add("README.md");
+        git.add("README.adoc");
         git.commit("Commit README on master branch");
         commit1Master = git.revParse("HEAD");
         assertTrue("master commit 1 missing on master branch", git.revList("master").contains(commit1Master));
@@ -118,7 +118,7 @@ public class MergeCommandTest {
             writer.println("");
             writer.println("Changed on branch commit");
         }
-        git.add("README.md");
+        git.add("README.adoc");
         git.commit("Commit README change on branch 2");
         commit1Branch2 = git.revParse("HEAD");
         assertTrue("Change README commit not on branch 2", git.revListAll().contains(commit1Branch2));
@@ -131,7 +131,7 @@ public class MergeCommandTest {
             writer.println("");
             writer.println("Second commit");
         }
-        git.add("README.md");
+        git.add("README.adoc");
         git.commit("Commit 2nd README change on master branch");
         commit2Master = git.revParse("HEAD");
         assertTrue("commit 2 not on master branch", git.revListAll().contains(commit2Master));
@@ -249,9 +249,9 @@ public class MergeCommandTest {
     public void testRecursiveTheirsStrategy() throws GitException, InterruptedException, FileNotFoundException, IOException {
         mergeCmd.setStrategy(MergeCommand.Strategy.RECURSIVE_THEIRS).setRevisionToMerge(commit1Branch2).execute();
         assertTrue("branch 2 commit 1 not on master branch after merge", git.revList("master").contains(commit1Branch2));
-        assertTrue("README.md is missing on master", readme.exists());
+        assertTrue("README.adoc is missing on master", readme.exists());
         try(FileReader reader = new FileReader(readme); BufferedReader br = new BufferedReader(reader)) {
-            assertTrue("README.md does not contain expected content", br.readLine().startsWith(BRANCH_2_README_CONTENT));
+            assertTrue("README.adoc does not contain expected content", br.readLine().startsWith(BRANCH_2_README_CONTENT));
         }
     }
 


### PR DESCRIPTION
## Switch from README.md to README.adoc in tests

Tests intentionally reuse data from the git client plugin master branch. Now that the README is in adoc format, the file name changes in the tests to match what is stored on the file system.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] Any dependent changes have been merged and published in upstream modules (like git-client-plugin)

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)