### PR TITLE
Minor improvements to CredentialsTest

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -84,7 +84,6 @@ public class CredentialsTest {
     private int logCount;
     private LogHandler handler;
     private LogTaskListener listener;
-    private static final String LOGGING_STARTED = "*** Logging started ***";
 
     private final static File HOME_DIR = new File(System.getProperty("user.home"));
     private final static File SSH_DIR = new File(HOME_DIR, ".ssh");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -8,16 +8,12 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import com.google.common.io.Files;
 import hudson.model.Fingerprint;
-import hudson.plugins.git.GitException;
 import hudson.util.LogTaskListener;
-import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -46,12 +46,10 @@ import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.ClassRule;
-import org.junit.rules.DisableOnDebug;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 
 /**
- *
+ * Test authenticated operations with the git implementations.
+ * Uses contents of ~/.ssh/auth-data for parameterized tests.
  * @author Mark Waite
  */
 @RunWith(Parameterized.class)

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -406,11 +406,11 @@ public class CredentialsTest {
             subcmd.execute();
         }
         assertTrue("master: " + master + " not in repo", git.isCommitInRepo(master));
-        assertEquals("Master != HEAD", master, git.withRepository((repo, channel) -> repo.findRef("master").getObjectId()));
-        assertEquals("Wrong branch", "master", git.withRepository((repo, channel) -> repo.getBranch()));
+        assertEquals("Master != HEAD", master, git.withRepository((gitRepo, unusedChannel)-> gitRepo.findRef("master").getObjectId()));
+        assertEquals("Wrong branch", "master", git.withRepository((gitRepo, unusedChanel) -> gitRepo.getBranch()));
         assertTrue("No file " + fileToCheck + ", has " + listDir(repo), clonedFile.exists());
         /* prune opens a remote connection to list remote branches */
-        git.prune(new RemoteConfig(git.withRepository((repo, channel) -> repo.getConfig()), "origin"));
+        git.prune(new RemoteConfig(git.withRepository((gitRepo, unusedChannel) -> gitRepo.getConfig()), "origin"));
     }
 
     @Test


### PR DESCRIPTION
## Minor improvements to CredentialsTest

While exploring a report in [JENKINS-59897](https://issues.jenkins-ci.org/browse/JENKINS-59897) that command line git does PATH resolution on GIT_ASKPASS values which do not include '/' (like Windows, where the value includes '\' instead of '/'), I found some minor items that could be improved in CredentialsTest.

This is test code. It is generally only run by developers that have created the `~/.ssh/auth-data` file to define private repositories and the credentials to use with those private repositories.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)