### PR TITLE
[JENKINS-63307] Honor property value in zOS credential files

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2195,7 +2195,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     private String computeCredentialFileCharset(String context, String defaultValue) {
         String property = CliGitAPIImpl.class.getName() + ".user." + context + ".file.encoding";
         if (isZos() && System.getProperty(property) != null) {
-            String charset = Charset.forName(property).toString();
+            String charset = Charset.forName(System.getProperty(property)).toString();
 	    listener.getLogger().println("Using " + context + " charset '" + charset + "'");
             return charset;
         }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -27,7 +27,6 @@ public class CliGitAPIImplTest extends GitAPITestCase {
     private void setCliGitDefaults() throws Exception {
         if (!cliGitDefaultsSet) {
             CliGitCommand gitCmd = new CliGitCommand(null);
-            gitCmd.setDefaults();
         }
         cliGitDefaultsSet = true;
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitCommand.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitCommand.java
@@ -86,30 +86,4 @@ class CliGitCommand {
         args.add(arguments);
         return run(false);
     }
-
-    private void setConfigIfEmpty(String configName, String value) throws Exception {
-        String[] cmdOutput = runWithoutAssert("config", configName);
-        if (cmdOutput == null || cmdOutput[0].isEmpty() || cmdOutput[0].equals("[]")) {
-            /* Set config value globally */
-            run("config", "--global", configName, value);
-            /* Read config value */
-            cmdOutput = run("config", configName);
-            if (cmdOutput == null || cmdOutput[0].isEmpty() || !cmdOutput[0].equals(value)) {
-                System.out.println("ERROR: git config " + configName + " reported '" + cmdOutput[0] + "' instead of '" + value + "'");
-            }
-        }
-    }
-
-    /**
-     * Set git config values for user.name and user.email if they are not
-     * already set. Many tests assume that "git commit" can be called without
-     * failure, but a newly installed user account does not necessarily have
-     * values assigned for user.name and user.email. This method checks the
-     * existing values, and if they are not set, assigns default values.
-     * If the values are already set, they are unchanged.
-     */
-    void setDefaults() throws Exception {
-        setConfigIfEmpty("user.name", "Vojtěch-Zweibrücken-Šafařík");
-        setConfigIfEmpty("user.email", "email.address.from.git.client.plugin.test@example.com");
-    }
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -237,8 +237,13 @@ public abstract class GitAPITestCase extends TestCase {
 
         WorkingArea init() throws IOException, InterruptedException {
             git.init();
-            git.setAuthor("root", "root@mydomain.com");
-            git.setCommitter("root", "root@domain.com");
+            String userName = "root";
+            String emailAddress = "root@mydomain.com";
+            CliGitCommand gitCmd = new CliGitCommand(git);
+            gitCmd.run("config", "user.name", userName);
+            gitCmd.run("config", "user.email", emailAddress);
+            git.setAuthor(userName, emailAddress);
+            git.setCommitter(userName, emailAddress);
             return this;
         }
 
@@ -339,7 +344,10 @@ public abstract class GitAPITestCase extends TestCase {
     protected WorkingArea clone(String src) throws Exception {
         WorkingArea x = new WorkingArea();
         x.launchCommand("git", "clone", src, x.repoPath());
-        return new WorkingArea(x.repo);
+        WorkingArea clonedArea = new WorkingArea(x.repo);
+        clonedArea.launchCommand("git", "config", "user.name", "Vojtěch Zweibrücken-Šafařík");
+        clonedArea.launchCommand("git", "config", "user.email", "email.address.from.git.client.plugin.test@example.com");
+        return clonedArea;
     }
 
     private boolean timeoutVisibleInCurrentTest;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -94,13 +94,15 @@ public class GitClientFetchTest {
         testGitClient = workspace.getGitClient();
         testGitDir = workspace.getGitFileDir();
         cliGitCommand = workspace.getCliGitCommand();
+        testGitClient.init();
+        cliGitCommand.run("config", "user.name", "Vojtěch GitClientFetchTest Zweibrücken-Šafařík");
+        cliGitCommand.run("config", "user.email", "email.by.git.client.test@example.com");
     }
 
     /* Workspace -> original repo, bareWorkspace -> bare repo and newAreaWorkspace -> newArea repo */
     @Test
     public void test_fetch() throws Exception {
         /* Create a working repo containing a commit */
-        testGitClient.init();
         workspace.touch(testGitDir, "file1", "file1 content " + UUID.randomUUID().toString());
         testGitClient.add("file1");
         testGitClient.commit("commit1");
@@ -231,7 +233,6 @@ public class GitClientFetchTest {
     @Issue("JENKINS-19591")
     public void test_fetch_needs_preceding_prune() throws Exception {
         /* Create a working repo containing a commit */
-        testGitClient.init();
         workspace.touch(testGitDir, "file1", "file1 content " + UUID.randomUUID().toString());
         testGitClient.add("file1");
         testGitClient.commit("commit1");
@@ -332,8 +333,6 @@ public class GitClientFetchTest {
 
     @Test
     public void test_prune_without_remote() throws Exception {
-        /* Create an empty working repo */
-        testGitClient.init();
         /* Prune when a remote is not yet defined */
         String expectedMessage = testGitClient instanceof CliGitAPIImpl ? "returned status code 1" : "The uri was empty or null";
         GitException gitException = assertThrows(GitException.class, () -> {
@@ -357,7 +356,6 @@ public class GitClientFetchTest {
         /* Create a working repo containing three branches */
         /* master -> branch1 */
         /*        -> branch2 */
-        testGitClient.init();
         testGitClient.setRemoteUrl("origin", bareWorkspace.getGitFileDir().getAbsolutePath());
         workspace.touch(testGitDir, "file-master", "file master content " + UUID.randomUUID().toString());
         testGitClient.add("file-master");
@@ -418,10 +416,11 @@ public class GitClientFetchTest {
     public void test_fetch_from_url() throws Exception {
         newAreaWorkspace = new WorkspaceWithRepo(thirdRepo.getRoot(), gitImplName, TaskListener.NULL);
         newAreaWorkspace.getGitClient().init();
+        newAreaWorkspace.launchCommand("git", "config", "user.name", "Vojtěch fetch from URL Zweibrücken-Šafařík");
+        newAreaWorkspace.launchCommand("git", "config", "user.email", "email.by.git.fetch.test@example.com");
         newAreaWorkspace.launchCommand("git", "commit", "--allow-empty", "-m", "init");
         String sha1 = newAreaWorkspace.launchCommand("git", "rev-list", "--no-walk", "--max-count=1", "HEAD");
 
-        testGitClient.init();
         cliGitCommand.run("remote", "add", "origin", newAreaWorkspace.getGitFileDir().getAbsolutePath());
         testGitClient.fetch(new URIish(newAreaWorkspace.getGitFileDir().toString()), Collections.<RefSpec>emptyList());
         assertThat(sha1.contains(newAreaWorkspace.launchCommand("git", "rev-list", "--no-walk", "--max-count=1", "HEAD")), is(true));
@@ -429,7 +428,6 @@ public class GitClientFetchTest {
 
     @Test
     public void test_fetch_shallow() throws Exception {
-        testGitClient.init();
         testGitClient.setRemoteUrl("origin", workspace.localMirror());
         testGitClient.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).shallow(true).execute();
         check_remote_url(workspace, workspace.getGitClient(), "origin");
@@ -444,7 +442,6 @@ public class GitClientFetchTest {
 
     @Test
     public void test_fetch_shallow_depth() throws Exception {
-        testGitClient.init();
         testGitClient.setRemoteUrl("origin", workspace.localMirror());
         testGitClient.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).shallow(true).depth(2).execute();
         check_remote_url(workspace, workspace.getGitClient(), "origin");
@@ -459,7 +456,6 @@ public class GitClientFetchTest {
 
     @Test
     public void test_fetch_noTags() throws Exception {
-        testGitClient.init();
         testGitClient.setRemoteUrl("origin", workspace.localMirror());
         testGitClient.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).tags(false).execute();
         check_remote_url(workspace, workspace.getGitClient(), "origin");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSampleRepoRule.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSampleRepoRule.java
@@ -43,25 +43,15 @@ import org.jvnet.hudson.test.JenkinsRule;
  */
 public final class GitClientSampleRepoRule extends AbstractSampleDVCSRepoRule {
 
-    private static boolean initialized = false;
-
     private static final Logger LOGGER = Logger.getLogger(GitClientSampleRepoRule.class.getName());
 
     public void git(String... cmds) throws Exception {
         run("git", cmds);
     }
 
-    private static void checkGlobalConfig() throws Exception {
-        if (initialized) return;
-        initialized = true;
-        CliGitCommand gitCmd = new CliGitCommand(null);
-        gitCmd.setDefaults();
-    }
-
     @Override
     public void init() throws Exception {
         run(true, tmp.getRoot(), "git", "version");
-        checkGlobalConfig();
         git("init");
         write("file", "");
         git("add", "file");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
@@ -165,13 +165,6 @@ public class GitClientSecurityTest {
         return arguments.subList(0, 25);
     }
 
-    @BeforeClass
-    public static void setCliGitDefaults() throws Exception {
-        /* Command line git commands fail unless certain default values are set */
-        CliGitCommand gitCmd = new CliGitCommand(null);
-        gitCmd.setDefaults();
-    }
-
     @AfterClass
     public static void resetRemoteCheckUrl() {
         org.jenkinsci.plugins.gitclient.CliGitAPIImpl.CHECK_REMOTE_URL = true;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -169,13 +169,6 @@ public class GitClientTest {
         return arguments;
     }
 
-    @BeforeClass
-    public static void setCliGitDefaults() throws Exception {
-        /* Command line git commands fail unless certain default values are set */
-        CliGitCommand gitCmd = new CliGitCommand(null);
-        gitCmd.setDefaults();
-    }
-
     /**
      * Mirror the git-client-plugin repo so that the tests have a reasonable and
      * repeatable set of commits, tags, and branches.
@@ -224,6 +217,9 @@ public class GitClientTest {
         gitClient.init_().workspace(repoRoot.getAbsolutePath()).execute();
         assertTrue("Missing " + gitDir, gitDir.isDirectory());
         gitClient.setRemoteUrl("origin", srcRepoDir.getAbsolutePath());
+        CliGitCommand gitCmd = new CliGitCommand(gitClient);
+        gitCmd.run("config", "user.name", "Vojtěch GitClientTest Zweibrücken-Šafařík");
+        gitCmd.run("config", "user.email", "email.from.git.client@example.com");
     }
 
     private static final String COMMITTED_ONE_TEXT_FILE = "Committed one text file";
@@ -843,6 +839,9 @@ public class GitClientTest {
         File repoRootTemp = tempFolder.newFolder();
         GitClient gitClientTemp = Git.with(TaskListener.NULL, new EnvVars()).in(repoRootTemp).using(gitImplName).getClient();
         gitClientTemp.init();
+        CliGitCommand gitCmd = new CliGitCommand(gitClientTemp);
+        gitCmd.run("config", "user.name", "Vojtěch GitClientTest Zweibrücken-Šafařík");
+        gitCmd.run("config", "user.email", "email.from.git.client@example.com");
         FilePath gitClientFilePath = gitClientTemp.getWorkTree();
         FilePath gitClientTempFile = gitClientFilePath.createTextTempFile("aPre", ".txt", "file contents");
         gitClientTemp.add(".");
@@ -887,6 +886,9 @@ public class GitClientTest {
         File repoRootTemp = tempFolder.newFolder();
         GitClient gitClientTemp = Git.with(TaskListener.NULL, new EnvVars()).in(repoRootTemp).using(gitImplName).getClient();
         gitClientTemp.init();
+        CliGitCommand gitCmd = new CliGitCommand(gitClientTemp);
+        gitCmd.run("config", "user.name", "Vojtěch GitClientTest temp Zweibrücken-Šafařík");
+        gitCmd.run("config", "user.email", "email.by.client@example.com");
         FilePath gitClientFilePath = gitClientTemp.getWorkTree();
         FilePath gitClientTempFile = gitClientFilePath.createTextTempFile("aPre", ".txt", "file contents");
         gitClientTemp.add(".");
@@ -2206,6 +2208,9 @@ public class GitClientTest {
         assertTrue("Failed to create URL repo dir", urlRepoDir.mkdir());
         GitClient urlRepoClient = Git.with(TaskListener.NULL, new EnvVars()).in(urlRepoDir).using(gitImplName).getClient();
         urlRepoClient.init();
+        CliGitCommand gitCmd = new CliGitCommand(urlRepoClient);
+        gitCmd.run("config", "user.name", "Vojtěch GitClientTest Zweibrücken-Šafařík");
+        gitCmd.run("config", "user.email", "email.from.git.client@example.com");
         File readme = new File(urlRepoDir, "readme");
         String readmeText = "This repo includes .url in its directory name (" + random.nextInt() + ")";
         Files.write(Paths.get(readme.getAbsolutePath()), readmeText.getBytes());
@@ -2217,6 +2222,9 @@ public class GitClientTest {
         assertTrue("Failed to create repo dir that will have submodule", repoHasSubmodule.mkdir());
         GitClient repoHasSubmoduleClient = Git.with(TaskListener.NULL, new EnvVars()).in(repoHasSubmodule).using(gitImplName).getClient();
         repoHasSubmoduleClient.init();
+        gitCmd = new CliGitCommand(repoHasSubmoduleClient);
+        gitCmd.run("config", "user.name", "Vojtěch GitClientTest repo submodule Zweibrücken-Šafařík");
+        gitCmd.run("config", "user.email", "email.from.git.client@example.com");
         File hasSubmoduleReadme = new File(repoHasSubmodule, "readme");
         String hasSubmoduleReadmeText = "Repo has a submodule that includes .url in its directory name (" + random.nextInt() + ")";
         Files.write(Paths.get(hasSubmoduleReadme.getAbsolutePath()), hasSubmoduleReadmeText.getBytes());

--- a/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
@@ -47,13 +47,6 @@ public class LegacyCompatibleGitAPIImplTest {
         gitImpl = "git";
     }
 
-    @BeforeClass
-    public static void setCliGitDefaults() throws Exception {
-        /* Command line git commands fail unless certain default values are set */
-        CliGitCommand gitCmd = new CliGitCommand(null);
-        gitCmd.setDefaults();
-    }
-
     @Before
     public void setUp() throws IOException, InterruptedException {
         repo = tempFolder.newFolder();
@@ -61,6 +54,9 @@ public class LegacyCompatibleGitAPIImplTest {
         git = (LegacyCompatibleGitAPIImpl) Git.with(listener, env).in(repo).using(gitImpl).getClient();
         assertNotGitRepo(repo);
         git.init();
+        CliGitCommand gitCmd = new CliGitCommand(git);
+        gitCmd.run("config", "user.name", "Vojtěch legacy Zweibrücken-Šafařík");
+        gitCmd.run("config", "user.email", "email.from.git.client.test@example.com");
         assertIsGitRepo(repo);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
@@ -191,7 +191,6 @@ public class LegacyCompatibleGitAPIImplTest {
     @Test
     @Deprecated
     public void testGetTagsOnCommit_SHA1() throws Exception {
-        repo = new File(".");
         LegacyCompatibleGitAPIImpl myGit = (LegacyCompatibleGitAPIImpl) Git.with(listener, env).in(repo).using(gitImpl).getClient();
         List<Tag> result = myGit.getTagsOnCommit(taggedCommit.name());
         assertTrue("Tag list not empty: " + result, result.isEmpty());
@@ -200,8 +199,8 @@ public class LegacyCompatibleGitAPIImplTest {
     @Test
     @Deprecated
     public void testGetTagsOnCommit() throws Exception {
-        repo = new File(".");
         LegacyCompatibleGitAPIImpl myGit = (LegacyCompatibleGitAPIImpl) Git.with(listener, env).in(repo).using(gitImpl).getClient();
+        File trackedFile = commitTrackedFile();
         final String uniqueTagName = "testGetTagsOnCommit-" + UUID.randomUUID().toString();
         final String tagMessage = "Tagged with " + uniqueTagName;
         myGit.tag(uniqueTagName, tagMessage);
@@ -215,7 +214,6 @@ public class LegacyCompatibleGitAPIImplTest {
     @Test
     @Deprecated
     public void testGetTagsOnCommit_sha1() throws Exception {
-        repo = new File(".");
         LegacyCompatibleGitAPIImpl myGit = (LegacyCompatibleGitAPIImpl) Git.with(listener, env).in(repo).using(gitImpl).getClient();
         String revName = "2db88a20bba8e98b6710f06213f3b60940a63c7c";
         List<Tag> result = myGit.getTagsOnCommit(revName);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
@@ -57,13 +57,6 @@ public class MergeCommandTest {
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
-    @BeforeClass
-    public static void setCliGitDefaults() throws Exception {
-        /* Command line git commands fail unless certain default values are set */
-        CliGitCommand gitCmd = new CliGitCommand(null);
-        gitCmd.setDefaults();
-    }
-
     @Before
     public void createMergeTestRepo() throws IOException, InterruptedException {
         EnvVars env = new hudson.EnvVars();
@@ -71,6 +64,9 @@ public class MergeCommandTest {
         File repo = tempFolder.newFolder();
         git = Git.with(listener, env).in(repo).using(gitImpl).getClient();
         git.init_().workspace(repo.getAbsolutePath()).execute();
+        CliGitCommand gitCmd = new CliGitCommand(git);
+        gitCmd.run("config", "user.name", "Vojtěch MergeCommandTest Zweibrücken-Šafařík");
+        gitCmd.run("config", "user.email", "email.from.git.client@example.com");
 
         // Create a master branch
         char randomChar = (char) ((new Random()).nextInt(26) + 'a');

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
@@ -177,6 +177,9 @@ public class PushTest {
         ObjectId workingHead = workingGitClient.getHeadRev(workingRepo.getAbsolutePath(), branchName);
         ObjectId bareHead = bareGitClient.getHeadRev(bareRepo.getAbsolutePath(), branchName);
         assertEquals("Initial checkout of " + branchName + " has different HEAD than bare repo", bareHead, workingHead);
+        CliGitCommand gitCmd = new CliGitCommand(workingGitClient);
+        gitCmd.run("config", "user.name", "Vojtěch PushTest working repo Zweibrücken-Šafařík");
+        gitCmd.run("config", "user.email", "email.from.git.client@example.com");
     }
 
     @After
@@ -192,10 +195,6 @@ public class PushTest {
 
     @BeforeClass
     public static void createBareRepository() throws Exception {
-        /* Command line git commands fail unless certain default values are set */
-        CliGitCommand gitCmd = new CliGitCommand(null);
-        gitCmd.setDefaults();
-
         /* Randomly choose git implementation to create bare repository */
         final String[] gitImplementations = {"git", "jgit"};
         Random random = new Random();
@@ -216,6 +215,9 @@ public class PushTest {
                 .url(bareRepo.getAbsolutePath())
                 .repositoryName("origin")
                 .execute();
+        CliGitCommand gitCmd = new CliGitCommand(cloneGitClient);
+        gitCmd.run("config", "user.name", "Vojtěch PushTest Zweibrücken-Šafařík");
+        gitCmd.run("config", "user.email", "email.from.git.client@example.com");
 
         for (String branchName : BRANCH_NAMES) {
             /* Add a file with random content to the current branch of working repo */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/RemoteGitImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/RemoteGitImplTest.java
@@ -193,6 +193,9 @@ public class RemoteGitImplTest {
 
     private ObjectId firstCommit(String fileName) throws Exception {
         firstAdd(fileName);
+        CliGitCommand gitCmd = new CliGitCommand(defaultClient);
+        gitCmd.run("config", "user.name", "Vojtěch remote Zweibrücken-Šafařík");
+        gitCmd.run("config", "user.email", "email.from.git.remote.test@example.com");
         remoteGit.commit("Adding the " + fileName + " file");
         return remoteGit.revParse("HEAD");
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/RemotingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/RemotingTest.java
@@ -51,18 +51,7 @@ public class RemotingTest {
 
         private final GitClient git;
 
-        private static boolean cliGitDefaultsSet = false;
-
-        private void setCliGitDefaults() throws Exception {
-            if (!cliGitDefaultsSet) {
-                CliGitCommand gitCmd = new CliGitCommand(null);
-                gitCmd.setDefaults();
-            }
-            cliGitDefaultsSet = true;
-        }
-
         private Work(GitClient git) throws Exception {
-            setCliGitDefaults();
             this.git = git;
         }
 


### PR DESCRIPTION
## [JENKINS-63307](https://issues.jenkins-ci.org/browse/JENKINS-63307) - Honor property value in zOS credential files

Use property value rather than property name for the character set.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)