### PR TITLE
Fix abnormally long duration of git fetch benchmark

### DIFF
--- a/src/test/java/jmh/benchmark/BenchmarkRunner.java
+++ b/src/test/java/jmh/benchmark/BenchmarkRunner.java
@@ -26,8 +26,9 @@ public class BenchmarkRunner {
                 .forks(2)   // Need to increase more forks to get more observations, increases precision.
                 .shouldFailOnError(true) // Will stop forking of JVM as soon as there is a compilation error
                 .shouldDoGC(true) // do GC between measurement iterations
-                .resultFormat(ResultFormatType.JSON) // store the results in a file called jmh-report.json
-                .result("jmh-report.json");
+                .output("jmh-readable-report.json");
+//                .resultFormat(ResultFormatType.JSON) // store the results in a file called jmh-report.json
+//                .result("jmh-report.json");
 
         BenchmarkFinder bf = new BenchmarkFinder(getClass());
         bf.findBenchmarks(options);

--- a/src/test/java/jmh/benchmark/BenchmarkRunner.java
+++ b/src/test/java/jmh/benchmark/BenchmarkRunner.java
@@ -26,7 +26,7 @@ public class BenchmarkRunner {
                 .forks(2)   // Need to increase more forks to get more observations, increases precision.
                 .shouldFailOnError(true) // Will stop forking of JVM as soon as there is a compilation error
                 .shouldDoGC(true) // do GC between measurement iterations
-                .output("jmh-readable-report.json");
+                .output("jmh-report.json");
 //                .resultFormat(ResultFormatType.JSON) // store the results in a file called jmh-report.json
 //                .result("jmh-report.json");
 

--- a/src/test/java/jmh/benchmark/GitClientInitBenchmark.java
+++ b/src/test/java/jmh/benchmark/GitClientInitBenchmark.java
@@ -11,7 +11,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.File;
 
-@JmhBenchmark
+//@JmhBenchmark
 public class GitClientInitBenchmark {
 
     @State(Scope.Thread)


### PR DESCRIPTION
The static state class provided by JMH supplements the overhead costs of running a benchmark which are not added in the benchmarking process.

Earlier, the scope of setup() and teardown() methods was set to `Level.Iteration` which means that for each invocation of a benchmark, we create a git client, clone the upstream repository and then test git fetch. This is _certainly_ not ideal. The cost of running a benchmark becomes too high as we are cloning each repository using network for each iteration of a benchmark (5 times is default by JMH) x 2 (fork = 2, all benchmarks are run twice in a separate JVM). 

Now, the state class has been divided into two parts: 

1) ClientState: This static state class provides a git client with a fresh initialized local repository. To keep this local repository clean for each invocation of git fetch benchmark, we have setup its scope to `Level.Iteration`. 

2) CloneRepoState: This static class provides the local copy of a cloned upstream repository. The setup and teardown methods for this class only run once during the execution of a benchmark class. This makes sure that we are not creating a local copy with each benchmark iteration. 

## This change has reduced the duration time of git fetch benchmark to 02:12:36 on my linux instance.

