### PR TITLE
Fix spotbugs warnings

### DIFF
--- a/src/main/java/hudson/plugins/git/GitObject.java
+++ b/src/main/java/hudson/plugins/git/GitObject.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.eclipse.jgit.lib.ObjectId;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -35,6 +36,7 @@ public class GitObject implements Serializable {
      *
      * @return {@link org.eclipse.jgit.lib.ObjectId} SHA1 of the object.
      */
+    @SuppressFBWarnings(value = "NM_CONFUSING", justification = "Published API in GitObject and Revision")
     public ObjectId getSHA1() {
         return sha1;
     }
@@ -54,6 +56,7 @@ public class GitObject implements Serializable {
      *
      * @return {@link java.lang.String} SHA1 of the object.
      */
+    @SuppressFBWarnings(value = "NM_CONFUSING", justification = "Published API in GitObject and Revision")
     @Exported(name="SHA1")
     public String getSHA1String() {
         return sha1 != null ? sha1.name() : null;

--- a/src/main/java/hudson/plugins/git/Revision.java
+++ b/src/main/java/hudson/plugins/git/Revision.java
@@ -1,5 +1,6 @@
 package hudson.plugins.git;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import static java.util.stream.Collectors.joining;
 
 import hudson.Util;
@@ -50,6 +51,7 @@ public class Revision implements java.io.Serializable, Cloneable {
      *
      * @return a {@link org.eclipse.jgit.lib.ObjectId} object.
      */
+    @SuppressFBWarnings(value = "NM_CONFUSING", justification = "Published API in GitObject and Revision")
     public ObjectId getSha1() {
         return sha1;
     }
@@ -59,6 +61,7 @@ public class Revision implements java.io.Serializable, Cloneable {
      *
      * @return a {@link java.lang.String} object.
      */
+    @SuppressFBWarnings(value = "NM_CONFUSING", justification = "Published API in GitObject and Revision")
     @Exported(name = "SHA1")
     public String getSha1String() {
         return sha1 == null ? "" : sha1.name();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -886,6 +886,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 }
 
                 args.add(fastForwardMode);
+                if (rev == null) {
+                    throw new GitException("MergeCommand requires a revision to merge");
+                }
                 args.add(rev.name());
 
                 /* See JENKINS-45228 */
@@ -2491,6 +2494,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @Override
             public void execute() throws GitException, InterruptedException {
                 ArgumentListBuilder args = new ArgumentListBuilder();
+                if (remote == null) {
+                    throw new GitException("PushCommand requires a 'remote'");
+                }
                 args.add("push", remote.toPrivateASCIIString());
 
                 if (refspec != null) {
@@ -2969,6 +2975,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 BufferedReader rdr = new BufferedReader(new StringReader(result));
                 String line;
 
+                if (out == null) {
+                    throw new GitException("RevListCommand requires a value for 'to'");
+                }
                 try {
                     while ((line = rdr.readLine()) != null) {
                         // Add the SHA1

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -3168,7 +3168,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 tags.add(tag.replaceFirst(".*refs/tags/", ""));
             }
             return tags;
-        } catch (Exception e) {
+        } catch (GitException | IOException | InterruptedException e) {
             throw new GitException("Error retrieving remote tag names", e);
         }
     }
@@ -3190,7 +3190,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 tags.add(tag);
             }
             return tags;
-        } catch (Exception e) {
+        } catch (GitException | IOException | InterruptedException e) {
             throw new GitException("Error retrieving tag names", e);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2683,12 +2683,13 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private void interruptThisCheckout() throws InterruptedException {
                 final File indexFile = new File(workspace.getPath() + File.separator
                         + INDEX_LOCK_FILE_PATH);
+                boolean created = false;
                 try {
-                    indexFile.createNewFile();
+                    created = indexFile.createNewFile();
                 } catch (IOException ex) {
                     throw new InterruptedException(ex.getMessage());
                 }
-                throw new InterruptedException(interruptMessage);
+                throw new InterruptedException(created ? interruptMessage : (interruptMessage + " " + INDEX_LOCK_FILE_PATH + " not created"));
             }
 
             @Override

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -64,6 +64,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -2183,7 +2184,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private String getPathToExe(String userGitExe) {
-        userGitExe = userGitExe.toLowerCase();
+        userGitExe = userGitExe.toLowerCase(Locale.ENGLISH); // Avoid the Turkish 'i' conversion
 
         String cmd;
         String exe;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -3126,6 +3126,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @return a {@link org.eclipse.jgit.lib.Repository} object.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      */
+    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
+                        justification = "JGit interaction with spotbugs")
     @NonNull
     @Override
     public Repository getRepository() throws GitException {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/Git.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/Git.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * Git repository access class. Provides local and remote access to a git
@@ -129,7 +130,7 @@ public class Git implements Serializable {
             final Class<?> it = Class.forName(className);
             final Constructor<?> constructor = it.getConstructor(String.class, EnvVars.class, File.class, TaskListener.class);
             return (GitClient)constructor.newInstance(exe, env, f, listener);
-        } catch (Exception e) {
+        } catch (ClassNotFoundException | IllegalAccessException | IllegalArgumentException | InstantiationException | NoSuchMethodException | SecurityException | InvocationTargetException e) {
             throw new RuntimeException("Unable to initialize mock GitClient " + className, e);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -955,6 +955,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @return a {@link org.eclipse.jgit.lib.Repository} object.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      */
+    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
+                        justification = "JGit interaction with spotbugs")
     @NonNull
     @Override
     public Repository getRepository() throws GitException {
@@ -1402,6 +1404,14 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
+                                justification = "JGit interaction with spotbugs")
+            private RepositoryBuilder newRepositoryBuilder() {
+                RepositoryBuilder builder = new RepositoryBuilder();
+                builder.setGitDir(new File(workspace, Constants.DOT_GIT)).readEnvironment();
+                return builder;
+            }
+
             @Override
             public void execute() throws GitException, InterruptedException {
                 Repository repository = null;
@@ -1414,8 +1424,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     // since jgit clone/init commands do not support object references (e.g. alternates),
                     // we build the repository directly using the RepositoryBuilder
 
-                    RepositoryBuilder builder = new RepositoryBuilder();
-                    builder.readEnvironment().setGitDir(new File(workspace, Constants.DOT_GIT));
+                    RepositoryBuilder builder = newRepositoryBuilder();
 
                     if (shared) {
                         if (reference == null || reference.isEmpty()) {
@@ -2728,6 +2737,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /** {@inheritDoc} */
+    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
+                        justification = "JGit interaction with spotbugs")
     @Deprecated
     @Override
     public boolean isBareRepository(String GIT_DIR) throws GitException, InterruptedException {
@@ -2767,7 +2778,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     @Deprecated
     @Override
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "Java 11 spotbugs error")
+    @SuppressFBWarnings(value = { "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+                                  "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE" },
+                        justification = "Java 11 spotbugs error and JGit interaction with spotbugs")
     public void setRemoteUrl(String name, String url, String GIT_DIR) throws GitException, InterruptedException {
         try (Repository repo = new RepositoryBuilder().setGitDir(new File(GIT_DIR)).build()) {
             StoredConfig config = repo.getConfig();
@@ -2785,7 +2798,9 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return getConfig(GIT_DIR).getString("remote", name, "url");
     }
 
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "Java 11 spotbugs error")
+    @SuppressFBWarnings(value = {"RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+                                 "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE"},
+                        justification = "Java 11 spotbugs error and JGit interaction with spotbugs")
     private StoredConfig getConfig(String GIT_DIR) throws GitException {
         try (Repository repo = isBlank(GIT_DIR) ? getRepository() : new RepositoryBuilder().setWorkTree(new File(GIT_DIR)).build()) {
             return repo.getConfig();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -928,17 +928,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     private Repository openDummyRepository() throws IOException {
         final File tempDir = Util.createTempDir();
-        return new FileRepository(tempDir) {
-            @Override
-            public void close() {
-                super.close();
-                try {
-                    Util.deleteRecursive(tempDir);
-                } catch (IOException e) {
-                    // ignore
-                }
-            }
-        };
+        return new FileRepositoryImpl(tempDir, tempDir);
     }
 
     /** {@inheritDoc} */
@@ -2836,5 +2826,25 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
         }
         return peeledTags;
+    }
+
+    private static class FileRepositoryImpl extends FileRepository {
+
+        private final File tempDir;
+
+        public FileRepositoryImpl(File gitDir, File tempDir) throws IOException {
+            super(gitDir);
+            this.tempDir = tempDir;
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            try {
+                Util.deleteRecursive(tempDir);
+            } catch (IOException e) {
+                // ignore
+            }
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -321,6 +321,14 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         };
     }
 
+    /* Separate method call for benefit of spotbugs */
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "Spotbugs and Netbeans disagree on potential for null")
+    private void closeRepo(Repository repo) {
+        if (repo != null) {
+            repo.close();
+        }
+    }
+
     private void doCheckoutWithResetAndRetry(String ref) throws GitException {
         boolean retried = false;
         Repository repo = null;
@@ -375,10 +383,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     .setStartPoint(matchingRemoteBranch).call();
                 return;
             } catch (CheckoutConflictException e) {
-                if (repo != null) {
-                    repo.close(); /* Close and null for immediate reuse */
-                    repo = null;
-                }
+                closeRepo(repo); /* Ready to reuse repo */
                 // "git checkout -f" seems to overwrite local untracked files but git CheckoutCommand doesn't.
                 // see the test case GitAPITestCase.test_localCheckoutConflict. so in this case we manually
                 // clean up the conflicts and try it again

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1780,7 +1780,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     RefUpdate update = gitRepo.updateRef(r.getName());
                     update.setRefLogMessage("remote branch pruned", false);
                     update.setForceUpdate(true);
-                    Result res = update.delete();
+                    update.delete();
                 }
             }
         } catch (URISyntaxException | IOException e) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2564,7 +2564,6 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
              * Tracks the depth of each tag as we find them.
              */
             class Candidate {
-                final RevCommit commit;
                 final Ref tag;
                 final RevFlag flag;
 
@@ -2575,7 +2574,6 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 int depth;
 
                 Candidate(RevCommit commit, Ref tag) {
-                    this.commit = commit;
                     this.tag = tag;
                     this.flag = w.newFlag(tag.getName());
                     // we'll mark all the nodes reachable from this tag accordingly

--- a/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/MergeCommand.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.gitclient;
 
+import java.util.Locale;
 import org.eclipse.jgit.lib.ObjectId;
 
 /**
@@ -38,7 +39,7 @@ public interface MergeCommand extends GitCommand {
 
         @Override
         public String toString() {
-            return name().toLowerCase();
+            return name().toLowerCase(Locale.ENGLISH); // Avoid Turkish 'i' conversion
         }
     }
 
@@ -59,7 +60,7 @@ public interface MergeCommand extends GitCommand {
 
         @Override
         public String toString() {
-            return "--"+name().toLowerCase().replace("_","-");
+            return "--"+name().toLowerCase(Locale.ENGLISH).replace("_","-"); // Avoid Turkish 'i' issue
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/jgit/PreemptiveAuthHttpClientConnection.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/jgit/PreemptiveAuthHttpClientConnection.java
@@ -431,27 +431,40 @@ public class PreemptiveAuthHttpClientConnection implements HttpConnection {
     }
 
     public void setHostnameVerifier(final HostnameVerifier hostnameverifier) {
-        this.hostnameverifier = new X509HostnameVerifier() {
-            public boolean verify(String hostname, SSLSession session) {
-                return hostnameverifier.verify(hostname, session);
-            }
+        this.hostnameverifier = new X509HostnameVerifierImpl(hostnameverifier);
+    }
 
-            public void verify(String host, String[] cns, String[] subjectAlts)
-                    throws SSLException {
-                throw new UnsupportedOperationException("Unsupported hostname verifier called for " + host);
-            }
+    private static class X509HostnameVerifierImpl implements X509HostnameVerifier {
 
-            public void verify(String host, X509Certificate cert)
-                    throws SSLException {
-                throw new UnsupportedOperationException("Unsupported hostname verifier called for " + host + " with X.509 certificate");
-            }
+        private final HostnameVerifier hostnameverifier;
 
-            public void verify(String host, SSLSocket ssl) throws IOException {
-                if (!hostnameverifier.verify(host, ssl.getSession())) {
-                    throw new IOException();
-                }
+        public X509HostnameVerifierImpl(HostnameVerifier hostnameverifier) {
+            this.hostnameverifier = hostnameverifier;
+        }
+
+        @Override
+        public boolean verify(String hostname, SSLSession session) {
+            return hostnameverifier.verify(hostname, session);
+        }
+
+        @Override
+        public void verify(String host, String[] cns, String[] subjectAlts)
+                throws SSLException {
+            throw new UnsupportedOperationException("Unsupported hostname verifier called for " + host);
+        }
+
+        @Override
+        public void verify(String host, X509Certificate cert)
+                throws SSLException {
+            throw new UnsupportedOperationException("Unsupported hostname verifier called for " + host + " with X.509 certificate");
+        }
+
+        @Override
+        public void verify(String host, SSLSocket ssl) throws IOException {
+            if (!hostnameverifier.verify(host, ssl.getSession())) {
+                throw new IOException();
             }
-        };
+        }
     }
 
     public void configure(KeyManager[] km, TrustManager[] tm,

--- a/src/main/java/org/jenkinsci/plugins/gitclient/trilead/TrileadSession.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/trilead/TrileadSession.java
@@ -50,7 +50,7 @@ public class TrileadSession implements RemoteSession {
 
             @Override
             public int waitFor() throws InterruptedException {
-                int r = s.waitForCondition(EXIT_STATUS, timeout * 1000);
+                int r = s.waitForCondition(EXIT_STATUS, timeout * 1000L);
                 if ((r&EXIT_STATUS)!=0)
                     return exitValue();
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/trilead/TrileadSession.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/trilead/TrileadSession.java
@@ -28,50 +28,61 @@ public class TrileadSession implements RemoteSession {
     }
 
     /** {@inheritDoc} */
+    @Override
     public Process exec(String commandName, final int timeout) throws IOException {
-        final Session s = con.openSession();
-        s.execCommand(commandName);
-
-        return new Process() {
-            @Override
-            public OutputStream getOutputStream() {
-                return s.getStdin();
-            }
-
-            @Override
-            public InputStream getInputStream() {
-                return s.getStdout();
-            }
-
-            @Override
-            public InputStream getErrorStream() {
-                return s.getStderr();
-            }
-
-            @Override
-            public int waitFor() throws InterruptedException {
-                int r = s.waitForCondition(EXIT_STATUS, timeout * 1000L);
-                if ((r&EXIT_STATUS)!=0)
-                    return exitValue();
-
-                // not sure what exception jgit expects
-                throw new InterruptedException("Timed out: "+r);
-            }
-
-            @Override
-            public int exitValue() {
-                Integer i = s.getExitStatus();
-                if (i==null)    throw new IllegalThreadStateException(); // hasn't finished
-                return i;
-            }
-
-            @Override
-            public void destroy() {
-                s.close();
-            }
-        };
+        return new ProcessImpl(con, commandName, timeout);
     }
 
+    private static class ProcessImpl extends Process {
+
+        private final int timeout;
+        private final Session s;
+
+        public ProcessImpl(Connection con, String commandName, final int timeout) throws IOException {
+            this.timeout = timeout;
+            s = con.openSession();
+            s.execCommand(commandName);
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return s.getStdin();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return s.getStdout();
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return s.getStderr();
+        }
+
+        @Override
+        public int waitFor() throws InterruptedException {
+            int r = s.waitForCondition(EXIT_STATUS, timeout * 1000L);
+            if ((r&EXIT_STATUS)!=0)
+                return exitValue();
+
+            // not sure what exception jgit expects
+            throw new InterruptedException("Timed out: " + r);
+        }
+
+        @Override
+        public int exitValue() {
+            Integer i = s.getExitStatus();
+            if (i==null)    throw new IllegalThreadStateException(); // hasn't finished
+            return i;
+        }
+
+        @Override
+        public void destroy() {
+            s.close();
+        }
+    }
+
+    @Override
     public void disconnect() {
         con.close();
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -3480,46 +3480,6 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.checkout().branch("master").ref("origin/master").timeout(checkoutTimeout).deleteBranchIfExist(true).execute();
     }
 
-    @Issue("JENKINS-25353")
-    @NotImplementedInJGit /* JGit lock file management ignored for now */
-    public void test_checkout_interrupted() throws Exception {
-        w = clone(localMirror());
-        File lockFile = new File(w.repo().getDirectory(), "index.lock");
-        assertFalse("lock file already exists", lockFile.exists());
-        String exceptionMsg = "test checkout intentionally interrupted";
-        CliGitAPIImpl cli = (CliGitAPIImpl) w.git;
-        CheckoutCommand cmd = cli.checkout().ref("6b7bbcb8f0e51668ddba349b683fb06b4bd9d0ea"); // git-client-1.6.0
-        cli.interruptNextCheckoutWithMessage(exceptionMsg);
-        try {
-            cmd.execute();
-            fail("Did not throw InterruptedException");
-        } catch (InterruptedException ie) {
-            assertEquals(exceptionMsg, ie.getMessage());
-        }
-        assertFalse("lock file '" + lockFile.getCanonicalPath() + " not removed by cleanup", lockFile.exists());
-    }
-
-    @Issue("JENKINS-25353")
-    @NotImplementedInJGit /* JGit lock file management ignored for now */
-    public void test_checkout_interrupted_with_existing_lock() throws Exception {
-        w = clone(localMirror());
-        File lockFile = new File(w.repo().getDirectory(), "index.lock");
-        lockFile.createNewFile();
-        Thread.sleep(1500); // Wait 1.5 seconds to "age" existing lock file
-        assertTrue("lock file does not exist", lockFile.exists());
-        String exceptionMsg = "test checkout intentionally interrupted";
-        CliGitAPIImpl cli = (CliGitAPIImpl) w.git;
-        CheckoutCommand cmd = cli.checkout().ref("6b7bbcb8f0e51668ddba349b683fb06b4bd9d0ea").timeout(1); // git-client-1.6.0
-        cli.interruptNextCheckoutWithMessage(exceptionMsg);
-        try {
-            cmd.execute();
-            fail("Did not throw InterruptedException");
-        } catch (InterruptedException ie) {
-            assertEquals(exceptionMsg, ie.getMessage());
-        }
-        assertTrue("lock file '" + lockFile.getCanonicalPath() + " removed by cleanup", lockFile.exists());
-    }
-
     public void test_revList_remote_branch() throws Exception {
         w = clone(localMirror());
         List<ObjectId> revList = w.git.revList("origin/1.4.x");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCliCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCliCloneTest.java
@@ -24,6 +24,9 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.io.FileMatchers.aReadableFile;
+import static org.junit.Assert.assertThrows;
+import org.jvnet.hudson.test.Issue;
 
 /*
  * Tests that are specific to command line git.
@@ -133,6 +136,43 @@ public class GitClientCliCloneTest {
         assertTimeout(testGitClient, "git checkout", CliGitAPIImpl.TIMEOUT);
         testGitClient.submoduleUpdate().timeout(largerTimeout).execute();
         assertTimeout(testGitClient, "git submodule update", largerTimeout);
+    }
+
+    @Issue("JENKINS-25353")
+    @Test
+    public void test_checkout_interrupted() throws Exception {
+        testGitClient.clone_().url(workspace.localMirror()).repositoryName("origin").execute();
+        File lockFile = new File(workspace.getGitFileDir(), "index.lock");
+        assertThat("Lock file", lockFile, is(not(aReadableFile())));
+        String exceptionMsg = "test checkout intentionally interrupted";
+        /* Configure next checkout to fail with an exception */
+        CliGitAPIImpl cli = workspace.cgit();
+        cli.interruptNextCheckoutWithMessage(exceptionMsg);
+        Exception exception = assertThrows(InterruptedException.class, () -> {
+            cli.checkout().ref("6b7bbcb8f0e51668ddba349b683fb06b4bd9d0ea").execute(); // git-client-1.6.0
+        });
+        assertThat(exception.getMessage(), is(exceptionMsg)); // Except exact exception message returned
+        assertThat("Lock file removed by checkout", lockFile, is(not(aReadableFile())));
+    }
+
+    @Issue("JENKINS-25353")
+    @Test
+    public void test_checkout_interrupted_with_existing_lock() throws Exception {
+        testGitClient.clone_().url(workspace.localMirror()).repositoryName("origin").execute();
+        File lockFile = new File(workspace.getGitFileDir(), "index.lock");
+        boolean created = lockFile.createNewFile();
+        assertThat("Lock file creation failed " + lockFile.getAbsolutePath(), created, is(true));
+        assertThat("Lock file", lockFile, is(not(aReadableFile())));
+        Thread.sleep(1500); // Wait 1.5 seconds to "age" the lock file - lock created before checkout
+        String exceptionMsg = "test checkout intentionally interrupted";
+        /* Configure next checkout to fail with an exception */
+        CliGitAPIImpl cli = workspace.cgit();
+        cli.interruptNextCheckoutWithMessage(exceptionMsg);
+        Exception exception = assertThrows(InterruptedException.class, () -> {
+            cli.checkout().ref("6b7bbcb8f0e51668ddba349b683fb06b4bd9d0ea").execute(); // git-client-1.6.0
+        });
+        assertThat(exception.getMessage(), containsString(exceptionMsg));
+        assertThat("Lock file removed by checkout", lockFile, is(aReadableFile()));
     }
 
     private void assertLoggedMessage(GitClient gitClient, final String candidateSubstring, final String expectedValue, final boolean expectToFindMatch) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCliCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCliCloneTest.java
@@ -162,8 +162,8 @@ public class GitClientCliCloneTest {
         File lockFile = new File(workspace.getGitFileDir(), "index.lock");
         boolean created = lockFile.createNewFile();
         assertThat("Lock file creation failed " + lockFile.getAbsolutePath(), created, is(true));
-        assertThat("Lock file", lockFile, is(not(aReadableFile())));
-        Thread.sleep(1500); // Wait 1.5 seconds to "age" the lock file - lock created before checkout
+        assertThat("Lock file", lockFile, is(aReadableFile()));
+        Thread.sleep(1800); // Wait 1.8 seconds to "age" the lock file - lock created before checkout
         String exceptionMsg = "test checkout intentionally interrupted";
         /* Configure next checkout to fail with an exception */
         CliGitAPIImpl cli = workspace.cgit();


### PR DESCRIPTION
## Fix spotbugs warnings from `Low` setting

When spotbugs 4.0.1 was introduced, the threshold was changed to `Low`.  That listed many warning which were not visible at the previous threshold.  This plugin resolves many of those warnings.  Remaining warnings do not seem interesting enough to modify.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
