### PR TITLE
Handle auto-installing PortableGit - return git.exe path when getHome() is a directory and getHome()/bin/git.exe exists

### DIFF
--- a/src/main/java/hudson/plugins/git/GitTool.java
+++ b/src/main/java/hudson/plugins/git/GitTool.java
@@ -58,6 +58,10 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
      * @return {@link java.lang.String} that will be used to execute git (e.g. "git" or "/usr/bin/git")
      */
     public String getGitExe() {
+        File gitHome = new File(getHome());
+        if(gitHome.isDirectory() && new File(gitHome.getAbsolutePath() + File.separator + "bin" + File.separator + "git.exe").exists()) {
+        	return new File(gitHome.getAbsolutePath() + File.separator + "bin" + File.separator + "git.exe").getAbsolutePath();
+        }
         return getHome();
     }
 


### PR DESCRIPTION
## [JENKINS-xxxxx](https://issues.jenkins-ci.org/browse/JENKINS-xxxxx) - summarize pull request in one line

Describe the big picture of your changes here to explain to the maintainers why this pull request should be accepted.
If it fixes a bug or resolves a feature request, include a link to the issue.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

We have multiple nodes that run on Windows and we'd been manually copying unpacked PortableGit installs to them in order to use it. While we've switched to using auto-installers for much of our tools this was impossible for Git because of errors like the following (with a little bit of manual internal printing to loggers and stderr):

```
Started by user Kyle Gottfried
Checking out git https://github.com/Spitfire1900/jenkins-test.git into C:\Jenkins-PortableGit\Jenkinshome\workspace\Test@script to read Jenkinsfile
Unpacking file:///C:/Jenkins-PortableGit/PortableGit.zip to C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe on Jenkins
[WARNING] using C:\Jenkins-PortableGit\Jenkinshome\workspace\Test@script as workspace, C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe as git exe

java.lang.Throwable
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.<init>(CliGitAPIImpl.java:309)
	at hudson.plugins.git.GitAPI.<init>(GitAPI.java:77)
	at org.jenkinsci.plugins.gitclient.Git$GitAPIMasterToSlaveFileCallable.invoke(Git.java:168)
	at org.jenkinsci.plugins.gitclient.Git$GitAPIMasterToSlaveFileCallable.invoke(Git.java:149)
	at hudson.FilePath.act(FilePath.java:1075)
	at hudson.FilePath.act(FilePath.java:1058)
	at org.jenkinsci.plugins.gitclient.Git.getClient(Git.java:121)
	at hudson.plugins.git.GitSCM.createClient(GitSCM.java:839)
	at hudson.plugins.git.GitSCM.createClient(GitSCM.java:830)
	at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1166)
	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep.checkout(SCMStep.java:125)
	at org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:155)
	at org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:69)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:309)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:428)

No credentials specified
Cloning the remote Git repository
Cloning repository https://github.com/Spitfire1900/jenkins-test.git
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe init C:\Jenkins-PortableGit\Jenkinshome\workspace\Test@script # timeout=10
ERROR: Error cloning remote repo 'origin'
hudson.plugins.git.GitException: Could not init C:\Jenkins-PortableGit\Jenkinshome\workspace\Test@script
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$5.execute(CliGitAPIImpl.java:1000)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$2.execute(CliGitAPIImpl.java:755)
	at hudson.plugins.git.GitSCM.retrieveChanges(GitSCM.java:1132)
	at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1177)
	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep.checkout(SCMStep.java:125)
	at org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:155)
	at org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:69)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:309)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:428)
Caused by: hudson.plugins.git.GitException: Error performing git command: C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe init C:\Jenkins-PortableGit\Jenkinshome\workspace\Test@script
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2455)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2378)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2374)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommand(CliGitAPIImpl.java:1926)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$5.execute(CliGitAPIImpl.java:998)
	... 9 more
Caused by: java.io.IOException: Cannot run program "C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe" (in directory "C:\Jenkins-PortableGit\Jenkinshome\workspace\Test@script"): CreateProcess error=5, Access is denied
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1128)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1071)
	at hudson.Proc$LocalProc.<init>(Proc.java:252)
	at hudson.Proc$LocalProc.<init>(Proc.java:221)
	at hudson.Launcher$LocalLauncher.launch(Launcher.java:936)
	at hudson.Launcher$ProcStarter.start(Launcher.java:454)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2441)
	... 13 more
Caused by: java.io.IOException: CreateProcess error=5, Access is denied
	at java.base/java.lang.ProcessImpl.create(Native Method)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:478)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:154)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1107)
	... 19 more
ERROR: Error cloning remote repo 'origin'
ERROR: Maximum checkout retry attempts reached, aborting
Finished: FAILURE
```

The "Path to Git executable" for field was acting like the name form field for most other plugins and then returning the unpacked location's folder rather than the executable itself.

This change has getGitExe() search for and return ${getHome()}/bin/git.exe if the path exists so that PortableGit can be auto-installed and used.

Manual test console output:
```
Started by user Kyle Gottfried
Checking out git https://github.com/Spitfire1900/jenkins-test.git into C:\Jenkins-PortableGit\Jenkinshome\workspace\Test@script to read Jenkinsfile
Unpacking file:///C:/Jenkins-PortableGit/PortableGit.zip to C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe on Jenkins
No credentials specified
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe rev-parse --is-inside-work-tree # timeout=10
Fetching changes from the remote Git repository
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe config remote.origin.url https://github.com/Spitfire1900/jenkins-test.git # timeout=10
Fetching upstream changes from https://github.com/Spitfire1900/jenkins-test.git
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe --version # timeout=10
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe fetch --tags --force --progress -- https://github.com/Spitfire1900/jenkins-test.git +refs/heads/*:refs/remotes/origin/* # timeout=10
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe rev-parse "refs/remotes/origin/master^{commit}" # timeout=10
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe rev-parse "refs/remotes/origin/origin/master^{commit}" # timeout=10
Checking out Revision 95c7b4f8d158337847f2953a28e4e0db50de5286 (refs/remotes/origin/master)
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe config core.sparsecheckout # timeout=10
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe checkout -f 95c7b4f8d158337847f2953a28e4e0db50de5286 # timeout=10
Commit message: "Create Jenkinsfile"
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe rev-list --no-walk 95c7b4f8d158337847f2953a28e4e0db50de5286 # timeout=10
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] Start of Pipeline
[Pipeline] node
Running on Jenkins in C:\Jenkins-PortableGit\Jenkinshome\workspace\Test
[Pipeline] {
[Pipeline] checkout
No credentials specified
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe rev-parse --is-inside-work-tree # timeout=10
Fetching changes from the remote Git repository
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe config remote.origin.url https://github.com/Spitfire1900/jenkins-test.git # timeout=10
Fetching upstream changes from https://github.com/Spitfire1900/jenkins-test.git
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe --version # timeout=10
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe fetch --tags --force --progress -- https://github.com/Spitfire1900/jenkins-test.git +refs/heads/*:refs/remotes/origin/* # timeout=10
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe rev-parse "refs/remotes/origin/master^{commit}" # timeout=10
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe rev-parse "refs/remotes/origin/origin/master^{commit}" # timeout=10
Checking out Revision 95c7b4f8d158337847f2953a28e4e0db50de5286 (refs/remotes/origin/master)
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe config core.sparsecheckout # timeout=10
 > C:\Jenkins-PortableGit\Jenkinshome\tools\git.exe\bin\git.exe checkout -f 95c7b4f8d158337847f2953a28e4e0db50de5286 # timeout=10
Commit message: "Create Jenkinsfile"
[Pipeline] echo
Hello world!
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```