### PR TITLE
[JENKINS-62382] Enhance checkout to use credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2721,18 +2721,45 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     sparseCheckout(sparseCheckoutPaths);
 
                     EnvVars checkoutEnv = environment;
+
+                    // Use credentials with checkout
+                    boolean useCredentials = false;
+                    URIish uri = null;
+                    StandardCredentials creds = null;
                     if (lfsRemote != null) {
                         // Disable the git-lfs smudge filter because it is much slower on
                         // certain OSes than doing a single "git lfs pull" after checkout.
                         checkoutEnv = new EnvVars(checkoutEnv);
                         checkoutEnv.put("GIT_LFS_SKIP_SMUDGE", "1");
+                    } else {
+                        useCredentials = true;
+                        String defaultRemote = null;
+                        try {
+                            defaultRemote = getDefaultRemote();
+                        } catch (GitException e) {
+                            useCredentials = false;
+                        }
+                        if (defaultRemote != null && !defaultRemote.isEmpty()) {
+                            final String url = getRemoteUrl(defaultRemote);
+                            creds = credentials.get(url);
+                            if (creds == null) creds = defaultCredentials;
+                            try {
+                                uri = new URIish(url);
+                            } catch (URISyntaxException e) {
+                                useCredentials = false;
+                            }
+                        }
                     }
 
                     if (branch!=null && deleteBranch) {
                         // First, checkout to detached HEAD, so we can delete the branch.
                         ArgumentListBuilder args = new ArgumentListBuilder();
                         args.add("checkout", "-f", ref);
-                        launchCommandIn(args, workspace, checkoutEnv, timeout);
+                        if (useCredentials) {
+                            launchCommandWithCredentials(args, workspace, creds, uri, timeout);
+                        } else {
+                            launchCommandIn(args, workspace, checkoutEnv, timeout);
+                        }
 
                         // Second, check to see if the branch actually exists, and then delete it if it does.
                         for (Branch b : getBranches()) {
@@ -2750,7 +2777,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         args.add("-f");
                     }
                     args.add(ref);
-                    launchCommandIn(args, workspace, checkoutEnv, timeout);
+                    if (useCredentials) {
+                        launchCommandWithCredentials(args, workspace, creds, uri, timeout);
+                    } else {
+                        launchCommandIn(args, workspace, checkoutEnv, timeout);
+                    }
 
                     if (lfsRemote != null) {
                         final String url = getRemoteUrl(lfsRemote);


### PR DESCRIPTION
## [JENKINS-62382](https://issues.jenkins-ci.org/browse/JENKINS-62382) - Enhance checkout to use credentials if git-lfs smudge is enabled

`checkout scm` for private repositories will fail or hang when it has lfs files. This is because git-lfs attempts to download those lfs blobs but without credentials it will fail or hang(assumed to be terminal prompt). This PR simply enhances checkout to use credentials for checkout when the smudge filter process is enabled.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
