### PR TITLE
JGit timeout support (extended)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CheckoutCommand.java
@@ -46,7 +46,7 @@ public interface CheckoutCommand extends GitCommand {
     /**
      * timeout.
      *
-     * @param timeout a {@link java.lang.Integer} object.
+     * @param timeout the timeout (in minutes) used for the command
      * @return a {@link org.jenkinsci.plugins.gitclient.CheckoutCommand} object.
      */
     CheckoutCommand timeout(Integer timeout);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
@@ -78,7 +78,7 @@ public interface CloneCommand extends GitCommand {
     /**
      * timeout.
      *
-     * @param timeout a {@link java.lang.Integer} object.
+     * @param timeout the timeout (in minutes) used for the command
      * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
      */
     CloneCommand timeout(Integer timeout);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
@@ -50,7 +50,7 @@ public interface FetchCommand extends GitCommand {
     /**
      * timeout.
      *
-     * @param timeout a {@link java.lang.Integer} object.
+     * @param timeout the timeout (in minutes) used for the command
      * @return a {@link org.jenkinsci.plugins.gitclient.FetchCommand} object.
      */
     FetchCommand timeout(Integer timeout);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -553,6 +553,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private List<RefSpec> refspecs;
             private boolean shouldPrune = false;
             private boolean tags = true;
+            private Integer timeout;
 
             @Override
             public org.jenkinsci.plugins.gitclient.FetchCommand from(URIish remote, List<RefSpec> refspecs) {
@@ -582,7 +583,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public org.jenkinsci.plugins.gitclient.FetchCommand timeout(Integer timeout) {
-                // noop in jgit
+                this.timeout = timeout;
                 return this;
             }
 
@@ -625,6 +626,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     fetch.setRefSpecs(allRefSpecs);
                     fetch.setRemoveDeletedRefs(shouldPrune);
 
+                    if (timeout != null) {
+                        fetch.setTimeout(timeout * 60);
+                    }
                     fetch.call();
                 } catch (GitAPIException e) {
                     throw new GitException(e);
@@ -1822,6 +1826,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private String refspec;
             private boolean force;
             private boolean tags;
+            private Integer timeout;
 
             @Override
             public PushCommand to(URIish remote) {
@@ -1854,7 +1859,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public PushCommand timeout(Integer timeout) {
-            	// noop in jgit
+                this.timeout = timeout;
                 return this;
             }
 
@@ -1872,6 +1877,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                             .setForce(force);
                     if(tags) {
                         pc.setPushTags();
+                    }
+                    if (timeout != null) {
+                        pc.setTimeout(timeout * 60);
                     }
                     Iterable<PushResult> results = pc.call();
                     for(PushResult result:results) for(RemoteRefUpdate update:result.getRemoteUpdates()) {
@@ -2162,6 +2170,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private boolean recursive      = false;
             private boolean remoteTracking = false;
             private String  ref            = null;
+            private Integer timeout;
 
             @Override
             public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand recursive(boolean recursive) {
@@ -2189,7 +2198,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand timeout(Integer timeout) {
-            	// noop in jgit
+                this.timeout = timeout;
                 return this;
             }
 
@@ -2239,6 +2248,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 try (Repository repo = getRepository()) {
                     SubmoduleUpdateCommand update = git(repo).submoduleUpdate();
                     update.setCredentialsProvider(getProvider());
+                    if (timeout != null) {
+                        update.setTimeout(timeout * 60);
+                    }
                     update.call();
                     if (recursive) {
                         for (JGitAPIImpl sub : submodules()) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1374,8 +1374,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public CloneCommand timeout(Integer timeout) {
-            	this.timeout = timeout;
-            	return this;
+                this.timeout = timeout;
+                return this;
             }
 
             @Override
@@ -1473,7 +1473,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                             .setCredentialsProvider(getProvider())
                             .setTagOpt(tags ? TagOpt.FETCH_TAGS : TagOpt.NO_TAGS)
                             .setRefSpecs(refspecs);
-                    if (timeout != null) fetch.setTimeout(timeout);
+                    if (timeout != null) {
+                        fetch.setTimeout(timeout * 60);
+                    }
                     fetch.call();
 
                     StoredConfig config = repository.getConfig();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/PushCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/PushCommand.java
@@ -54,7 +54,7 @@ public interface PushCommand extends GitCommand {
     /**
      * timeout.
      *
-     * @param timeout a {@link java.lang.Integer} object.
+     * @param timeout the timeout (in minutes) used for the command
      * @return a {@link org.jenkinsci.plugins.gitclient.PushCommand} object.
      */
     PushCommand timeout(Integer timeout);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
@@ -54,7 +54,7 @@ public interface SubmoduleUpdateCommand extends GitCommand {
     /**
      * timeout.
      *
-     * @param timeout a {@link java.lang.Integer} object.
+     * @param timeout the timeout (in minutes) used for the command
      * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
      */
     SubmoduleUpdateCommand timeout(Integer timeout);


### PR DESCRIPTION
This change adds a timeout to all JGit commands that not yet supported it. Only the `CloneCommand` so far used a timeout.

A slight difference between CliGit and JGit remains
* CliGit: timeout for the whole command
* JGit: timeout only for transport step (therefore missing for `CheckoutCommand`)