### PR TITLE
Added timeout option to the MergeCommand Interface.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
@@ -26,6 +26,14 @@ public interface MergeCommand extends GitCommand {
     MergeCommand setMessage(String message);
 
     /**
+     * setTimeout.
+     *
+     * @param timeout the desired timeout for the merge command.
+     * @return a {@link org.jenkinsci.plugins.gitclient.MergeCommand} object.
+     */
+    MergeCommand setTimeout(String timeout);
+
+    /**
      * setStrategy.
      *
      * @param strategy a {@link org.jenkinsci.plugins.gitclient.MergeCommand.Strategy} object.


### PR DESCRIPTION
This PR is a follow up to the discussion [here](https://github.com/jenkinsci/git-plugin/pull/822#discussion_r375369953). The main aim of this PR to make available to the MergeCommand a timeout option so as to abort the merge after a specific time period.

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
