### PR TITLE
Disable benchmarks on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,10 @@ buildPlugin(failFast: false)
 // Benchmarks run on the master branch always
 // Benchmarks run if any of the most recent 3 commits includes the word 'benchmark'
 boolean shouldRunBenchmarks(String branchName) {
-    if (branchName.endsWith('master')) { // accept both origin/master and master
-        return true;
-    }
+    // Disable benchmarks on master branch for speed
+    // if (branchName.endsWith('master')) { // accept both origin/master and master
+    //     return true;
+    // }
     def recentCommitMessages
     node('linux') {
         checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@
 buildPlugin(failFast: false)
 
 // Return true if benchmarks should be run
-// Benchmarks run on the master branch always
 // Benchmarks run if any of the most recent 3 commits includes the word 'benchmark'
 boolean shouldRunBenchmarks(String branchName) {
     // Disable benchmarks on master branch for speed


### PR DESCRIPTION
## Disable benchmarks on master branch

We're not adjusting code based on benchmarks at this time, let's save the execution time on the CI servers until we need to compare JGit and command line git again.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)