### PR TITLE
Use bom 2.204.x for dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.190.x</artifactId>
-        <version>7</version>
+        <artifactId>bom-2.204.x</artifactId>
+        <version>9</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Use BOM 2.204.x for dependencies

Use latest bill of materials to match with the minimum Jenkins version.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)