### PR TITLE
Add a new command: UnsupportedCommand to communicate compatibility of JGit

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
@@ -1,0 +1,110 @@
+package org.jenkinsci.plugins.gitclient;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A command to convey unsupported features (Currently, implemented for JGit)
+ *
+ * All of the operations listed below are not implemented in JGit currently.
+ */
+public class UnsupportedCommand {
+
+    private boolean useJGit = true;
+
+    // From CheckoutCommand
+    public UnsupportedCommand sparseCheckoutPaths(List<String> sparseCheckoutPaths) {
+        List<String> sparseList = sparseCheckoutPaths == null ? Collections.<String>emptyList() : sparseCheckoutPaths;
+        if (!sparseList.isEmpty()) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    public UnsupportedCommand timeout(Integer timeout) {
+        if (timeout != null) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    public UnsupportedCommand lfsRemote(String lfsRemote) {
+        if (lfsRemote != null) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    public UnsupportedCommand lfsCredentials(StandardCredentials lfsCredentials) {
+        if (lfsCredentials != null) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    // From CloneCommand
+    public UnsupportedCommand shallow(boolean shallow) {
+        if (shallow) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    public UnsupportedCommand depth(Integer depth) {
+        if (depth != null) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    // From RevListCommand
+    public UnsupportedCommand firstParent(boolean firstParent) {
+        if (firstParent) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    // From SubmoduleUpdateCommand
+    public UnsupportedCommand threads(int threads) {
+        if (threads != 0) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    public UnsupportedCommand remoteTracking(boolean remoteTracking) {
+        if (remoteTracking) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    public UnsupportedCommand ref(String ref) {
+        if (ref != null && !ref.isEmpty()) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    public UnsupportedCommand parentCredentials(boolean parentCredentials) {
+        if (parentCredentials) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    public UnsupportedCommand useBranch(String submodule, String branchname) {
+        if (submodule != null || branchname != null) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    public boolean determineSupportForJGit() {
+        return useJGit;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A command to convey unsupported features (Currently, implemented for JGit)
+ * A command to convey unsupported features. Currently, implemented for JGit.
  *
  * All of the operations listed below are not implemented in JGit currently.
  */
@@ -15,6 +15,12 @@ public class UnsupportedCommand {
     private boolean useJGit = true;
 
     // From CheckoutCommand
+    /**
+     * JGit is unsupported if sparseCheckoutPaths is non-empty.
+     *
+     * @param sparseCheckoutPaths list of paths to be included in the checkout
+     * @return this for chaining
+     */
     public UnsupportedCommand sparseCheckoutPaths(List<String> sparseCheckoutPaths) {
         List<String> sparseList = sparseCheckoutPaths == null ? Collections.<String>emptyList() : sparseCheckoutPaths;
         if (!sparseList.isEmpty()) {
@@ -23,6 +29,13 @@ public class UnsupportedCommand {
         return this;
     }
 
+    /**
+     * JGit is unsupported if timeout is non-null. Could be supported if timeout
+     * is 0, since that means no timeout.
+     *
+     * @param timeout maximum time git operation is allowed before it is interrupted
+     * @return this for chaining
+     */
     public UnsupportedCommand timeout(Integer timeout) {
         if (timeout != null) {
             useJGit = false;
@@ -30,6 +43,12 @@ public class UnsupportedCommand {
         return this;
     }
 
+    /**
+     * JGit is unsupported if lfsRemote is non-null.
+     *
+     * @param lfsRemote URL of large file support server
+     * @return this for chaining
+     */
     public UnsupportedCommand lfsRemote(String lfsRemote) {
         if (lfsRemote != null) {
             useJGit = false;
@@ -37,6 +56,12 @@ public class UnsupportedCommand {
         return this;
     }
 
+    /**
+     * JGit is unsupported if lfsCredentials is non-null.
+     *
+     * @param lfsCredentials credential used for large file support
+     * @return this for chaining
+     */
     public UnsupportedCommand lfsCredentials(StandardCredentials lfsCredentials) {
         if (lfsCredentials != null) {
             useJGit = false;
@@ -45,6 +70,12 @@ public class UnsupportedCommand {
     }
 
     // From CloneCommand
+    /**
+     * JGit is unsupported if shallow is true.
+     *
+     * @param shallow if true then shallow clone and fetch are enabled
+     * @return this for chaining
+     */
     public UnsupportedCommand shallow(boolean shallow) {
         if (shallow) {
             useJGit = false;
@@ -52,6 +83,13 @@ public class UnsupportedCommand {
         return this;
     }
 
+    /**
+     * JGit is unsupported if depth is non-null. Could also be supported if
+     * depth is 0, since that means unlimited depth.
+     *
+     * @param depth depth of commits to be fetched into workspace
+     * @return this for chaining
+     */
     public UnsupportedCommand depth(Integer depth) {
         if (depth != null) {
             useJGit = false;
@@ -60,6 +98,12 @@ public class UnsupportedCommand {
     }
 
     // From RevListCommand
+    /**
+     * JGit is unsupported if firstParent is true.
+     *
+     * @param firstParent if true, only consider the first parents of a merge in revision list
+     * @return this for chaining
+     */
     public UnsupportedCommand firstParent(boolean firstParent) {
         if (firstParent) {
             useJGit = false;
@@ -68,6 +112,12 @@ public class UnsupportedCommand {
     }
 
     // From SubmoduleUpdateCommand
+    /**
+     * JGit is unsupported if threads is non-zero.
+     *
+     * @param threads count of threads to use for parallel submodule update
+     * @return this for chaining
+     */
     public UnsupportedCommand threads(int threads) {
         if (threads != 0) {
             useJGit = false;
@@ -75,6 +125,12 @@ public class UnsupportedCommand {
         return this;
     }
 
+    /**
+     * JGit is unsupported if remoteTracking is true.
+     *
+     * @param remoteTracking submodule should use a remote tracking branch if true
+     * @return this for chaining
+     */
     public UnsupportedCommand remoteTracking(boolean remoteTracking) {
         if (remoteTracking) {
             useJGit = false;
@@ -82,6 +138,12 @@ public class UnsupportedCommand {
         return this;
     }
 
+    /**
+     * JGit is unsupported if ref is non-empty.
+     *
+     * @param ref location of submodule reference repository
+     * @return this for chaining
+     */
     public UnsupportedCommand ref(String ref) {
         if (ref != null && !ref.isEmpty()) {
             useJGit = false;
@@ -89,6 +151,12 @@ public class UnsupportedCommand {
         return this;
     }
 
+    /**
+     * JGit is unsupported if parentCredentials is true.
+     *
+     * @param parentCredentials submodule update uses credentials from parent repository if true
+     * @return this for chaining
+     */
     public UnsupportedCommand parentCredentials(boolean parentCredentials) {
         if (parentCredentials) {
             useJGit = false;
@@ -96,6 +164,13 @@ public class UnsupportedCommand {
         return this;
     }
 
+    /**
+     * JGit is unsupported if submodule or branchName are non-null.
+     *
+     * @param submodule name of submodule that should checkout a specific branch
+     * @param branchname name of branch to be checked out for submodule
+     * @return this for chaining
+     */
     public UnsupportedCommand useBranch(String submodule, String branchname) {
         if (submodule != null || branchname != null) {
             useJGit = false;
@@ -103,8 +178,12 @@ public class UnsupportedCommand {
         return this;
     }
 
+    /**
+     * Returns true if JGit is supported based on previously passed values.
+     *
+     * @return true if JGit is supported based on previously passed values
+     */
     public boolean determineSupportForJGit() {
         return useJGit;
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/UnsupportedCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/UnsupportedCommandTest.java
@@ -1,0 +1,252 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 Mark Waite.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.gitclient;
+
+import com.cloudbees.plugins.credentials.CredentialsDescriptor;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class UnsupportedCommandTest {
+
+    private final UnsupportedCommand unsupportedCommand;
+
+    public UnsupportedCommandTest() {
+        unsupportedCommand = new UnsupportedCommand();
+    }
+
+    @Test
+    public void testSparseCheckoutPathsNull() {
+        unsupportedCommand.sparseCheckoutPaths(null);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testSparseCheckoutPathsEmptyList() {
+        List<String> emptyList = new ArrayList<>();
+        unsupportedCommand.sparseCheckoutPaths(emptyList);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testSparseCheckoutPaths() {
+        List<String> sparseList = new ArrayList<>();
+        sparseList.add("a-file-for-sparse-checkout");
+        unsupportedCommand.sparseCheckoutPaths(sparseList);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testTimeoutNull() {
+        unsupportedCommand.timeout(null);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testTimeout() {
+        Integer five = 5;
+        unsupportedCommand.timeout(five);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testLfsRemoteNull() {
+        unsupportedCommand.lfsRemote(null);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testLfsRemote() {
+        unsupportedCommand.lfsRemote("https://github.com/MarkEWaite/docker-lfs");
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testLfsCredentialsNull() {
+        unsupportedCommand.lfsCredentials(null);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testLfsCredentials() {
+        FakeCredentials credentials = new FakeCredentials();
+        unsupportedCommand.lfsCredentials(credentials);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testNotShallow() {
+        unsupportedCommand.shallow(false);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testShallow() {
+        unsupportedCommand.shallow(true);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testDepthNull() {
+        unsupportedCommand.depth(null);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testDepthNegative() {
+        unsupportedCommand.depth(-1); // Surprising, but acceptable
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testDepth() {
+        unsupportedCommand.depth(1);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testNotFirstParent() {
+        unsupportedCommand.firstParent(false);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testFirstParent() {
+        unsupportedCommand.firstParent(true);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testThreadsZero() {
+        unsupportedCommand.threads(0);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testThreads() {
+        unsupportedCommand.threads(42);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testNotRemoteTracking() {
+        unsupportedCommand.remoteTracking(false);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testRemoteTracking() {
+        unsupportedCommand.remoteTracking(true);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testRefNull() {
+        unsupportedCommand.ref(null);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testRefEmpty() {
+        unsupportedCommand.ref("");
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testRef() {
+        unsupportedCommand.ref("beadeddeededcededadded");
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testNotParentCredentials() {
+        unsupportedCommand.parentCredentials(false);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testParentCredentials() {
+        unsupportedCommand.remoteTracking(true);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testUseBranchNull() {
+        unsupportedCommand.useBranch(null, null);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testUseBranchNullBranchName() {
+        unsupportedCommand.useBranch("some-submodule", null);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testUseBranchNullSubmodule() {
+        unsupportedCommand.useBranch(null, "some-branch");
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testUseBranch() {
+        unsupportedCommand.useBranch("some-submodule", "some-branch");
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testDetermineSupportForJGit() {
+        /* Confirm default is true */
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    private static class FakeCredentials implements StandardCredentials {
+
+        public FakeCredentials() {
+        }
+
+        @Override
+        public String getDescription() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        @Override
+        public String getId() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        @Override
+        public CredentialsScope getScope() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        @Override
+        public CredentialsDescriptor getDescriptor() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+    }
+}


### PR DESCRIPTION
This command serves as a way to communicate to the git plugin which git features
are not supported by JGit.

- The reason for not implementing it as a GitCommand implementation is to separate
the need of a `JGitAPIImpl` or `CliGitAPIImpl` to check if a certain additional behaviour
of git is supported or not.
- This class can be instantiated with no need of any information, it can be decorated by a
GitSCMExtension to fill in the features which are not supported.

## How to use it in the Git Plugin? 

- Step 1: Define a function within the GitSCMExtension to be implemented by extensions which are not supported by JGit.
ex: ```public void determineSupportForJGit(GitSCM scm, UnsupportedCommand unsupportedCommand) {
    }```
- Step 2: Let's take GitLFSPull as an example, implement a function called: 
```@Override
    public void determineSupportForJGit(GitSCM scm, UnsupportedCommand cmd) {
        List<RemoteConfig> repos = scm.getRepositories();
        cmd.lfsRemote(repos.get(0).getName()); 
}
```
- Step 3: Use the collected information to determine if JGit can be supported or not using the UnsupportedCommand only.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

