### PR TITLE
[JENKINS-62587] Log git version value for easier debug

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -249,6 +249,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         String version = "";
         try {
             version = launchCommand("--version").trim();
+            listener.getLogger().println(" > git --version # '" + version + "'");
         } catch (Throwable e) {
         }
 


### PR DESCRIPTION
## [JENKINS-62587](https://issues.jenkins-ci.org/browse/JENKINS-62587) - Log git version value for easier debug

Preparation for an eventual warning that should be added to tell users
they are running an outdated version of command line git.  Command line
git versions prior to 2.7 are lacking important features that the
git plugin could use and we'd like to eventually be able to use those
features.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)