### PR TITLE
Convert threads from int to Integer in UnsupportedCommand API

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
@@ -119,7 +119,7 @@ public class UnsupportedCommand {
      * @return this for chaining
      */
     public UnsupportedCommand threads(Integer threads) {
-        if (threads != 0) {
+        if (threads != null && threads != 0) {
             useJGit = false;
         }
         return this;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/UnsupportedCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/UnsupportedCommandTest.java
@@ -141,6 +141,12 @@ public class UnsupportedCommandTest {
     }
 
     @Test
+    public void testThreadsNull() {
+        unsupportedCommand.threads(null);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
     public void testThreadsZero() {
         unsupportedCommand.threads(0);
         assertTrue(unsupportedCommand.determineSupportForJGit());


### PR DESCRIPTION
Since the SubmoduleOption has an option of number of threads declared as an `Integer threads`, the `UnsupportedCommand` should expect the same and not the primitive type which could potentially lead to some NPE issues.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
