### PR TITLE
Throw GitException as expected in GitClientTest

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -2569,7 +2569,7 @@ public class GitClientTest {
     @Test(expected = GitException.class)
     public void testgetRemoteSymbolicReferences_URI_Syntax() throws Exception {
         if (!CLI_GIT_SUPPORTS_SYMREF) {
-            return;
+            throw new GitException("Skipping JGit tests in testgetRemoteSymbolicReferences_URI_Syntax");
         }
         gitClient.getRemoteSymbolicReferences("error: invalid repo URL", Constants.HEAD);
     }


### PR DESCRIPTION
## Throw GitException as expected in GitClientTest

When command line git does not support remote symbolic references, the test intentionally exits early.  In order to pass the test, it needs to throw the expected exception instead of simply returning. Throw the
expected exception.

Allows tests to run successfully on CentOS 7 with git 1.8.3.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Tests