### PR TITLE
[JENKINS-63146] Honor ibm.system.encoding property in passphrase file

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2165,8 +2165,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private File createPassphraseFile(SSHUserPrivateKey sshUser) throws IOException {
+        String charset = "UTF-8";
+        if (isZos() && System.getProperty("ibm.system.encoding") != null) {
+            charset = Charset.forName(System.getProperty("ibm.system.encoding")).toString();
+        }
         File passphraseFile = createTempFile("phrase", ".txt");
-        try (PrintWriter w = new PrintWriter(passphraseFile, "UTF-8")) {
+        try (PrintWriter w = new PrintWriter(passphraseFile, charset)) {
             w.println(Secret.toString(sshUser.getPassphrase()));
         }
         return passphraseFile;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2168,6 +2168,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         String charset = "UTF-8";
         if (isZos() && System.getProperty("ibm.system.encoding") != null) {
             charset = Charset.forName(System.getProperty("ibm.system.encoding")).toString();
+	    listener.getLogger().println("Using passphrase charset '" + charset + "'");
         }
         File passphraseFile = createTempFile("phrase", ".txt");
         try (PrintWriter w = new PrintWriter(passphraseFile, charset)) {


### PR DESCRIPTION
## [JENKINS-63146](https://issues.jenkins-ci.org/browse/JENKINS-63198) Honor ibm.system.encoding property in passphrase file

Consistent with usage in other locations in the plugin but requires that a property be set on the agent JVM.  Setting a property on the agent JVM may be a little more complicated than setting an environment variable.  May require setting the argument in the advanced section of the agent startup rather than in the agent properties.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)