### PR TITLE
Require Jenkins 2.204.1 or later

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,8 @@ def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build b
 
 // build recommended configurations
 subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                      ],
-                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.176.3' : '2.164.1', javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.176.3' : '2.164.1', javaLevel: '8' ]
+                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.204.6' : '2.222.1', javaLevel: '8' ],
+                        [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.204.6' : '2.222.1', javaLevel: '8' ]
                       ]
 
 buildPlugin(configurations: subsetConfiguration, failFast: false)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 Random random = new Random() // Randomize which Jenkins version is selected for more testing
 def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other
 
-// build recommended configurations
+// Test plugin compatibility to recommended configurations
 subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                      ],
                         // Compile with Java 8, test 2.204.6 or 2.222.1 depending on random use_newer_jenkins
                         [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.204.6' : '2.222.1', javaLevel: '8' ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,9 @@ def use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build b
 
 // build recommended configurations
 subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                      ],
+                        // Compile with Java 8, test 2.204.6 or 2.222.1 depending on random use_newer_jenkins
                         [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.204.6' : '2.222.1', javaLevel: '8' ],
+                        // Compile with Java 11, test the Jenkins version that Java 8 did *not* test
                         [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.204.6' : '2.222.1', javaLevel: '8' ]
                       ]
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,22 +53,23 @@
   </scm>
 
   <properties>
-    <revision>3.2.2</revision>
+    <revision>3.3</revision>
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.204.1</jenkins.version>
     <java.level>8</java.level>
     <jgit.version>5.7.0.202003110725-r</jgit.version>
     <forkCount>1C</forkCount>
     <configuration-as-code.version>1.35</configuration-as-code.version>
+    <slf4jVersion>1.7.26</slf4jVersion>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.138.x</artifactId>
+        <artifactId>bom-2.176.x</artifactId>
         <version>4</version>
         <type>pom</type>
         <scope>import</scope>
@@ -76,6 +77,11 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>trilead-api</artifactId>
+      <version>1.0.5</version>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
     <jenkins.version>2.204.1</jenkins.version>
     <java.level>8</java.level>
     <jgit.version>5.7.0.202003110725-r</jgit.version>
-    <forkCount>1C</forkCount>
     <configuration-as-code.version>1.36</configuration-as-code.version>
     <slf4jVersion>1.7.26</slf4jVersion>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.0-beta-6</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <java.level>8</java.level>
     <jgit.version>5.7.0.202003110725-r</jgit.version>
     <forkCount>1C</forkCount>
-    <configuration-as-code.version>1.35</configuration-as-code.version>
+    <configuration-as-code.version>1.36</configuration-as-code.version>
     <slf4jVersion>1.7.26</slf4jVersion>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </scm>
 
   <properties>
-    <revision>3.3</revision>
+    <revision>3.3.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>


### PR DESCRIPTION
## Require Jenkins 2.204.1 or later

This pull request switches from requiring Jenkins 2.138.4 as minimum version to require Jenkins 2.204.1 as minimum version.  Using a modern version like 2.204.1 includes the trilead-api separation from the Jenkins core and simplifies testing.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)

## Further comments

User based justification for choosing 2.204.1 as the new minimum version:

* Over 50% of the 240 000 installations of git client plugin are running git client plugin 3.0.0 or newer.  Over 40 000 git client plugin installations are using Jenkins 2.204.2
* Almost 10x more installations of git client plugin are on Jenkins 2.204.2 than any other single release

Users that are choosing to stay current with the git client plugin are also choosing to stay current with Jenkins releases.  That's a very good thing.  Special thanks to the users for choosing to update to recent releases!

The Jenkinsfile is now configured to test Jenkins 2.204.6 on Windows with Java 8 and Jenkins 2.222.1 or 2.204.6 on Linux with both Java 8 and Java 11.  It intentionally tests the most recent release of Jenkins 2.204.x while only requiring 2.204.1 so that users of 2.204.2 are not forced to update to use the git client plugin.

There are still some spotbugs warnings that will either need to be suppressed, resolved, or hidden by restoring the spotbugs settings that were used until the recent update to spotbugs 4.0.1.  Specifically, the spotbugs threshold was previously set to 'High' with the effort set to 'Low'.  The new settings invert that and set the threshold to 'Low' and the effort to 'Max'.

This change intentionally uses plugin pom 4.0-beta with the assumption that plugin pom 4.0 will be released within the next month or so.  If it is not released in that time, then the most recent released parent will be used instead.

Marching pull request for git plugin at https://github.com/jenkinsci/git-plugin/pull/862