### PR TITLE
Skip JMH benchmarks based on commit message content

### DIFF
--- a/src/test/java/jmh/benchmark/BenchmarkRunner.java
+++ b/src/test/java/jmh/benchmark/BenchmarkRunner.java
@@ -1,22 +1,55 @@
 package jmh.benchmark;
 
+import hudson.EnvVars;
+import hudson.model.TaskListener;
+
+import java.io.File;
+import java.io.StringWriter;
+import java.util.concurrent.TimeUnit;
+
 import jenkins.benchmark.jmh.BenchmarkFinder;
+
+import org.jenkinsci.plugins.gitclient.ChangelogCommand;
+import org.jenkinsci.plugins.gitclient.Git;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.JGitAPIImpl;
+
 import org.junit.Test;
+
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.util.concurrent.TimeUnit;
-
 /**
  * A runner class which finds benchmark tests annotated with @JmhBenchmark and launches them with the selected options
  * provided by JMH
  */
 public class BenchmarkRunner {
+    /**
+     * Return true if benchmarks should be run.
+     *
+     * If one of the last 3 commits includes the word "Benchmark" or
+     * "benchmark", then benchmarks should run.  Otherwise, do not run
+     * benchmarks.
+     *
+     * See Jenkinsfile for the same logic.
+     *
+     * @return true if benchmarks should be run
+     */
+    private boolean shouldRunBenchmarks() throws Exception {
+        GitClient defaultClient = Git.with(TaskListener.NULL, new EnvVars()).in(new File(".")).using("git").getClient();
+        StringWriter changelogWriter = new StringWriter();
+        defaultClient.changelog().includes("HEAD").max(3).to(changelogWriter).execute();
+        return changelogWriter.toString().matches("[Bb]enchmark");
+    }
+
     @Test
     public void runJmhBenchmarks() throws Exception {
+        if (!shouldRunBenchmarks()) {
+            return;
+        }
         ChainedOptionsBuilder options = new OptionsBuilder()
                 .mode(Mode.AverageTime) // Performance metric is Average time (ms per operation)
                 .warmupIterations(5) // Used to warm JVM before executing benchmark tests


### PR DESCRIPTION
## Skip JMH benchmarks based on commit message content

The Jenkinsfile already requires a commit message that includes the word "benchmark" or "Benchmark".  This change makes the unit test have the same condition.  JMH benchmarks will be run in CI if and only if the word "[Bb]enchmark" is included in one of the last 3 messages.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)