### PR TITLE
[JENKINS-63146] Use credentials.file.encoding property for passphrase file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -114,6 +114,13 @@ Command line git 2.20 and later do not update an existing tag if the remote tag 
 +
 Default is `true` so that newer command line git versions behave the same as older versions.
 
+password.file.encoding::
+When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.password.file.encoding` is set to a non-empty value (like `IBM-1047`) and the agent is running on IBM zOS, the password file is written using that character set.
+The character sets of other credential files are not changed.
+The character sets on other operating systems are not changed.
++
+Default is empty so that zOS file encoding behaves as it did previously.
+
 promptForAuthentication::
 When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.promptForAuthentication` is set to `true` it allows command line git versions 2.3 and later to prompt the user for authentication.
 Command line git prompting for authentication should be rare, since Jenkins credentials should be managed through the credentials plugin.

--- a/README.adoc
+++ b/README.adoc
@@ -98,6 +98,13 @@ When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.checkRemoteURL` is set to `f
 +
 Default is `true` so that repository URL's are rejected if they start with `-` or contain space characters.
 
+credentials.file.encoding::
+When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.credentials.file.encoding` is set to a non-empty value (like `IBM-1047`) and the agent is running on IBM zOS, the ssh passphrase file is written using that character set.
+The character sets of other credential files are not changed.
+The character sets on other operating systems are not changed.
++
+Default is empty so that zOS file encoding behaves as it did previously.
+
 forceFetch::
 When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.forceFetch` is set to `false` it allows command line git versions 2.20 and later to not update tags which have already been fetched into the workspace.
 +

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2166,8 +2166,13 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private File createPassphraseFile(SSHUserPrivateKey sshUser) throws IOException {
+        String charset = "UTF-8";
+        if (isZos() && System.getProperty(CliGitAPIImpl.class.getName() + ".credentials.file.encoding") != null) {
+            charset = Charset.forName(System.getProperty(CliGitAPIImpl.class.getName() + ".credentials.file.encoding")).toString();
+	    listener.getLogger().println("Using passphrase charset '" + charset + "'");
+        }
         File passphraseFile = createTempFile("phrase", ".txt");
-        try (PrintWriter w = new PrintWriter(passphraseFile, "UTF-8")) {
+        try (PrintWriter w = new PrintWriter(passphraseFile, charset)) {
             w.println(Secret.toString(sshUser.getPassphrase()));
         }
         return passphraseFile;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2187,8 +2187,13 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private File createPasswordFile(StandardUsernamePasswordCredentials userPass) throws IOException {
+        String charset = "UTF-8";
+        if (isZos() && System.getProperty(CliGitAPIImpl.class.getName() + ".password.file.encoding") != null) {
+            charset = Charset.forName(System.getProperty(CliGitAPIImpl.class.getName() + ".credentials.file.encoding")).toString();
+	    listener.getLogger().println("Using password charset '" + charset + "'");
+        }
         File passwordFile = createTempFile("password", ".txt");
-        try (PrintWriter w = new PrintWriter(passwordFile, "UTF-8")) {
+        try (PrintWriter w = new PrintWriter(passwordFile, charset)) {
             w.println(Secret.toString(userPass.getPassword()));
         }
         return passwordFile;


### PR DESCRIPTION
## [JENKINS-63146](https://issues.jenkins-ci.org/browse/JENKINS-63146) Honor credentials.file.encoding property for passphrase file

Not consistent with usage in other locations in the plugin that use the ibm.system.encoding Java property rather than an environment variable.  Setting an environment variable may be a little easier.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes (tested by Randall Becker)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.