### PR TITLE
[JENKINS-60316] Fix escaping single quotes in Unix file paths

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2078,7 +2078,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     private String windowsArgEncodeFileName(String filename) {
         if (filename.contains("\"")) {
-            filename = filename.replaceAll("\"", "^\"");
+            filename = filename.replace("\"", "^\"");
         }
         return "\"" + filename + "\"";
     }
@@ -2089,7 +2089,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             // avoid echoing command as part of the password
             w.println("@echo off");
             w.println("type " + windowsArgEncodeFileName(passphrase.getAbsolutePath()));
-            w.flush();
         }
         ssh.setExecutable(true, true);
         return ssh;
@@ -2100,7 +2099,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     private String unixArgEncodeFileName(String filename) {
         if (filename.contains("'")) {
-            filename = filename.replaceAll("'", "'\\\\''");
+            filename = filename.replace("'", "'\\''");
         }
         return "'" + filename + "'";
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2100,7 +2100,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     private String unixArgEncodeFileName(String filename) {
         if (filename.contains("'")) {
-            filename = filename.replaceAll("'", "\\'");
+            filename = filename.replaceAll("'", "'\\\\''");
         }
         return "'" + filename + "'";
     }


### PR DESCRIPTION
## [JENKINS-60316](https://issues.jenkins-ci.org/browse/JENKINS-60316)

Points addressed
- a single quote is not allowed between single quotes, even if escaped
- a backslash requires escaping if to be used literally in a reqular expression

This escaping has previously already been used in `quoteUnixCredentials` which was added in commit 62872bccaf3f0e02c663acfdd85be2b38bddf1e8 - see [here](https://github.com/jenkinsci/git-client-plugin/commit/62872bccaf3f0e02c663acfdd85be2b38bddf1e8#diff-4a13310f7c84a9d6e133def48c0aed5aR1449-R1453).

Also see https://www.gnu.org/software/bash/manual/html_node/Single-Quotes.html.

I tested it manually on Linux, with a SSH key and a username/password credential, with a job inside a folder that contains spaces and single quotes.

There is no test infrastructure available yet to test such things automatically - right?