### PR TITLE
Make benchmarks conditional on commit message content

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,10 @@ boolean shouldRunBenchmarks(String branchName) {
     if (branchName.endsWith('master')) { // accept both origin/master and master
         return true;
     }
-    def gitLog = 'git log -n 3'
     def recentCommitMessages
     node('linux') {
-        recentCommitMessages = sh(script: gitLog, returnStdout: true)
+        checkout scm
+        recentCommitMessages = sh(script: 'git log -n 3', returnStdout: true)
     }
     return recentCommitMessages =~ /.*[Bb]enchmark.*/
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,21 @@
 
 buildPlugin(failFast: false)
 
-runBenchmarks('jmh-report.json')
+// Return true if benchmarks should be run
+// Benchmarks run on the master branch always
+// Benchmarks run if any of the most recent 3 commits includes the word 'benchmark'
+boolean shouldRunBenchmarks(String branchName) {
+    if (branchName.endsWith('master')) { // accept both origin/master and master
+        return true;
+    }
+    def gitLog = 'git log -n 3'
+    def recentCommitMessages
+    node('linux') {
+        recentCommitMessages = sh(script: gitLog, returnStdout: true)
+    }
+    return recentCommitMessages =~ /.*[Bb]enchmark.*/
+}
+
+if (shouldRunBenchmarks(env.BRANCH_NAME)) {
+    runBenchmarks('jmh-report.json')
+}

--- a/Priorities.adoc
+++ b/Priorities.adoc
@@ -14,7 +14,7 @@ When others provide additional help on an item, it tends to raise the priority o
 . link:CONTRIBUTING.adoc#bug-triage[Bug report triage]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3AShortTerm[Short term improvements]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3ACaching[Caching & performance improvements]
-. link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3AnotifyCommit[notifyCommit and webhook improvements]
+. link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3AnotifyCommit[notifyCommit & webhook improvements]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3AChangelog+[Changelog improvements]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3ASubmodules[Submodule improvements]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3ABuildData[BuildData memory bloat]

--- a/Priorities.adoc
+++ b/Priorities.adoc
@@ -17,7 +17,7 @@ When others provide additional help on an item, it tends to raise the priority o
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3AnotifyCommit[notifyCommit & webhook improvements]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3AChangelog+[Changelog improvements]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3ASubmodules[Submodule improvements]
-. link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3ABuildData[BuildData memory bloat]
+. link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3ABuildData[BuildData memory bloat reduction]
 
 [[bug-reports]]
 == Bug Reports

--- a/Priorities.adoc
+++ b/Priorities.adoc
@@ -13,7 +13,7 @@ When others provide additional help on an item, it tends to raise the priority o
 
 . link:CONTRIBUTING.adoc#bug-triage[Bug report triage]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3AShortTerm[Short term improvements]
-. link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3ACaching[Caching and performance improvements]
+. link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3ACaching[Caching & performance improvements]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3AnotifyCommit[notifyCommit and webhook improvements]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3AChangelog+[Changelog improvements]
 . link:https://github.com/jenkinsci/git-client-plugin/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aunmerged+label%3ASubmodules[Submodule improvements]


### PR DESCRIPTION
## Make benchmarks conditional on commit message content

Avoid running benchmarks unless the recent commit messages include the word 'benchmark' or we are on the master branch.

This is my alternative to the "run on every branch" we are currently using and the "run only on gsoc-*" branches.  Comments?

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)