### PR TITLE
Fix windows git LFS tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -73,7 +73,6 @@ public class GitClientTest {
     /* Capabilities of command line git in current environment */
     private final boolean CLI_GIT_HAS_GIT_LFS;
     private final boolean CLI_GIT_REPORTS_DETACHED_SHA1;
-    private final boolean CLI_GIT_SUPPORTS_SUBMODULES;
     private final boolean CLI_GIT_SUPPORTS_SUBMODULE_DEINIT;
     private final boolean CLI_GIT_SUPPORTS_SUBMODULE_RENAME;
     private final boolean CLI_GIT_SUPPORTS_SYMREF;
@@ -97,7 +96,6 @@ public class GitClientTest {
             cliGitClient = (CliGitAPIImpl) Git.with(TaskListener.NULL, new EnvVars()).in(srcRepoDir).using("git").getClient();
         }
         CLI_GIT_REPORTS_DETACHED_SHA1 = cliGitClient.isAtLeastVersion(1, 8, 0, 0);
-        CLI_GIT_SUPPORTS_SUBMODULES = cliGitClient.isAtLeastVersion(1, 8, 0, 0);
         CLI_GIT_SUPPORTS_SUBMODULE_DEINIT = cliGitClient.isAtLeastVersion(1, 9, 0, 0);
         CLI_GIT_SUPPORTS_SUBMODULE_RENAME = cliGitClient.isAtLeastVersion(1, 9, 0, 0);
         CLI_GIT_SUPPORTS_SYMREF = cliGitClient.isAtLeastVersion(2, 8, 0, 0);


### PR DESCRIPTION
## [JENKINS-61684](https://issues.jenkins-ci.org/browse/JENKINS-61684) - Adapt GitClientTest for MinGit install

Git for Windows provides three different installers:
* Windows installer (as an MSI file)
* PortableGit (as a self-extracting exe)
* MinGit (as a self-extracting exe)

Windows installer and PortableGit both include git large file support.  MinGit does not.  If Git LFS is configured and then MinGit is installed, command line git attempts to invoke the smudge filter on checkout.  Since the smudge filter invokes `git-lfs`, it fails with a non-existent command.

Having git lfs configured and not installed will cause repository checkout to fail when the repository includes LFS files.  That failed checkout seems reasonable to me, since a tool is configured but not installed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
