### PR TITLE
[JENKINS-57205] Packed lightweight tags must resolve to meaningful object IDs lest they cause NPEs downstream

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2792,18 +2792,19 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 /* Prefer peeled ref if available (for tag commit), otherwise take first tag reference seen */
                 String tagName = entry.getKey();
                 Ref tagRef = entry.getValue();
-                if (!entry.getValue().isPeeled()) {
+                if (!tagRef.isPeeled()) {
                     Ref peeledRef = repo.peel(tagRef);
                     if (peeledRef.getPeeledObjectId() != null) {
                         tagRef = peeledRef; // Use peeled ref instead of annotated ref
                     }
                 }
-                if (tagRef.isPeeled()) {
+                /* Packed lightweight (non-annotated) tags can wind up peeled with no peeled obj ID */
+                if (tagRef.isPeeled() && tagRef.getPeeledObjectId() != null) {
                     peeledTags.add(new GitObject(tagName, tagRef.getPeeledObjectId()));
                 } else if (!tagNames.contains(tagName)) {
                     peeledTags.add(new GitObject(tagName, tagRef.getObjectId()));
                 }
-                tagNames.add(entry.getKey());
+                tagNames.add(tagName);
             }
         }
         return peeledTags;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitClientTest.java
@@ -1,0 +1,162 @@
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.EnvVars;
+import hudson.model.TaskListener;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitObject;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.Set;
+
+// Collides with implicit org.jenkinsci.plugins.gitclient.Git.
+//import org.eclipse.jgit.api.Git;
+import static org.eclipse.jgit.lib.Constants.HEAD;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.GC;
+import org.eclipse.jgit.lib.ObjectId;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * JGit Client-specific tests. In their own Test file to ward off bloat in 
+ * GitClient and minimized parameterized and other test logic conditional 
+ * on Git implementation.
+ *
+ * @author Brian Ray
+ */
+public class JGitClientTest {
+    /* These tests are only for the JGit client. */
+    private static final String GIT_IMPL_NAME = "jgit";
+
+    /* Instance under test. */
+    private GitClient gitClient;
+
+    /* Lower level "porcelain" API when gitClient can't do something. */
+    private org.eclipse.jgit.api.Git gitAPI;
+
+    /* Repo garbage collector. */
+    private GC gc;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+    private File repoRoot;
+
+    @Before
+    public void setGitClientEtc() throws IOException, InterruptedException {
+        repoRoot = tempFolder.newFolder();
+        gitClient = Git.with(TaskListener.NULL, new EnvVars())
+                       .in(repoRoot)
+                       .using(GIT_IMPL_NAME)
+                       .getClient();
+        FileRepository repo = (FileRepository) gitClient.getRepository();
+        // See comment up in imports as to why this is fully qualified.
+        gitAPI = org.eclipse.jgit.api.Git.wrap(repo);
+        gc = new GC(repo);
+
+        File gitDir = gitClient.withRepository((r, channel) -> r.getDirectory());
+        gitClient.init_()
+                 .workspace(repoRoot.getAbsolutePath())
+                 .execute();
+        assertTrue("Missing " + gitDir, gitDir.isDirectory());
+    }
+
+    private ObjectId commitFile(final String path, final String content, final String commitMessage) throws Exception {
+        createFile(path, content);
+        gitClient.add(path);
+        gitClient.commit(commitMessage);
+
+        List<ObjectId> headList = gitClient.revList(HEAD);
+        assertThat(headList.size(), is(greaterThan(0)));
+        return headList.get(0);
+    }
+
+    private void createFile(final String path, final String content) throws Exception {
+        File aFile = new File(repoRoot, path);
+        File parentDir = aFile.getParentFile();
+        if (parentDir != null) {
+            parentDir.mkdirs();
+        }
+        try (PrintWriter writer = new PrintWriter(aFile, "UTF-8")) {
+            writer.printf(content);
+        } catch (FileNotFoundException | UnsupportedEncodingException ex) {
+            throw new GitException(ex);
+        }
+    }
+
+    private void packRefs() throws IOException {
+        gc.packRefs();
+    }
+
+    // No flavor of GitClient has a tag(String) API, only tag(String,String). 
+    // But sometimes we want a lightweight a.k.a. non-annotated tag.
+    private void tag(String name) throws GitException {
+        try {
+            gitAPI.tag().setName(name).setAnnotated(false).call();
+        } catch (GitAPIException e) {
+            throw new GitException(e);
+        }
+    }
+
+    @Issue("JENKINS-57205") // NPE on PreBuildMerge with packed lightweight tag
+    @Test
+    public void testGetTags_packedRefs() throws Exception {
+        // JENKINS-57205 is triggered by lightweight tags
+        ObjectId firstCommit = commitFile(
+            "first.txt",
+            "Great info here",
+            "First commit"
+        );
+        String lightweightTagName = "lightweight_tag";
+        tag(lightweightTagName);
+
+        // But throw in an annotated tag for symmetry and coverage
+        ObjectId secondCommit = commitFile(
+            "second.txt",
+            "Great info here, too",
+            "Second commit"
+        );
+        String annotatedTagName = "annotated_tag";
+        gitClient.tag(annotatedTagName, "Tag annotation");
+
+        packRefs();
+
+        Set<GitObject> tags = gitClient.getTags();
+
+        assertThat(
+            tags,
+            hasItem(
+                allOf(
+                    hasProperty("name", equalTo(lightweightTagName)),
+                    hasProperty("SHA1", equalTo(firstCommit))
+                )
+            )
+        );
+        assertThat(
+            tags,
+            hasItem(
+                allOf(
+                    hasProperty("name", equalTo(annotatedTagName)),
+                    hasProperty("SHA1", equalTo(secondCommit))
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
## [JENKINS-57205](https://issues.jenkins-ci.org/browse/JENKINS-57205) - Packed lightweight tags must resolve to meaningful object IDs lest they cause NPEs downstream

Between Git Client 2.9.0 and 3.0.0 the bundled JGit bumped up from 4.5.7 to 5.5.1. Starting with JGit 4.9.0 upon repo clone, references are packed instead of left loose. All well and good save that `JGitClientAPIImpl.getTags()` trips up over ligthweight tags packed thus, resolving them to null SHA1s. Downstream anything trying to process them is at high risk of an NPE--as in the pre-build merge scenario in the attached JIRA.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
