### PR TITLE
[JENKINS-60985] - Fix checkout serialization error

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -224,7 +224,7 @@ public class GitAPI extends CliGitAPIImpl {
 
     /** {@inheritDoc} */
     public void checkout(String ref, String branch) throws GitException, InterruptedException {
-        if (Git.USE_CLI) super.checkout().ref(ref).branch(branch).execute(); else  jgit.checkout().ref(ref).branch(branch).execute();
+        if (Git.USE_CLI) super.checkout(ref, branch); else  jgit.checkout(ref, branch);
     }
 
     /** {@inheritDoc} */
@@ -263,7 +263,7 @@ public class GitAPI extends CliGitAPIImpl {
 
     /** {@inheritDoc} */
     public void checkout(String ref) throws GitException, InterruptedException {
-        if (Git.USE_CLI) super.checkout().ref(ref).execute(); else  jgit.checkout().ref(ref).execute();
+        if (Git.USE_CLI) super.checkout(ref); else  jgit.checkout(ref);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -27,6 +27,7 @@ import java.util.Set;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  * @deprecated
  */
+@Deprecated
 public class GitAPI extends CliGitAPIImpl {
     private static final long serialVersionUID = 1L;
     private final GitClient jgit;

--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -290,7 +290,7 @@ public class GitAPI extends CliGitAPIImpl {
 
     /** {@inheritDoc} */
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
-        if (Git.USE_CLI) super.fetch_().from(url, refspecs).execute(); else  jgit.fetch_().from(url, refspecs).execute();
+        if (Git.USE_CLI) super.fetch(url, refspecs); else  jgit.fetch(url, refspecs);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -167,14 +167,14 @@ public class GitAPI extends CliGitAPIImpl {
     */
 
     /*
-    public void submoduleUpdate(boolean recursive) throws GitException, InterruptedException {
-        if (Git.USE_CLI) super.submoduleUpdate().recursive(recursive).execute(); else  jgit.submoduleUpdate().recursive(recursive).execute();
+    public void submoduleUpdate(boolean recursive) throws GitException {
+        if (Git.USE_CLI) super.submoduleUpdate(recursive); else  jgit.submoduleUpdate(recursive);
     }
     */
 
     /*
-    public void submoduleUpdate(boolean recursive, String reference) throws GitException, InterruptedException {
-        if (Git.USE_CLI) super.submoduleUpdate().recursive(recursive).ref(reference).execute(); else  jgit.submoduleUpdate().recursive(recursive).ref(reference).execute();
+    public void submoduleUpdate(boolean recursive, String reference) throws GitException {
+        if (Git.USE_CLI) super.submoduleUpdate(recursive, String reference); else  jgit.submoduleUpdate(recursive, String reference);
     }
     */
 

--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -223,7 +223,9 @@ public class GitAPI extends CliGitAPIImpl {
     }
 
     /** {@inheritDoc} */
+    @SuppressWarnings("deprecation")
     public void checkout(String ref, String branch) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         if (Git.USE_CLI) super.checkout(ref, branch); else  jgit.checkout(ref, branch);
     }
 
@@ -262,7 +264,9 @@ public class GitAPI extends CliGitAPIImpl {
     }
 
     /** {@inheritDoc} */
+    @SuppressWarnings("deprecation")
     public void checkout(String ref) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         if (Git.USE_CLI) super.checkout(ref); else  jgit.checkout(ref);
     }
 
@@ -289,7 +293,9 @@ public class GitAPI extends CliGitAPIImpl {
     */
 
     /** {@inheritDoc} */
+    @SuppressWarnings("deprecation")
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         if (Git.USE_CLI) super.fetch(url, refspecs); else  jgit.fetch(url, refspecs);
     }
 

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -216,6 +216,7 @@ public interface IGitAPI extends GitClient {
      *             instead. This method does work only with local branches on
      *             one implementation and with all the branches - in the other
      */
+    @Deprecated
     List<Branch> getBranchesContaining(String revspec) throws GitException, InterruptedException;
 
     /**
@@ -230,6 +231,7 @@ public interface IGitAPI extends GitClient {
      * @deprecated
      *  Use {@link #lsTree(String, boolean)} to be explicit about the recursion behaviour.
      */
+    @Deprecated
     List<IndexEntry> lsTree(String treeIsh) throws GitException, InterruptedException;
 
     /**
@@ -300,5 +302,6 @@ public interface IGitAPI extends GitClient {
      * @throws java.lang.InterruptedException if interrupted.
      */
     @Restricted(NoExternalUse.class)
+    @Deprecated
     String getAllLogEntries(String branch) throws InterruptedException;
 }

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -16,6 +16,7 @@ import java.util.List;
  *
  * @deprecated methods here are deprecated until proven useful by a plugin
  */
+@Deprecated
 public interface IGitAPI extends GitClient {
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -120,6 +120,7 @@ public interface GitClient {
      * @return a {@link org.eclipse.jgit.lib.Repository} object.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      */
+    @Deprecated
     Repository getRepository() throws GitException;
 
     /**
@@ -178,6 +179,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void commit(String message, PersonIdent author, PersonIdent committer) throws GitException, InterruptedException;
 
     /**
@@ -238,6 +240,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void checkout(String ref) throws GitException, InterruptedException;
 
     /**
@@ -252,6 +255,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void checkout(String ref, String branch) throws GitException, InterruptedException;
 
     /**
@@ -322,6 +326,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException;
 
     /**
@@ -333,6 +338,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void fetch(String remoteName, RefSpec... refspec) throws GitException, InterruptedException;
 
     /**
@@ -344,6 +350,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void fetch(String remoteName, RefSpec refspec) throws GitException, InterruptedException;
 
     /**
@@ -362,6 +369,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void push(String remoteName, String refspec) throws GitException, InterruptedException;
 
     /**
@@ -373,6 +381,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void push(URIish url, String refspec) throws GitException, InterruptedException;
 
     /**
@@ -391,6 +400,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void merge(ObjectId rev) throws GitException, InterruptedException;
 
     /**
@@ -729,6 +739,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void submoduleUpdate(boolean recursive)  throws GitException, InterruptedException;
 
     /**
@@ -742,6 +753,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void submoduleUpdate(boolean recursive, String reference) throws GitException, InterruptedException;
 
     /**
@@ -754,6 +766,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void submoduleUpdate(boolean recursive, boolean remoteTracking)  throws GitException, InterruptedException;
     /**
      * Run submodule update optionally recursively on all submodules, optionally with remoteTracking, with a specific
@@ -767,6 +780,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void submoduleUpdate(boolean recursive, boolean remoteTracking, String reference)  throws GitException, InterruptedException;
 
     /**
@@ -817,6 +831,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
+    @Deprecated
     void changelog(String revFrom, String revTo, OutputStream os) throws GitException, InterruptedException;
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2254,7 +2254,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     update.call();
                     if (recursive) {
                         for (JGitAPIImpl sub : submodules()) {
-                            sub.submoduleUpdate().recursive(recursive).execute();
+                            sub.submoduleUpdate(recursive);
                         }
                     }
                 } catch (IOException | GitAPIException e) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2254,6 +2254,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     update.call();
                     if (recursive) {
                         for (JGitAPIImpl sub : submodules()) {
+                            /* Intentionally using the deprecated method because the replacement method is not serializable. */
                             sub.submoduleUpdate(recursive);
                         }
                     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -626,7 +626,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
 
     /** {@inheritDoc} */
     public void submoduleUpdate(boolean recursive) throws GitException, InterruptedException {
-        proxy.submoduleUpdate().recursive(recursive).execute();
+        proxy.submoduleUpdate(recursive);
     }
 
     /**
@@ -638,17 +638,17 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws java.lang.InterruptedException if any.
      */
     public void submoduleUpdate(boolean recursive, String ref) throws GitException, InterruptedException {
-        proxy.submoduleUpdate().recursive(recursive).ref(ref).execute();
+        proxy.submoduleUpdate(recursive, ref);
     }
 
     /** {@inheritDoc} */
     public void submoduleUpdate(boolean recursive, boolean remoteTracking) throws GitException, InterruptedException {
-        proxy.submoduleUpdate().recursive(recursive).remoteTracking(remoteTracking).execute();
+        proxy.submoduleUpdate(recursive, remoteTracking);
     }
 
     /** {@inheritDoc} */
     public void submoduleUpdate(boolean recursive, boolean remoteTracking, String reference) throws GitException, InterruptedException {
-        proxy.submoduleUpdate().recursive(recursive).remoteTracking(remoteTracking).ref(reference).execute();
+        proxy.submoduleUpdate(recursive, remoteTracking, reference);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -411,7 +411,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws java.lang.InterruptedException if any.
      */
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
-        proxy.fetch_().from(url, refspecs).execute();
+        proxy.fetch(url, refspecs);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -306,11 +306,13 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
 
     /** {@inheritDoc} */
     public void checkout(String ref) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         proxy.checkout(ref);
     }
 
     /** {@inheritDoc} */
     public void checkout(String ref, String branch) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         proxy.checkout(ref, branch);
     }
 
@@ -411,6 +413,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws java.lang.InterruptedException if any.
      */
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         proxy.fetch(url, refspecs);
     }
 
@@ -436,6 +439,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
 
     /** {@inheritDoc} */
     public void merge(ObjectId rev) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         proxy.merge(rev);
     }
 
@@ -626,6 +630,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
 
     /** {@inheritDoc} */
     public void submoduleUpdate(boolean recursive) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         proxy.submoduleUpdate(recursive);
     }
 
@@ -638,16 +643,19 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
      * @throws java.lang.InterruptedException if any.
      */
     public void submoduleUpdate(boolean recursive, String ref) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         proxy.submoduleUpdate(recursive, ref);
     }
 
     /** {@inheritDoc} */
     public void submoduleUpdate(boolean recursive, boolean remoteTracking) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         proxy.submoduleUpdate(recursive, remoteTracking);
     }
 
     /** {@inheritDoc} */
     public void submoduleUpdate(boolean recursive, boolean remoteTracking, String reference) throws GitException, InterruptedException {
+        /* Intentionally using the deprecated method because the replacement method is not serializable. */
         proxy.submoduleUpdate(recursive, remoteTracking, reference);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -306,12 +306,12 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
 
     /** {@inheritDoc} */
     public void checkout(String ref) throws GitException, InterruptedException {
-        proxy.checkout().ref(ref).execute();
+        proxy.checkout(ref);
     }
 
     /** {@inheritDoc} */
     public void checkout(String ref, String branch) throws GitException, InterruptedException {
-        proxy.checkout().ref(ref).branch(branch).execute();
+        proxy.checkout(ref, branch);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -436,7 +436,7 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
 
     /** {@inheritDoc} */
     public void merge(ObjectId rev) throws GitException, InterruptedException {
-        proxy.merge().setRevisionToMerge(rev).execute();
+        proxy.merge(rev);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -11,7 +11,6 @@ import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitObject;
-import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.Tag;
@@ -44,7 +43,8 @@ import java.util.Set;
  *
  * @author Kohsuke Kawaguchi
  */
-class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
+@SuppressWarnings("deprecation") // Suppressing deprecation warnings intentionally
+class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializable {
     private final GitClient proxy;
     private transient Channel channel;
 
@@ -52,8 +52,8 @@ class RemoteGitImpl implements GitClient, IGitAPI, Serializable {
         this.proxy = proxy;
     }
 
-    private IGitAPI getGitAPI() {
-        return (IGitAPI)proxy;
+    private hudson.plugins.git.IGitAPI getGitAPI() {
+        return (hudson.plugins.git.IGitAPI)proxy;
     }
 
     private Object readResolve() {


### PR DESCRIPTION
## [JENKINS-60985](https://issues.jenkins-ci.org/browse/JENKINS-60985) Fix checkout serialization error

The previous call to checkout was entirely inside the CliGitAPIImpl and JGitAPIImpl classes.  The replacement used a CheckoutCommand that is not serializable.  This change reverts the replacement.  Issue has been in the git client plugin since git client plugin 3.1.0.

The change development process visited each of the changes in git-client-plugin#399 and retained the changes from that PR which are safe from serialization issues.

Would appreciate review by @dwnusbaum and @fcojfernandez so that we can deliver a new version to fix the issue.

Would love to have suggestions or pointers to ways that this could be tested in the git client plugin test automation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)