### PR TITLE
Test 3 of 4 benchmarks to reduce run time

### DIFF
--- a/src/test/java/jmh/benchmark/GitClientFetchBenchmark.java
+++ b/src/test/java/jmh/benchmark/GitClientFetchBenchmark.java
@@ -41,7 +41,8 @@ public class GitClientFetchBenchmark {
         @Param({"https://github.com/stephenc/java-logging-benchmarks.git",
                 "https://github.com/uutils/coreutils.git",
                 "https://github.com/freedesktop/cairo.git",
-                "https://github.com/samba-team/samba.git"})
+                // "https://github.com/samba-team/samba.git",
+               })
         String repoUrl;
 
         final FolderForBenchmark tmp = new FolderForBenchmark();


### PR DESCRIPTION
## Test 3 of 4 benchmarks to reduce run time

The CI job benchmark run requires over 3 hours and holds a lock on a ci.jenkins.io resource during that 3 hour run.  Needs to be faster.  Temporarily reduce to run 3 of the 4 tests.

Run on ci.jenkins.io used 51 minutes for the 3 tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)