### PR TITLE
[JENKINS-55875] Forcibly update git submodules

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1294,6 +1294,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private boolean remoteTracking                 = false;
             private boolean parentCredentials              = false;
             private boolean shallow                        = false;
+            private boolean forceUpdate                    = false;
             private String  ref                            = null;
             private Map<String, String> submodBranch   = new HashMap<>();
             private Integer timeout;
@@ -1343,6 +1344,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
+            public SubmoduleUpdateCommand forceUpdate(boolean forceUpdate) {
+                this.forceUpdate = forceUpdate;
+                return this;
+            }
+
+            @Override
             public SubmoduleUpdateCommand depth(Integer depth) {
                 this.depth = depth;
                 return this;
@@ -1366,8 +1373,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 ArgumentListBuilder args = new ArgumentListBuilder();
 
+                args.add("submodule", "update");
                 // Force the update, in the same manner we force checkouts
-                args.add("submodule", "update", "--checkout", "--force");
+                if (forceUpdate) {
+                    args.add("--checkout", "--force");
+                }
                 if (recursive) {
                     args.add("--init", "--recursive");
                 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1365,7 +1365,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 submoduleInit();
 
                 ArgumentListBuilder args = new ArgumentListBuilder();
-                args.add("submodule", "update");
+
+                // Force the update, in the same manner we force checkouts
+                args.add("submodule", "update", "--force");
                 if (recursive) {
                     args.add("--init", "--recursive");
                 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1367,7 +1367,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 ArgumentListBuilder args = new ArgumentListBuilder();
 
                 // Force the update, in the same manner we force checkouts
-                args.add("submodule", "update", "--force");
+                args.add("submodule", "update", "--checkout", "--force");
                 if (recursive) {
                     args.add("--init", "--recursive");
                 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2214,6 +2214,14 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
+            public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand forceUpdate(boolean forceUpdate) {
+                if (forceUpdate) {
+                    listener.getLogger().println("[WARNING] JGit doesn't support forceUpdate clone. This flag is ignored");
+                }
+                return this;
+            }
+
+            @Override
             public org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand depth(Integer depth) {
                 listener.getLogger().println("[WARNING] JGit doesn't support shallow clone and therefore depth is meaningless. This flag is ignored");
                 return this;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
@@ -69,6 +69,17 @@ public interface SubmoduleUpdateCommand extends GitCommand {
     SubmoduleUpdateCommand shallow(boolean shallow);
 
     /**
+     * Forces the checkout of submodules. 
+     * This will discard any conflicting local changes and makes sure the
+     * submodule is at the requested commit
+     * this addes --checkout --force to the submodule update command.
+     *
+     * @param forceUpdate boolean controlling whether to force update the submodule or not
+     * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
+     */
+    SubmoduleUpdateCommand forceUpdate(boolean forceUpdate);
+
+    /**
      * When shallow cloning, allow for a depth to be set in cases where you need more than the immediate last commit.
      * Has no effect if shallow is set to false (default).
      *

--- a/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
@@ -191,6 +191,19 @@ public class UnsupportedCommand {
     }
 
     /**
+     * JGit is unsupported if forceUpdate is true.
+     *
+     * @param forceUpdate submodule update uses force checkout flag
+     * @return this for chaining
+     */
+    public UnsupportedCommand forceUpdate(boolean forceUpdate) {
+        if (forceUpdate) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    /**
      * Returns true if JGit is supported based on previously passed values.
      *
      * @return true if JGit is supported based on previously passed values

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2001,7 +2001,7 @@ public abstract class GitAPITestCase extends TestCase {
             w.git.submoduleUpdate().execute();
             fail("Did not throw expected submodule update exception");
         } catch (GitException e) {
-            assertThat(e.getMessage(), containsString("Command \"git submodule update modules/ntp\" returned status code 1"));
+            assertThat(e.getMessage(), containsString("Command \"git submodule update --checkout --force modules/ntp\" returned status code 1"));
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2005,33 +2005,6 @@ public abstract class GitAPITestCase extends TestCase {
         }
     }
 
-    @NotImplementedInJGit
-    public void test_submodule_update_with_dirty_index() throws Exception {
-        w.git.clone_().url(localMirror()).execute();
-        w.git.checkout().ref("origin/tests/getSubmodules").execute();
-        // fetch the submodules a first time to initialize the directories.
-        w.git.submoduleUpdate().execute();
-        // create a new file and commit the submodule
-        File ntpRepo = w.file("modules/ntp");
-        WorkingArea submoduleWorkingArea = new WorkingArea(ntpRepo).init();
-        submoduleWorkingArea.touch("test_file");
-        submoduleWorkingArea.git.add("test_file");
-        submoduleWorkingArea.git.commit("submod-commit1");
-        // add the changed submodule to the repo
-        w.git.add("modules/ntp");
-        w.git.commit("commit1");
-        String head = w.git.revParse("HEAD").name();
-        // revert to the previous commit and clean the submodule
-        w.launchCommand("git", "reset", "HEAD~");
-        w.git.submoduleUpdate().execute();
-        // manually create the test_file again, which does not exist in this revision of the submodule
-        submoduleWorkingArea.touch("test_file");
-        // revert back to the previous HEAD
-        w.launchCommand("git", "reset", head);
-        // Now try and launch the submodule update again. Without --force, this will fail.
-        w.git.submoduleUpdate().execute();
-    }
-
     public void test_submodule_update_shallow() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2001,7 +2001,7 @@ public abstract class GitAPITestCase extends TestCase {
             w.git.submoduleUpdate().execute();
             fail("Did not throw expected submodule update exception");
         } catch (GitException e) {
-            assertThat(e.getMessage(), containsString("Command \"git submodule update --checkout --force modules/ntp\" returned status code 1"));
+            assertThat(e.getMessage(), containsString("Command \"git submodule update modules/ntp\" returned status code 1"));
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2005,6 +2005,33 @@ public abstract class GitAPITestCase extends TestCase {
         }
     }
 
+    @NotImplementedInJGit
+    public void test_submodule_update_with_dirty_index() throws Exception {
+        w.git.clone_().url(localMirror()).execute();
+        w.git.checkout().ref("origin/tests/getSubmodules").execute();
+        // fetch the submodules a first time to initialize the directories.
+        w.git.submoduleUpdate().execute();
+        // create a new file and commit the submodule
+        File ntpRepo = w.file("modules/ntp");
+        WorkingArea submoduleWorkingArea = new WorkingArea(ntpRepo).init();
+        submoduleWorkingArea.touch("test_file");
+        submoduleWorkingArea.git.add("test_file");
+        submoduleWorkingArea.git.commit("submod-commit1");
+        // add the changed submodule to the repo
+        w.git.add("modules/ntp");
+        w.git.commit("commit1");
+        String head = w.git.revParse("HEAD").name();
+        // revert to the previous commit and clean the submodule
+        w.launchCommand("git", "reset", "HEAD~");
+        w.git.submoduleUpdate().execute();
+        // manually create the test_file again, which does not exist in this revision of the submodule
+        submoduleWorkingArea.touch("test_file");
+        // revert back to the previous HEAD
+        w.launchCommand("git", "reset", head);
+        // Now try and launch the submodule update again. Without --force, this will fail.
+        w.git.submoduleUpdate().execute();
+    }
+
     public void test_submodule_update_shallow() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/UnsupportedCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/UnsupportedCommandTest.java
@@ -239,6 +239,18 @@ public class UnsupportedCommandTest {
     }
 
     @Test
+    public void testNotForceUpdate() {
+        unsupportedCommand.forceUpdate(false);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testForceUpdate() {
+        unsupportedCommand.forceUpdate(true);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
     public void testDetermineSupportForJGit() {
         /* Confirm default is true */
         assertTrue(unsupportedCommand.determineSupportForJGit());


### PR DESCRIPTION
## [JENKINS-55875](https://issues.jenkins-ci.org/browse/JENKINS-55875) - Forcibly update git submodules

Currently, submodules are not updated with `--force`. This means if there is a local change, then the checkout fails, causing the build to fail.

This can be worked round by cleaning the repository before every checkout, but this makes build jobs much slower, as they aren't able to be incrementally built, as the entire workspace has to be thrown away each time, or requires manual intervention.

Instead, this changes the checkout to be done forcefully, which matches how the checkout of the top level Git repository works.

This change should not have any harmful effects - it will only cause builds which were failing to now succeed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
