### PR TITLE
[JENKINS-62767] Need to bundle org.eclipse.jgit.ssh.jsch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,6 @@
       <artifactId>org.eclipse.jgit</artifactId>
       <version>${jgit.version}</version>
       <exclusions>
-        <exclusion><!-- Provided by JSch plugin -->
-          <groupId>com.jcraft</groupId>
-          <artifactId>jsch</artifactId>
-        </exclusion>
         <exclusion>
           <!-- Provided by apache-httpcomponents-client-4-api -->
           <groupId>org.apache.httpcomponents</groupId>
@@ -117,10 +113,6 @@
       <artifactId>org.eclipse.jgit.http.server</artifactId>
       <version>${jgit.version}</version>
       <exclusions>
-        <exclusion><!-- Provided by JSch plugin -->
-          <groupId>com.jcraft</groupId>
-          <artifactId>jsch</artifactId>
-        </exclusion>
         <exclusion>
           <!-- Provided by apache-httpcomponents-client-4-api -->
           <groupId>org.apache.httpcomponents</groupId>
@@ -139,10 +131,6 @@
       <artifactId>org.eclipse.jgit.http.apache</artifactId>
       <version>${jgit.version}</version>
       <exclusions>
-        <exclusion><!-- Provided by JSch plugin -->
-          <groupId>com.jcraft</groupId>
-          <artifactId>jsch</artifactId>
-        </exclusion>
         <exclusion>
           <!-- Provided by apache-httpcomponents-client-4-api -->
           <groupId>org.apache.httpcomponents</groupId>
@@ -165,10 +153,6 @@
       <artifactId>org.eclipse.jgit.lfs</artifactId>
       <version>${jgit.version}</version>
       <exclusions>
-        <exclusion><!-- Provided by JSch plugin -->
-          <groupId>com.jcraft</groupId>
-          <artifactId>jsch</artifactId>
-        </exclusion>
         <exclusion>
           <!-- Provided by apache-httpcomponents-client-4-api -->
           <groupId>org.apache.httpcomponents</groupId>
@@ -178,6 +162,25 @@
           <!-- Provided by Jenkins core -->
           <groupId>com.jcraft</groupId>
           <artifactId>jzlib</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+      <version>${jgit.version}</version>
+      <exclusions>
+        <exclusion> <!-- provided by jenkins-core -->
+          <groupId>com.jcraft</groupId>
+          <artifactId>jzlib</artifactId>
+        </exclusion>
+        <exclusion> <!-- Provided by jsch plugin -->
+          <groupId>com.jcraft</groupId>
+          <artifactId>jsch</artifactId>
+        </exclusion>
+        <exclusion> <!-- provided by jenkins-core -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
[JENKINS-62767](https://issues.jenkins-ci.org/browse/JENKINS-62767) - need to bundle org.eclipse.jgit.ssh.jsch

Amends #561 to handle https://github.com/eclipse/jgit/commit/8d2d683655e2de17cf465fa46af10e0e56b3aaed.

Not tested in any way, except verifying that the list of bundle JARs now looks saner and includes the missing class.