### PR TITLE
Whitelist CliGitAPIImpl.TIMEOUT for Pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,10 @@
       <artifactId>structs</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -37,6 +37,7 @@ import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.plugins.gitclient.cgit.GitCommandsExecutor;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.framework.io.WriterOutputStream;
 
 import java.io.*;
@@ -3474,6 +3475,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * We run git as an external process so can't guarantee it won't hang for whatever reason. Even though the plugin does its
      * best to avoid git interactively asking for credentials, there are many of other cases where git may hang.
      */
+    @Whitelisted
     public static final int TIMEOUT = Integer.getInteger(Git.class.getName() + ".timeOut", 10);
 
     /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */


### PR DESCRIPTION
## Allow CliGitAPIImpl.TIMEOUT to be read in Pipeline

The default command line git timeout value is a constant that should be readable from Pipeline scripts.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)