### PR TITLE
[JENKINS-63307] Allow zOS encoding of user name, password, and passphrase

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -98,13 +98,6 @@ When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.checkRemoteURL` is set to `f
 +
 Default is `true` so that repository URL's are rejected if they start with `-` or contain space characters.
 
-credentials.file.encoding::
-When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.credentials.file.encoding` is set to a non-empty value (like `IBM-1047`) and the agent is running on IBM zOS, the ssh passphrase file is written using that character set.
-The character sets of other credential files are not changed.
-The character sets on other operating systems are not changed.
-+
-Default is empty so that zOS file encoding behaves as it did previously.
-
 forceFetch::
 When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.forceFetch` is set to `false` it allows command line git versions 2.20 and later to not update tags which have already been fetched into the workspace.
 +
@@ -113,13 +106,6 @@ Command line git before 2.20 silently updates an existing tag if the remote tag 
 Command line git 2.20 and later do not update an existing tag if the remote tag points to a different SHA1 than the local tag unless the `--force` option is passed to `git fetch`.
 +
 Default is `true` so that newer command line git versions behave the same as older versions.
-
-password.file.encoding::
-When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.password.file.encoding` is set to a non-empty value (like `IBM-1047`) and the agent is running on IBM zOS, the password file is written using that character set.
-The character sets of other credential files are not changed.
-The character sets on other operating systems are not changed.
-+
-Default is empty so that zOS file encoding behaves as it did previously.
 
 promptForAuthentication::
 When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.promptForAuthentication` is set to `true` it allows command line git versions 2.3 and later to prompt the user for authentication.
@@ -134,6 +120,27 @@ useCLI::
 When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.useCLI` is set to `false`, it will use JGit as the default implementation instead of command line git.
 +
 Default is `true` so that command line git is chosen as the default implementation.
+
+user.name.file.encoding::
+When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.user.name.file.encoding` is set to a non-empty value (like `IBM-1047`) and the agent is running on IBM zOS, the username credentials file is written using that character set.
+The character sets of other credential files are not changed.
+The character sets on other operating systems are not changed.
++
+Default is empty so that zOS file encoding behaves as it did previously.
+
+user.passphrase.file.encoding::
+When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.user.passphrase.file.encoding` is set to a non-empty value (like `IBM-1047`) and the agent is running on IBM zOS, the ssh passphrase file is written using that character set.
+The character sets of other credential files are not changed.
+The character sets on other operating systems are not changed.
++
+Default is empty so that zOS file encoding behaves as it did previously.
+
+user.password.file.encoding::
+When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.user.password.file.encoding` is set to a non-empty value (like `IBM-1047`) and the agent is running on IBM zOS, the password file is written using that character set.
+The character sets of other credential files are not changed.
+The character sets on other operating systems are not changed.
++
+Default is empty so that zOS file encoding behaves as it did previously.
 
 useSETSID::
 When `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.useSETSID` is set to `true` and the `setsid` command is available, the git client process on non-Windows computers will be started with the `setsid` command so that they are detached from any controlling terminal.


### PR DESCRIPTION
## [JENKINS-63307](https://issues.jenkins-ci.org/browse/JENKINS-63307) Allow zOS encoding of user name, password, and passphrase

Changes the character set definition properties.  Properties are now:

* `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.user.name.file.encoding`
* `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.user.passphrase.file.encoding`
* `org.jenkinsci.plugins.gitclient.CliGitAPIImpl.user.password.file.encoding`

Keeps the documentation simpler and the code simpler.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)