### PR TITLE
JENKINS-60727 Add cleanSubmodule parameter to submoduleClean to add c…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1482,16 +1482,28 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * Cleans submodules
      */
     @Override
-    public void submoduleClean(boolean recursive) throws GitException, InterruptedException {
+    public void submoduleClean(boolean recursive, boolean cleanSubmodule) throws GitException, InterruptedException {
         submoduleReset(true, true);
         ArgumentListBuilder args = new ArgumentListBuilder();
         args.add("submodule", "foreach");
-    	if (recursive) {
+        if (recursive) {
             args.add("--recursive");
-    	}
-    	args.add("git clean -fdx");
+        }
+        String cmd = "git clean -fdx";
+        if (cleanSubmodule) cmd = "git clean -ffdx";
+        args.add(cmd);
 
-    	launchCommand(args);
+        launchCommand(args);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Cleans submodules
+     */
+    @Override
+    public void submoduleClean(boolean recursive) throws GitException, InterruptedException {
+        this.submoduleClean(recursive, false);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -786,6 +786,16 @@ public interface GitClient {
     void submoduleClean(boolean recursive)  throws GitException, InterruptedException;
 
     /**
+     * submoduleClean.
+     *
+     * @param recursive a boolean.
+     * @param cleanSubmodule flag to add extra -f
+     * @throws hudson.plugins.git.GitException if underlying git operation fails.
+     * @throws java.lang.InterruptedException if interrupted.
+     */
+    void submoduleClean(boolean recursive, boolean cleanSubmodule)  throws GitException, InterruptedException;
+
+    /**
      * submoduleInit.
      *
      * @throws hudson.plugins.git.GitException if underlying git operation fails.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2136,17 +2136,23 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /** {@inheritDoc} */
     @Override
-    public void submoduleClean(boolean recursive) throws GitException {
+    public void submoduleClean(boolean recursive, boolean cleanSubmodule) throws GitException {
         try {
             for (JGitAPIImpl sub : submodules()) {
-                sub.clean();
+                sub.clean(cleanSubmodule);
                 if (recursive) {
-                    sub.submoduleClean(true);
+                    sub.submoduleClean(true, cleanSubmodule);
                 }
             }
         } catch (IOException e) {
             throw new GitException(e);
         }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void submoduleClean(boolean recursive) throws GitException {
+        this.submoduleClean(recursive, false);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -666,6 +666,11 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
     }
 
     /** {@inheritDoc} */
+    public void submoduleClean(boolean recursive, boolean cleanSubmodule) throws GitException, InterruptedException {
+        proxy.submoduleClean(recursive, cleanSubmodule);
+    }
+
+    /** {@inheritDoc} */
     public void setupSubmoduleUrls(Revision rev, TaskListener listener) throws GitException, InterruptedException {
         proxy.setupSubmoduleUrls(rev, listener);
     }


### PR DESCRIPTION
…lean a submodule's untracked submodules.

## [JENKINS-60727](https://issues.jenkins-ci.org/browse/JENKINS-60727) - allow submodule clean --ffdx

#222 added the necessary plumbing for `git clean -ffdx`. This adds the necessary plumbing for `git submodule foreach --recursive git clean -ffdx`. _ie._, it allows you to clean a submodule's untracked submodule after updating it.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

I appreciate that the names of the arguments aren't entirely clear - I used what was used previously for consistency but I'm not wedded to it.
