### PR TITLE
[JENKINS-45228] Add authentication to git merge operations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -885,7 +885,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 args.add(fastForwardMode);
                 args.add(rev.name());
-                launchCommand(args);
+
+                String repoUrl = getRemoteUrl(getDefaultRemote());
+                StandardCredentials cred = credentials.get(repoUrl);
+                if (cred == null) cred = defaultCredentials;
+
+                launchCommandWithCredentials(args, workspace, cred, repoUrl);
             }
         };
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -886,11 +886,25 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 args.add(fastForwardMode);
                 args.add(rev.name());
 
-                String repoUrl = getRemoteUrl(getDefaultRemote());
-                StandardCredentials cred = credentials.get(repoUrl);
-                if (cred == null) cred = defaultCredentials;
+                /* See JENKINS-45228 */
+                /* Git merge requires authentication in LFS merges, plugin does not authenticate the git merge command */
+                String defaultRemote = null;
+                try {
+                    defaultRemote = getDefaultRemote();
+                } catch (GitException e) {
+                    /* Nothing to do, just keeping defaultRemote = null */
+                }
 
-                launchCommandWithCredentials(args, workspace, cred, repoUrl);
+                if (defaultRemote != null && !defaultRemote.isEmpty()) {
+                    String repoUrl = getRemoteUrl(defaultRemote);
+                    StandardCredentials cred = credentials.get(repoUrl);
+                    if (cred == null) cred = defaultCredentials;
+                    launchCommandWithCredentials(args, workspace, cred, repoUrl);
+                } else {
+                    /* Merge is allowed even if a remote URL is not defined. */
+                    /* If there is no remote URL, there is no need to use credentials in the merge. */
+                    launchCommand(args);
+                }
             }
         };
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -74,6 +74,7 @@ public class CredentialsTest {
     private final String fileToCheck;
     private final Boolean submodules;
     private final Boolean useParentCreds;
+    private final Boolean lfsSpecificTest;
     private final char specialCharacter;
     private final Boolean credentialsEmbeddedInURL;
 
@@ -107,7 +108,7 @@ public class CredentialsTest {
             + (isWindows() ? "" : "*<>:|?");
     private static int specialsIndex = 0;
 
-    public CredentialsTest(String gitImpl, String gitRepoUrl, String username, String password, File privateKey, String passphrase, String fileToCheck, Boolean submodules, Boolean useParentCreds, Boolean credentialsEmbeddedInURL) {
+    public CredentialsTest(String gitImpl, String gitRepoUrl, String username, String password, File privateKey, String passphrase, String fileToCheck, Boolean submodules, Boolean useParentCreds, Boolean credentialsEmbeddedInURL, Boolean lfsSpecificTest) {
         this.gitImpl = gitImpl;
         this.gitRepoURL = gitRepoUrl;
         this.privateKey = privateKey;
@@ -117,6 +118,7 @@ public class CredentialsTest {
         this.fileToCheck = fileToCheck;
         this.submodules = submodules;
         this.useParentCreds = useParentCreds;
+        this.lfsSpecificTest = lfsSpecificTest;
         this.specialCharacter = SPECIALS_TO_CHECK.charAt(specialsIndex);
         this.credentialsEmbeddedInURL = credentialsEmbeddedInURL;
         specialsIndex = specialsIndex + 1;
@@ -240,7 +242,7 @@ public class CredentialsTest {
                 String url = "https://github.com/jenkinsci/git-client-plugin.git";
                 /* Add URL if it matches the pattern */
                 if (URL_MUST_MATCH_PATTERN.matcher(url).matches()) {
-                    Object[] masterRepo = {implementation, url, username, null, DEFAULT_PRIVATE_KEY, null, "README.adoc", false, false, false};
+                    Object[] masterRepo = {implementation, url, username, null, DEFAULT_PRIVATE_KEY, null, "README.adoc", false, false, false, false};
                     repos.add(masterRepo);
                 }
             }
@@ -253,7 +255,6 @@ public class CredentialsTest {
             if (authDataDefinitions.exists()) {
                 JSONParser parser = new JSONParser();
                 Object obj = parser.parse(new FileReader(authDataDefinitions));
-
                 JSONArray authEntries = (JSONArray) obj;
 
                 for (Object entryObj : authEntries) {
@@ -286,6 +287,11 @@ public class CredentialsTest {
                         useParentCreds = false;
                     }
 
+                    Boolean lfsSpecificTest = (Boolean) entry.get("lfsSpecificTest");
+                    if (lfsSpecificTest == null) {
+                        lfsSpecificTest = false;
+                    }
+
                     String keyfile = (String) entry.get("keyfile");
                     File privateKey = null;
 
@@ -313,7 +319,7 @@ public class CredentialsTest {
 
                     /* Add URL if it matches the pattern */
                     if (URL_MUST_MATCH_PATTERN.matcher(repoURL).matches()) {
-                        Object[] repo = {implementation, repoURL, username, password, privateKey, passphrase, fileToCheck, submodules, useParentCreds, false};
+                        Object[] repo = {implementation, repoURL, username, password, privateKey, passphrase, fileToCheck, submodules, useParentCreds, false, lfsSpecificTest};
                         repos.add(repo);
                         /* Add embedded credentials test case if valid username, valid password, CLI git, and http protocol */
                         if (username != null && !username.matches(".*[@:].*") && // Skip special cases of username
@@ -322,7 +328,7 @@ public class CredentialsTest {
                             repoURL.startsWith("http")) {
                             /* Use existing username and password to create an embedded credentials test case */
                             String repoURLwithCredentials = repoURL.replaceAll("(https?://)(.*@)?(.*)", "$1" + username + ":" + password + "@$3");
-                            Object[] repoWithCredentials = {implementation, repoURLwithCredentials, username, password, privateKey, passphrase, fileToCheck, submodules, useParentCreds, true};
+                            Object[] repoWithCredentials = {implementation, repoURLwithCredentials, username, password, privateKey, passphrase, fileToCheck, submodules, useParentCreds, true, lfsSpecificTest};
                             repos.add(0, repoWithCredentials);
                         }
                     }
@@ -335,10 +341,14 @@ public class CredentialsTest {
     }
 
     private void doFetch(String source) throws Exception {
+        doFetch(source, "master", true);
+    }
+
+    private void doFetch(String source, String branch, Boolean allowShallowClone) throws Exception {
         /* Save some bandwidth with shallow clone for CliGit, not yet available for JGit */
         URIish sourceURI = new URIish(source);
         List<RefSpec> refSpecs = new ArrayList<>();
-        refSpecs.add(new RefSpec("+refs/heads/master:refs/remotes/origin/master"));
+        refSpecs.add(new RefSpec("+refs/heads/"+branch+":refs/remotes/origin/"+branch+""));
         FetchCommand cmd = git.fetch_().from(sourceURI, refSpecs).tags(false);
         if (isShallowCloneSupported(gitImpl, git)) {
             // Reduce network transfer by using shallow clone
@@ -385,6 +395,7 @@ public class CredentialsTest {
     @Issue("JENKINS-50573")
     public void testFetchWithCredentials() throws Exception {
         assumeTrue(testPeriodNotExpired());
+        assumeFalse(lfsSpecificTest);
         File clonedFile = new File(repo, fileToCheck);
         git.init_().workspace(repo.getAbsolutePath()).execute();
         assertFalse("file " + fileToCheck + " in " + repo + ", has " + listDir(repo), clonedFile.exists());
@@ -437,6 +448,31 @@ public class CredentialsTest {
     public void isURIishRemote() throws Exception {
         URIish uri = new URIish(gitRepoURL);
         assertTrue("Should be remote but isn't: " + uri, uri.isRemote());
+    }
+
+    @Test
+    @Issue("JENKINS-45228")
+    public void testLfsMergeWithCredentials() throws Exception {
+        assumeTrue(testPeriodNotExpired());
+        assumeTrue(lfsSpecificTest);
+        File clonedFile = new File(repo, fileToCheck);
+        git.init_().workspace(repo.getAbsolutePath()).execute();
+        assertFalse("file " + fileToCheck + " in " + repo + ", has " + listDir(repo), clonedFile.exists());
+        addCredential();
+
+        /* Fetch with remote name "origin" instead of remote URL */
+        git.setRemoteUrl("origin", gitRepoURL);
+        doFetch("origin", "*", false);
+        ObjectId master = git.getHeadRev(gitRepoURL, "master");
+        git.checkout().branch("master").ref(master.getName()).lfsRemote("origin").deleteBranchIfExist(true).execute();
+        assertTrue("master: " + master + " not in repo", git.isCommitInRepo(master));
+        assertEquals("Master != HEAD", master, git.getRepository().findRef("master").getObjectId());
+        assertEquals("Wrong branch", "master", git.getRepository().getBranch());
+        assertTrue("No file " + fileToCheck + ", has " + listDir(repo), clonedFile.exists());
+
+        ObjectId modified_lfs = git.getHeadRev(gitRepoURL, "modified_lfs");
+        git.merge().setStrategy(MergeCommand.Strategy.DEFAULT).setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF).setRevisionToMerge(modified_lfs).execute();
+        assertEquals("Fast-forward merge failed. master and modified_lfs should be the same.", git.revParse("HEAD"), modified_lfs);
     }
 
     private boolean isWindows() {


### PR DESCRIPTION
## [JENKINS-45228](https://issues.jenkins-ci.org/browse/JENKINS-45228) - Authenticate merges for Git LFS

Follow-up of #433 and #461

When doing a git merge in a branch containing modified/new LFS objects, git LFS will connect to remote to fetch the LFS objects.

`ssh -- git@github.com git-lfs-authenticate ...`

If the merge is executed without a credential, it fails with an obscure error message:

```
Error downloading object: binary2.bin (d3cf8be): Smudge error: Error downloading binary2.bin (d3cf8beded408772d7d3fbecd0423ca9b26265426f3a101cf263a549fc49e16b): batch request: Permission denied (publickey).: exit status 255

Errors logged to /var/jenkins_home/workspace/reproduce_JENKINS_45228/.git/lfs/logs/20190613T143217.983927423.log
Use `git lfs logs last` to view the log.
error: external filter 'git-lfs filter-process' failed
fatal: binary2.bin: smudge filter lfs failed
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Comments

This is a very first attempt to fix this problem.  It was just interactively tested locally, and it actually solves related issue.  Anyway, i'm not Java developer, so probably this PR lack some quality (unit test, coverage, ...).  Any guidance to make it quickly acceptable and candidate for release would be appreciated.

Note: i was not able to implement the same for JGit

## Testing Checklist

* [x] Interactive test with sample public repository ([jenkins-bugs](https://github.com/MarkEWaite/jenkins-bugs)]
    * [x] Intentionally vary the merge strategies
* [x] Interactive test with sample private repository ([jenkins-bugs-private](https://github.com/MarkEWaite/jenkins-bugs-private))
    * [x] Confirm ssh credentials on multiple platforms
    * [x] Confirm https credentials on multiple platforms
* [x] Interactive test with private LFS enabled Docker repo (docker-private-lfs)
* [x] JGit implementation not needed because JGit implementation in plugin does not use LFS