### PR TITLE
[JENKINS-63727] Add support to convey compatibility info related to JGit and Git Publisher

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
@@ -179,7 +179,9 @@ public class UnsupportedCommand {
     }
 
     /**
-     * JGit doesn't support Git Publisher
+     * JGit doesn't support Git Publisher.
+     * @param isEnabled if true, then git publisher post-build action is enabled in this context
+     * @return this for chaining
      */
     public UnsupportedCommand gitPublisher(boolean isEnabled) {
         if (isEnabled) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/UnsupportedCommand.java
@@ -179,6 +179,16 @@ public class UnsupportedCommand {
     }
 
     /**
+     * JGit doesn't support Git Publisher
+     */
+    public UnsupportedCommand gitPublisher(boolean isEnabled) {
+        if (isEnabled) {
+            useJGit = false;
+        }
+        return this;
+    }
+
+    /**
      * Returns true if JGit is supported based on previously passed values.
      *
      * @return true if JGit is supported based on previously passed values

--- a/src/test/java/org/jenkinsci/plugins/gitclient/UnsupportedCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/UnsupportedCommandTest.java
@@ -225,6 +225,20 @@ public class UnsupportedCommandTest {
     }
 
     @Test
+    public void testGitPublisherDisabled() {
+        /* Disabled git publisher is allowed to use JGit */
+        unsupportedCommand.gitPublisher(false);
+        assertTrue(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
+    public void testGitPublisher() {
+        /* Enabled git publisher must not use JGit */
+        unsupportedCommand.gitPublisher(true);
+        assertFalse(unsupportedCommand.determineSupportForJGit());
+    }
+
+    @Test
     public void testDetermineSupportForJGit() {
         /* Confirm default is true */
         assertTrue(unsupportedCommand.determineSupportForJGit());


### PR DESCRIPTION
## [JENKINS-63727](https://issues.jenkins-ci.org/browse/JENKINS-63727) - Add support to convey compatibility info related to JGit and Git Publisher

The UnsupportedCommand now features a support to convey if JGit should be suggested
as a viable implementation in the scenario where Git Publisher is added as a post build
action.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
