### PR TITLE
Add docs badge for new gitter channel

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,6 +7,7 @@ link:https://ci.jenkins.io/job/Plugins/job/git-client-plugin/job/master/[image:h
 link:https://github.com/jenkinsci/git-client-plugin/graphs/contributors[image:https://img.shields.io/github/contributors/jenkinsci/git-client-plugin.svg?color=blue[Contributors]]
 link:https://plugins.jenkins.io/git-client[image:https://img.shields.io/jenkins/plugin/i/git-client.svg?color=blue&label=installations[Jenkins Plugin Installs]]
 link:https://github.com/jenkinsci/git-client-plugin/releases/latest[image:https://img.shields.io/github/release/jenkinsci/git-client-plugin.svg?label=changelog[GitHub release]]
+link:https://gitter.im/jenkinsci/git-plugin[image:https://badges.gitter.im/jenkinsci/git-plugin.svg[Gitter]]
 
 [[introduction]]
 == Introduction


### PR DESCRIPTION
## Add docs badge for new gitter channel

Link to the newly created gitter channel for the git plugin.  We need the gitter channel for Google Summer of Code project mentoring, so we should also include it in the docs.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)