### PR TITLE
[JENKINS-60694] Fix InjectedTest failures from JTH 2.57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,9 @@
     <jgit.version>5.6.0.201912101111-r</jgit.version>
     <forkCount>1C</forkCount>
     <configuration-as-code.version>1.35</configuration-as-code.version>
+    <!-- Fix InjectedTest hang on multi-core machines and InjectedTest failures on ci.jenkins.io -->
+    <!-- Remove when parent pom 3.56 is used -->
+    <jenkins-test-harness.version>2.60</jenkins-test-harness.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## [JENKINS-60694](https://issues.jenkins-ci.org/browse/JENKINS-60694) - Fix Jenkins Test Harness hangs and failures

Avoid InjectedTest hangs and failures from JTH 2.57

* See [JENKINS-60694](https://issues.jenkins-ci.org/browse/JENKINS-60694)
* See [JENKINS-60754](https://issues.jenkins-ci.org/browse/JENKINS-60754)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)