### PR TITLE
Upgrade to use jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <java.level>8</java.level>
     <jgit.version>5.6.0.201912101111-r</jgit.version>
     <forkCount>1C</forkCount>
+    <configuration-as-code.version>1.35</configuration-as-code.version>
   </properties>
 
   <dependencyManagement>
@@ -261,12 +262,13 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
+      <version>${configuration-as-code.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
-      <classifier>tests</classifier>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a `tests` classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
https://github.com/jenkinsci/bom/pull/164

Note: We'll need a release for PCT please