### PR TITLE
Safely handle localMirror creation in tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -78,6 +78,12 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.StandardCopyOption;
 
 /**
+ * JUnit 3 based tests inherited by CliGitAPIImplTest, JGitAPIImplTest, and JGitApacheAPIImplTest.
+ * Tests are expected to run in ALL git implementations in the git client plugin.
+ *
+ * Tests in this class are being migrated to JUnit 4 in other classes.
+ * Refer to GitClientTest, GitClientCliTest, GitClientCloneTest, and GitClientFetchTest for examples.
+ *
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public abstract class GitAPITestCase extends TestCase {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCliCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCliCloneTest.java
@@ -1,8 +1,13 @@
 package org.jenkinsci.plugins.gitclient;
 
+import hudson.Util;
 import hudson.model.TaskListener;
+import hudson.util.StreamTaskListener;
+import java.io.File;
+import java.nio.file.Files;
 import org.eclipse.jgit.transport.URIish;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -30,6 +35,16 @@ public class GitClientCliCloneTest {
     private WorkspaceWithRepo workspace;
 
     private GitClient testGitClient;
+
+    @BeforeClass
+    public static void loadLocalMirror() throws Exception {
+        /* Prime the local mirror cache before other tests run */
+        TaskListener mirrorListener = StreamTaskListener.fromStdout();
+        File tempDir = Files.createTempDirectory("PrimeCliCloneTest").toFile();
+        WorkspaceWithRepo cache = new WorkspaceWithRepo(tempDir, "git", mirrorListener);
+        cache.localMirror();
+        Util.deleteRecursive(tempDir);
+    }
 
     @Before
     public void setUpRepositories() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -1,9 +1,11 @@
 package org.jenkinsci.plugins.gitclient;
 
+import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
 import hudson.remoting.VirtualChannel;
+import hudson.util.StreamTaskListener;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.ConfigConstants;
@@ -11,6 +13,7 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.RefSpec;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,6 +21,7 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -70,6 +74,21 @@ public class GitClientCloneTest {
             arguments.add(item);
         }
         return arguments;
+    }
+
+    @BeforeClass
+    public static void loadLocalMirror() throws Exception {
+        /* Prime the local mirror cache before other tests run */
+        /* Allow 3-7 second delay before priming the cache */
+        /* Allow other tests a better chance to prime the cache */
+        /* 3-7 second delay is small compared to execution time of this test */
+        Random random = new Random();
+        Thread.sleep((3 + random.nextInt(5)) * 1000L); // Wait 3-7 seconds before priming the cache
+        TaskListener mirrorListener = StreamTaskListener.fromStdout();
+        File tempDir = Files.createTempDirectory("PrimeCloneTest").toFile();
+        WorkspaceWithRepo cache = new WorkspaceWithRepo(tempDir, "git", mirrorListener);
+        cache.localMirror();
+        Util.deleteRecursive(tempDir);
     }
 
     @Before
@@ -237,7 +256,8 @@ public class GitClientCloneTest {
         assertThat(new File(SRC_DIR + File.separator + ".git"), is(anExistingDirectory()));
         final File shallowFile = new File(SRC_DIR + File.separator + ".git" + File.separator + "shallow");
         if (shallowFile.exists()) {
-            return; /* Reference repository pointing to a shallow checkout is nonsense */
+            return;
+            /* Reference repository pointing to a shallow checkout is nonsense */
         }
         testGitClient.clone_().url(workspace.localMirror()).repositoryName("origin").reference(SRC_DIR).execute();
         testGitClient.checkout().ref("origin/master").branch("master").execute();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/WorkspaceWithRepo.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/WorkspaceWithRepo.java
@@ -67,7 +67,14 @@ public class WorkspaceWithRepo {
         }
     }
 
-    protected String localMirror() throws IOException, InterruptedException {
+    /**
+     * Populate the local mirror of the repository.
+     *
+     * @return path to the local mirrror directory
+     * @throws IOException on I/O error
+     * @throws InterruptedException when execption is interrupted
+     */
+    String localMirror() throws IOException, InterruptedException {
         File base = new File(".").getAbsoluteFile();
         for (File f = base; f != null; f = f.getParentFile()) {
             File targetDir = new File(f, "target");
@@ -75,11 +82,41 @@ public class WorkspaceWithRepo {
                 String cloneDirName = "clone.git";
                 File clone = new File(targetDir, cloneDirName);
                 if (!clone.exists()) {
+                    /* Clone to a temporary directory then move the
+                     * temporary directory to the final destination
+                     * directory. The temporary directory prevents
+                     * collision with other tests running in parallel.
+                     * The atomic move after clone completion assures
+                     * that only one of the parallel processes creates
+                     * the final destination directory.
+                     */
                     Path tempClonePath = Files.createTempDirectory(targetDir.toPath(), "clone-");
                     cliGitCommand.run("clone", "--reference", f.getCanonicalPath(), "--mirror", repoURL, tempClonePath.toFile().getAbsolutePath());
                     if (!clone.exists()) { // Still a race condition, but a narrow race handled by Files.move()
                         renameAndDeleteDir(tempClonePath, cloneDirName);
                     } else {
+                        /*
+                         * If many unit tests run at the same time and
+                         * are using the localMirror, multiple clones
+                         * will happen.  All but one of the clones
+                         * will be discarded.  The tests reduce the
+                         * likelihood of multiple concurrent clones by
+                         * adding a random delay to the start of
+                         * longer running tests that use the local
+                         * mirror.  The delay was enough in my tests
+                         * to prevent the duplicate clones and the
+                         * resulting discard of the results of the
+                         * clone.
+                         *
+                         * Different processor configurations with
+                         * different performance characteristics may
+                         * still have parallel tests which attempt to
+                         * clone the local mirror concurrently. If
+                         * parallel clones happen, only one of the
+                         * parallel clones will 'win the race'.  The
+                         * deleteRecursive() will discard a clone that
+                         * 'lost the race'.
+                         */
                         Util.deleteRecursive(tempClonePath.toFile());
                     }
                 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/WorkspaceWithRepo.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/WorkspaceWithRepo.java
@@ -68,7 +68,8 @@ public class WorkspaceWithRepo {
     }
 
     /**
-     * Populate the local mirror of the repository.
+     * Populate the local mirror of the git client plugin repository.
+     * Returns path to the local mirror directory.
      *
      * @return path to the local mirrror directory
      * @throws IOException on I/O error


### PR DESCRIPTION
## Safely handle localMirror creation in tests

The localMirror() method clones the remote git client plugin repository into a local copy for use by tests.  Using a remote clone is better than cloning from the local copy because the local copy may be a shallow clone or may be using a sparse checkout.

Unfortunately, the prior implementation of localMirror assumed exclusive access to the target/clone.git directory.  When tests run in parallel, that assumption of exclusive access is wrong.  Multiple tests would attempt to populate the target/clone.git repository.  They would conflict and fail the tests in strange and undesirable ways.

Safely populate the local mirror by cloning to a temporary directory then moving the temporary directory to the intended final destination directory after the clone is complete and after confirming that the destination directory still does not exist.  There is still a brief window where the directory is created after the existance check and before the atomic move which renames the temporary directory to the correct final name.

The implementation accepts that if many unit tests were all executed at the same time and were all using the localMirror, multiple clones will happen and all but one of the clones will be discarded.  The tests reduce the likelihood of that problem by adding a random delay to the start of longer running tests that use the local mirror.  The delay was enough in my tests to prevent the duplicate clones and the resulting discard of the results of the clone.

@rishabhBudhouliya I would love to have your review of these proposed changes.  They've passed the CI tests in my environment including the machine that I can access with many cores.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)