### PR TITLE
Reduce a few JUnit 3 tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1821,7 +1821,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             return Files.createTempFile(prefix, suffix).toFile();
         }
         Set<PosixFilePermission> ownerOnly = PosixFilePermissions.fromString("rw-------");
-        FileAttribute fileAttribute = PosixFilePermissions.asFileAttribute(ownerOnly);
+        FileAttribute<Set<PosixFilePermission>> fileAttribute = PosixFilePermissions.asFileAttribute(ownerOnly);
         return Files.createTempFile(prefix, suffix, fileAttribute).toFile();
     }
 
@@ -1887,7 +1887,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             return createTempFileInSystemDir(prefix, suffix);
         }
         Set<PosixFilePermission> ownerOnly = PosixFilePermissions.fromString("rw-------");
-        FileAttribute fileAttribute = PosixFilePermissions.asFileAttribute(ownerOnly);
+        FileAttribute<Set<PosixFilePermission>> fileAttribute = PosixFilePermissions.asFileAttribute(ownerOnly);
         return Files.createTempFile(tmpPath, prefix, suffix, fileAttribute).toFile();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -3570,7 +3570,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
          */
         String[] output = result.split("[\\n\\r]+");
         if (output.length == 0 || (output.length == 1 && output[0].isEmpty())) {
-            return Collections.EMPTY_SET;
+            return Collections.<GitObject>emptySet();
         }
         Pattern pattern = Pattern.compile("(\\p{XDigit}{40})\\s+refs/tags/([^^]+)(\\^\\{\\})?");
         Map<String, ObjectId> tagMap = new HashMap<>();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/jgit/PreemptiveAuthHttpClientConnection.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/jgit/PreemptiveAuthHttpClientConnection.java
@@ -59,7 +59,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.SystemDefaultCredentialsProvider;
@@ -127,7 +126,8 @@ public class PreemptiveAuthHttpClientConnection implements HttpConnection {
 
     private Boolean followRedirects;
 
-    private X509HostnameVerifier hostnameverifier;
+    @Deprecated
+    private org.apache.http.conn.ssl.X509HostnameVerifier hostnameverifier;
 
     SSLContext ctx;
 
@@ -434,7 +434,8 @@ public class PreemptiveAuthHttpClientConnection implements HttpConnection {
         this.hostnameverifier = new X509HostnameVerifierImpl(hostnameverifier);
     }
 
-    private static class X509HostnameVerifierImpl implements X509HostnameVerifier {
+    @Deprecated
+    private static class X509HostnameVerifierImpl implements org.apache.http.conn.ssl.X509HostnameVerifier {
 
         private final HostnameVerifier hostnameverifier;
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -583,25 +583,6 @@ public abstract class GitAPITestCase extends TestCase {
     }
 
     @Deprecated
-    public void test_getRemoteURL_two_args() throws Exception {
-        w.init();
-        String originUrl = "https://github.com/bogus/bogus.git";
-        w.git.setRemoteUrl("origin", originUrl);
-        assertEquals("Wrong remote URL", originUrl, w.git.getRemoteUrl("origin"));
-        assertEquals("Wrong null remote URL", originUrl, w.igit().getRemoteUrl("origin", null));
-        assertEquals("Wrong blank remote URL", originUrl, w.igit().getRemoteUrl("origin", ""));
-        if (w.igit() instanceof CliGitAPIImpl) {
-            String gitDir = w.repoPath() + File.separator + ".git";
-            assertEquals("Wrong repoPath/.git remote URL for " + gitDir, originUrl, w.igit().getRemoteUrl("origin", gitDir));
-            assertEquals("Wrong .git remote URL", originUrl, w.igit().getRemoteUrl("origin", ".git"));
-        } else {
-            assertEquals("Wrong repoPath remote URL", originUrl, w.igit().getRemoteUrl("origin", w.repoPath()));
-        }
-        // Fails on both JGit and CliGit, though with different failure modes in each
-        // assertEquals("Wrong . remote URL", originUrl, w.igit().getRemoteUrl("origin", "."));
-    }
-
-    @Deprecated
     public void test_getDefaultRemote() throws Exception {
         w.init();
         w.launchCommand("git", "remote", "add", "origin", "https://github.com/jenkinsci/git-client-plugin.git");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -545,18 +545,6 @@ public abstract class GitAPITestCase extends TestCase {
         }
     }
 
-    public void test_setCommitter() throws Exception {
-        final String committerName = "Test Commiter";
-        final String committerEmail = "jenkins.plugin@example.com";
-        w.init();
-        w.touch("file1", "Varying content " + java.util.UUID.randomUUID().toString());
-        w.git.add("file1");
-        w.git.setCommitter(committerName, committerEmail);
-        w.git.commit("Committer was set explicitly on this commit");
-        List<String> revision = w.git.showRevision(w.head());
-        assertTrue("Wrong committer in " + revision, revision.get(3).startsWith("committer " + committerName + " <" + committerEmail + "> "));
-    }
-
     public void test_detect_commit_in_repo() throws Exception {
         w.init();
         assertFalse(w.git.isCommitInRepo(null)); // NPE safety check

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -534,12 +534,6 @@ public abstract class GitAPITestCase extends TestCase {
         }
     }
 
-    private void check_remote_url(final String repositoryName) throws InterruptedException, IOException {
-        assertEquals("Wrong remote URL", localMirror(), w.git.getRemoteUrl(repositoryName));
-        String remotes = w.launchCommand("git", "remote", "-v");
-        assertTrue("remote URL has not been updated", remotes.contains(localMirror()));
-    }
-
     private Collection<String> getBranchNames(Collection<Branch> branches) {
         return branches.stream().map(Branch::getName).collect(toList());
     }
@@ -548,13 +542,6 @@ public abstract class GitAPITestCase extends TestCase {
         Collection<String> branchNames = getBranchNames(branches);
         for (String name : names) {
             assertThat(branchNames, hasItem(name));
-        }
-    }
-
-    private void assertBranchesNotExist(Set<Branch> branches, String ... names) throws InterruptedException {
-        Collection<String> branchNames = getBranchNames(branches);
-        for (String name : names) {
-            assertThat(branchNames, not(hasItem(name)));
         }
     }
 
@@ -580,35 +567,6 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.commit("Committer was set explicitly on this commit");
         List<String> revision = w.git.showRevision(w.head());
         assertTrue("Wrong committer in " + revision, revision.get(3).startsWith("committer " + committerName + " <" + committerEmail + "> "));
-    }
-
-    private void assertNoObjectsInRepository() {
-        List<String> objectsDir = new ArrayList<>(Arrays.asList(w.file(".git/objects").list()));
-        objectsDir.remove("info");
-        objectsDir.remove("pack");
-        assertTrue("Objects directory must not contain anything but 'info' and 'pack' folders", objectsDir.isEmpty());
-
-        File packDir = w.file(".git/objects/pack");
-        if (packDir.isDirectory()) {
-            assertEquals("Pack dir must noct contain anything", 0, packDir.list().length);
-        }
-
-    }
-
-    private void assertAlternatesFileNotFound() {
-        final String alternates = ".git" + File.separator + "objects" + File.separator + "info" + File.separator + "alternates";
-        assertFalse("Alternates file found: " + alternates, w.exists(alternates));
-    }
-
-    private void assertAlternateFilePointsToLocalMirror() throws IOException, InterruptedException {
-        final String alternates = ".git" + File.separator + "objects" + File.separator + "info" + File.separator + "alternates";
-
-        assertTrue("Alternates file not found: " + alternates, w.exists(alternates));
-        final String expectedContent = localMirror().replace("\\", "/") + "/objects";
-        final String actualContent = w.contentOf(alternates);
-        assertEquals("Alternates file wrong content", expectedContent, actualContent);
-        final File alternatesDir = new File(actualContent);
-        assertTrue("Alternates destination " + actualContent + " missing", alternatesDir.isDirectory());
     }
 
     public void test_detect_commit_in_repo() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -545,18 +545,6 @@ public abstract class GitAPITestCase extends TestCase {
         }
     }
 
-    public void test_setAuthor() throws Exception {
-        final String authorName = "Test Author";
-        final String authorEmail = "jenkins@example.com";
-        w.init();
-        w.touch("file1", "Varying content " + java.util.UUID.randomUUID().toString());
-        w.git.add("file1");
-        w.git.setAuthor(authorName, authorEmail);
-        w.git.commit("Author was set explicitly on this commit");
-        List<String> revision = w.git.showRevision(w.head());
-        assertTrue("Wrong author in " + revision, revision.get(2).startsWith("author " + authorName + " <" + authorEmail +"> "));
-    }
-
     public void test_setCommitter() throws Exception {
         final String committerName = "Test Commiter";
         final String committerEmail = "jenkins.plugin@example.com";

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -545,18 +545,6 @@ public abstract class GitAPITestCase extends TestCase {
         }
     }
 
-    public void test_detect_commit_in_repo() throws Exception {
-        w.init();
-        assertFalse(w.git.isCommitInRepo(null)); // NPE safety check
-        w.touch("file1");
-        w.git.add("file1");
-        w.git.commit("commit1");
-        assertTrue("HEAD commit not found", w.git.isCommitInRepo(w.head()));
-        // this MAY fail if commit has this exact sha1, but please admit this would be unlucky
-        assertFalse(w.git.isCommitInRepo(ObjectId.fromString("1111111111111111111111111111111111111111")));
-        assertFalse(w.git.isCommitInRepo(null)); // NPE safety check
-    }
-
     @Deprecated
     public void test_lsTree_non_recursive() throws IOException, InterruptedException {
         w.init();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -607,6 +607,9 @@ public class GitClientTest {
     public void testIsCommitInRepo() throws Exception {
         assertTrue(srcGitClient.isCommitInRepo(upstreamCommit));
         assertFalse(gitClient.isCommitInRepo(upstreamCommit));
+        assertFalse(gitClient.isCommitInRepo(null)); // NPE safety check
+        // this MAY fail if commit has this exact sha1, but please admit this would be unlucky
+        assertFalse(gitClient.isCommitInRepo(ObjectId.fromString("1111111111111111111111111111111111111111")));
     }
 
     private void assertExceptionMessageContains(GitException ge, String expectedSubstring) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -816,6 +816,15 @@ public class GitClientTest {
     }
 
     @Test
+    @Deprecated
+    public void testGetRemoteUrl_two_args() throws Exception {
+        IGitAPI iGitAPI = (IGitAPI) gitClient;
+        String originUrl = gitClient.getRemoteUrl("origin");
+        assertThat("Null URL arg", iGitAPI.getRemoteUrl("origin", null), is(originUrl));
+        assertThat("Empty string URL arg", iGitAPI.getRemoteUrl("origin", ""), is(originUrl));
+    }
+
+    @Test
     public void testSetRemoteUrl() throws Exception {
         assertEquals(srcRepoDir.getAbsolutePath(), gitClient.getRemoteUrl("origin"));
         gitClient.setRemoteUrl("origin", upstreamRepoURL);


### PR DESCRIPTION
## Reduce a few JUnit 3 tests

The GitAPITestCase (JUnit 3) needs to be converted to GitClientTest (JUnit 4).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Test