### PR TITLE
Added no-proxy hosts when using proxy in CliGitAPIImpl

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2013,6 +2013,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             if ("http".equalsIgnoreCase(url.getScheme()) || "https".equalsIgnoreCase(url.getScheme())) {
                 if (proxy != null) {
+                    List<String>listOfConfiguredNoProxyHosts = new ArrayList<String>();
+                    listOfConfiguredNoProxyHosts.add("169.254.169.254");
                     boolean shouldProxy = true;
                     for(Pattern p : proxy.getNoProxyHostPatterns()) {
                         if(p.matcher(url.getHost()).matches()) {
@@ -2034,6 +2036,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                             URI http_proxy = new URI("http", userInfo, proxy.name, proxy.port, null, null, null);
                             env.put("http_proxy", http_proxy.toString());
                             env.put("https_proxy", http_proxy.toString());
+                            env.put("NO_PROXY", String.join(", ",listOfConfiguredNoProxyHosts));
                         } catch (URISyntaxException ex) {
                             throw new GitException("Failed to create http proxy uri", ex);
                         }


### PR DESCRIPTION
## [JENKINS-61193](https://issues.jenkins-ci.org/browse/JENKINS-61192) - When using proxy also export the no_proxy hosts

I have added an ArrayList containing all the hosts which don't need any proxy. Then at the time of setting environment variables for proxy I have also set the hosts(e.g. 169.254.169.254) which will not require any proxy.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
