### PR TITLE
Add conditional logic in JenkinsFile to run benchmarks conditionally

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,4 +12,8 @@ subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null         
                       ]
 
 buildPlugin(configurations: subsetConfiguration, failFast: false)
-runBenchmarks('jmh-report.json')
+
+def branchName = "${env.BRANCH_NAME}"
+if (branchName ==~ /master/ || branchName =~ /gsoc-*/) {
+	runBenchmarks('jmh-report.json')
+}


### PR DESCRIPTION
## Update in JenkinsFile 

This change will ensure that JMH benchmark module will run benchmarks only if it is the "master" branch or any "gsoc-" related branch.

If only one branch is kept for gsoc in the future, for example gsoc-dev, then we can remove the regex and only search for "gsoc-dev"

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
