### PR TITLE
Bump incrementals version

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-7</version>
+    <version>1.1</version>
   </extension>
 </extensions>


### PR DESCRIPTION
Incrementals seem to be no longer publishing for this plugin, maybe this will fix it

https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/git-client/