### PR TITLE
Use parent pom 3.55

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -25,7 +25,8 @@ Please don't introduce new spotbugs output.
 
 Code formatting in the git client plugin varies between files.
 Try to maintain reasonable consistency with the existing files where feasible.
-Please don't perform wholesale reformatting of a file without discussing with the current maintainers.
+Please *don't reformat a file* without discussing with the current maintainers.
+There are many closed pull requests with label 'https://github.com/jenkinsci/git-client-plugin/milestone/2?closed=1[Later]' that may develop conflicts due to whitespace changes.
 New code should follow the https://github.com/jenkinsci/scm-api-plugin/blob/master/CONTRIBUTING.md#code-style-guidelines[SCM API code style guidelines].
 
 [[pull-request-review]]

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.54</version>
+    <version>3.55</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.1.10</version>
+      <version>3.1.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Use parent pom 3.55

Use the latest parent pom and the latest release of equalsverifier.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)