### PR TITLE
Add scm-api dependency for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,11 +188,16 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
     </dependency>
-    <dependency>
+    <dependency> <!-- Credentials test requires scm-api -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-        <classifier>tests</classifier>
-        <scope>test</scope>
+      <scope>test</scope>
+    </dependency>
+    <dependency> <!-- Tests require the scm-api-tests jar -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Add scm-api dependency for tests

The CredentialsTest reports an ugly stack trace during startup because it cannot find the scm-api plugin.  The stack trace does not fail the tests but is a distraction from the purpose of the CredentialsTest.  Include the scm-api asa  test dependency so that the tests do not include that distracting stack trace.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)

## Further comments

Without the scm-api dependency, the CredentialsTest reports:

```
   2.505 [id=31]        WARNING hudson.ExtensionFinder$Sezpoz#scout: Failed to scout jenkins.scm.impl.mock.MockSCMDiscoverBranches$DescriptorImpl
java.lang.ClassNotFoundException: jenkins.scm.api.trait.SCMSourceTraitDescriptor
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
Caused: java.lang.NoClassDefFoundError: jenkins/scm/api/trait/SCMSourceTraitDescriptor
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:800)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:698)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:621)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:579)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:576)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at net.java.sezpoz.IndexItem.element(IndexItem.java:134)
Caused: java.lang.InstantiationException
        at net.java.sezpoz.IndexItem.element(IndexItem.java:146)
        at hudson.ExtensionFinder.getClassFromIndex(ExtensionFinder.java:741)
        at hudson.ExtensionFinder.access$900(ExtensionFinder.java:89)
        at hudson.ExtensionFinder$Sezpoz.scout(ExtensionFinder.java:726)
        at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:338)
        at hudson.ExtensionList.load(ExtensionList.java:381)
        at hudson.ExtensionList.ensureLoaded(ExtensionList.java:317)
        at hudson.ExtensionList.getComponents(ExtensionList.java:183)
        at jenkins.model.Jenkins$6.onInitMilestoneAttained(Jenkins.java:1151)
        at jenkins.InitReactorRunner$1.onAttained(InitReactorRunner.java:83)
        at org.jvnet.hudson.reactor.ReactorListener$Aggregator.lambda$onAttained$3(ReactorListener.java:102)
        at org.jvnet.hudson.reactor.ReactorListener$Aggregator.run(ReactorListener.java:109)
        at org.jvnet.hudson.reactor.ReactorListener$Aggregator.onAttained(ReactorListener.java:102)
        at org.jvnet.hudson.reactor.Reactor$1.run(Reactor.java:177)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
```

Failure is visible in my test environment.  Since the CredentialsTest requires private files for the credentials, we will never see that failure in the public CI on ci.jenkins.io.