### PR TITLE
Use parent pom 3.56

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.55</version>
+    <version>3.56</version>
     <relativePath />
   </parent>
 
@@ -62,9 +62,6 @@
     <jgit.version>5.6.0.201912101111-r</jgit.version>
     <forkCount>1C</forkCount>
     <configuration-as-code.version>1.35</configuration-as-code.version>
-    <!-- Fix InjectedTest hang on multi-core machines and InjectedTest failures on ci.jenkins.io -->
-    <!-- Remove when parent pom 3.56 is used -->
-    <jenkins-test-harness.version>2.60</jenkins-test-harness.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Use parent pom 3.56

Remove Jenkins test harness workaround

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)