### PR TITLE
Use parent pom 3.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.50</version>
+    <version>3.54</version>
     <relativePath />
   </parent>
 
@@ -111,6 +111,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.1.9</version>
+      <version>3.1.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/hudson/plugins/git/GitExceptionTest.java
+++ b/src/test/java/hudson/plugins/git/GitExceptionTest.java
@@ -20,6 +20,7 @@ import org.junit.rules.ExpectedException;
 import static org.junit.Assert.*;
 import org.junit.rules.TemporaryFolder;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assume.*;
 
 public class GitExceptionTest {
@@ -51,7 +52,7 @@ public class GitExceptionTest {
         String message = "My custom git exception message";
         thrown.expect(GitException.class);
         thrown.expectMessage(is(message));
-        thrown.expectCause(is(IOException.class));
+        thrown.expectCause(instanceOf(IOException.class));
         throw new GitException(message, new IOException("Custom IOException message"));
     }
 
@@ -90,7 +91,7 @@ public class GitExceptionTest {
         GitClient defaultClient = Git.with(TaskListener.NULL, new EnvVars()).in(badDirectory).using("jgit").getClient();
         assertNotNull(defaultClient);
         thrown.expect(JGitInternalException.class);
-        thrown.expectCause(is(IOException.class));
+        thrown.expectCause(instanceOf(IOException.class));
         defaultClient.init_().workspace(badDirectory.getAbsolutePath()).execute();
     }
 
@@ -110,7 +111,7 @@ public class GitExceptionTest {
         File dotGit = folder.newFile(".git");
         Files.write(dotGit.toPath(), "file named .git".getBytes("UTF-8"), APPEND);
         thrown.expect(JGitInternalException.class);
-        thrown.expectCause(is(IOException.class));
+        thrown.expectCause(instanceOf(IOException.class));
         GitClient defaultClient = Git.with(TaskListener.NULL, new EnvVars()).in(dir).using("jgit").getClient();
         defaultClient.init_().workspace(dir.getAbsolutePath()).execute();
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/StringSharesPrefix.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/StringSharesPrefix.java
@@ -7,17 +7,14 @@ import org.hamcrest.core.SubstringMatcher;
  * Tests if the argument shares a prefix.
  */
 public class StringSharesPrefix extends SubstringMatcher {
-    public StringSharesPrefix(String substring) { super(substring); }
+    private static final String RELATIONSHIP = "sharing prefix with";
+
+    protected StringSharesPrefix(String relationship, boolean ignoringCase, String substring) { super(RELATIONSHIP, false, substring); }
 
     @Override
     protected boolean evalSubstringOf(String s) {
         return s.startsWith(substring) ||
                substring.startsWith(s);
-    }
-
-    @Override
-    protected String relationship() {
-            return "sharing prefix with";
     }
 
     /**
@@ -32,5 +29,5 @@ public class StringSharesPrefix extends SubstringMatcher {
      *      the substring that the returned matcher will expect to share a
      *      prefix of any examined string
      */
-    public static Matcher<String> sharesPrefix(String prefix) { return new StringSharesPrefix(prefix); }
+    public static Matcher<String> sharesPrefix(String prefix) { return new StringSharesPrefix(RELATIONSHIP, false, prefix); }
 }


### PR DESCRIPTION
## Use parent pom 3.54, Hamcrest 2.2, and EqualsVerifier 3.1.10

Use latest versions of dependencies.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)

## Further comments

Hamcrest 2.2 upgrade detected some flaws in the eariler implementation.  Those flaws are fixed now.