### PR TITLE
Reduce code scanner warnings

### DIFF
--- a/src/main/java/hudson/plugins/git/GitTool.java
+++ b/src/main/java/hudson/plugins/git/GitTool.java
@@ -17,6 +17,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import java.io.File;
 import java.io.IOException;
@@ -151,6 +152,7 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
             return true;
         }
 
+        @RequirePOST
         public FormValidation doCheckHome(@QueryParameter File value) {
             Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
             String path = value.getPath();

--- a/src/main/resources/hudson/plugins/git/GitTool/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitTool/config.jelly
@@ -4,7 +4,7 @@
         <f:textbox />
     </f:entry>
     <f:entry title="${%Path to Git executable}" field="home">
-        <f:textbox />
+        <f:textbox checkMethod="post"/>
     </f:entry>
     <j:set var="toolDescriptor" value="${descriptor}" /><!-- to make this descriptor accessible from properties -->
     <f:descriptorList descriptors="${descriptor.propertyDescriptors}" field="properties"/>

--- a/src/test/java/jmh/benchmark/GitClientFetchBenchmark.java
+++ b/src/test/java/jmh/benchmark/GitClientFetchBenchmark.java
@@ -40,7 +40,7 @@ public class GitClientFetchBenchmark {
          * "before" and "after" JUnit annotations.
          */
         @Setup(Level.Iteration)
-        public void doSetup() throws Exception {
+        public void setup() throws Exception {
             tmp.before();
             gitDir = tmp.newFolder();
 
@@ -56,7 +56,7 @@ public class GitClientFetchBenchmark {
         }
 
         @TearDown(Level.Iteration)
-        public void doTearDown() {
+        public void tearDown() {
             try {
                 // making sure that git init made a git an empty repository
                 File gitDir = gitClient.withRepository((repo, channel) -> repo.getDirectory());
@@ -112,7 +112,7 @@ public class GitClientFetchBenchmark {
         }
 
         @TearDown(Level.Trial)
-        public void doTearDown() {
+        public void tearDown() {
             tmp.after();
             System.out.println("Removed local upstream directory for: " + repoUrl);
         }

--- a/src/test/java/jmh/benchmark/GitClientFetchVanillaBenchmark.java
+++ b/src/test/java/jmh/benchmark/GitClientFetchVanillaBenchmark.java
@@ -92,7 +92,7 @@
 //    }
 //
 //    @After
-//    public void doTearDown() {
+//    public void tearDown() {
 //        try {
 //            File gitDir = gitClient.withRepository((repo, channel) -> repo.getDirectory());
 //            System.out.println(gitDir.isDirectory());

--- a/src/test/java/jmh/benchmark/GitClientInitBenchmark.java
+++ b/src/test/java/jmh/benchmark/GitClientInitBenchmark.java
@@ -29,7 +29,7 @@ public class GitClientInitBenchmark {
          * "before" and "after" JUnit annotations.
          */
         @Setup(Level.Iteration)
-        public void doSetup() throws Exception {
+        public void setup() throws Exception {
             tmp.before();
             gitDir = tmp.newFolder();
 
@@ -39,7 +39,7 @@ public class GitClientInitBenchmark {
         }
 
         @TearDown(Level.Iteration)
-        public void doTearDown() {
+        public void tearDown() {
             try {
                 // making sure that git init made a git an empty repository
                 File gitDir = gitClient.withRepository((repo, channel) -> repo.getDirectory());

--- a/src/test/java/jmh/benchmark/GitClientLSRemoteBenchmark.java
+++ b/src/test/java/jmh/benchmark/GitClientLSRemoteBenchmark.java
@@ -37,7 +37,7 @@ public class GitClientLSRemoteBenchmark {
          * "before" and "after" JUnit annotations.
          */
         @Setup(Level.Iteration)
-        public void doSetup() throws Exception {
+        public void setup() throws Exception {
             tmp.before();
             gitDir = tmp.newFolder();
 
@@ -48,7 +48,7 @@ public class GitClientLSRemoteBenchmark {
         }
 
         @TearDown(Level.Iteration)
-        public void doTearDown() {
+        public void tearDown() {
             try {
                 // making sure that git init made a git an empty repository
                 File gitDir = gitClient.withRepository((repo, channel) -> repo.getDirectory());

--- a/src/test/java/jmh/benchmark/GitClientRedundantFetchBenchmark.java
+++ b/src/test/java/jmh/benchmark/GitClientRedundantFetchBenchmark.java
@@ -78,7 +78,7 @@ public class GitClientRedundantFetchBenchmark {
          * "before" and "after" JUnit annotations.
          */
         @Setup(Level.Iteration)
-        public void doSetup() throws Exception {
+        public void setup() throws Exception {
             tmp.before();
             gitDir = tmp.newFolder();
             gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(gitDir).using(gitExe).getClient();
@@ -98,7 +98,7 @@ public class GitClientRedundantFetchBenchmark {
         }
 
         @TearDown(Level.Iteration)
-        public void doTearDown() {
+        public void tearDown() {
             try {
                 // making sure that git init made a git an empty repository
                 File gitDir = gitClient.withRepository((repo, channel) -> repo.getDirectory());

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -71,7 +71,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         }
     }
 
-    public void doTest(String versionOutput, VersionTest[] versions) {
+    public void assertVersionOutput(String versionOutput, VersionTest[] versions) {
         setTimeoutVisibleInCurrentTest(false); /* No timeout for git --version command */
         CliGitAPIImpl git = new CliGitAPIImpl("git", new File("."), listener, env);
         git.computeGitVersion(versionOutput);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -335,11 +335,11 @@ public class CredentialsTest {
         return TEST_ALL_CREDENTIALS ? repos : repos.subList(0, Math.min(repos.size(), 6));
     }
 
-    private void doFetch(String source) throws Exception {
-        doFetch(source, "master", true);
+    private void gitFetch(String source) throws Exception {
+        gitFetch(source, "master", true);
     }
 
-    private void doFetch(String source, String branch, Boolean allowShallowClone) throws Exception {
+    private void gitFetch(String source, String branch, Boolean allowShallowClone) throws Exception {
         /* Save some bandwidth with shallow clone for CliGit, not yet available for JGit */
         URIish sourceURI = new URIish(source);
         List<RefSpec> refSpecs = new ArrayList<>();
@@ -397,10 +397,10 @@ public class CredentialsTest {
         assertFalse("file " + fileToCheck + " in " + repo + ", has " + listDir(repo), clonedFile.exists());
         addCredential();
         /* Fetch with remote URL */
-        doFetch(gitRepoURL);
+        gitFetch(gitRepoURL);
         git.setRemoteUrl("origin", gitRepoURL);
         /* Fetch with remote name "origin" instead of remote URL */
-        doFetch("origin");
+        gitFetch("origin");
         ObjectId master = git.getHeadRev(gitRepoURL, "master");
         git.checkout().branch("master").ref(master.getName()).deleteBranchIfExist(true).execute();
         if (submodules) {
@@ -461,7 +461,7 @@ public class CredentialsTest {
 
         /* Fetch with remote name "origin" instead of remote URL */
         git.setRemoteUrl("origin", gitRepoURL);
-        doFetch("origin", "*", false);
+        gitFetch("origin", "*", false);
         ObjectId master = git.getHeadRev(gitRepoURL, "master");
         git.checkout().branch("master").ref(master.getName()).lfsRemote("origin").deleteBranchIfExist(true).execute();
         assertTrue("master: " + master + " not in repo", git.isCommitInRepo(master));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -2736,7 +2736,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 7, 10, 3),
                 cliGitAPIImplTest.new VersionTest(false, 1, 7, 10, 5)
         };
-        cliGitAPIImplTest.doTest("git version 1.7.10.4", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.7.10.4", versions);
     }
 
     @Test
@@ -2750,7 +2750,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(false, 2, 0, 2, 0),
                 cliGitAPIImplTest.new VersionTest(false, 2, 1, 0, 0)
         };
-        cliGitAPIImplTest.doTest("git version 2.0.1", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 2.0.1", versions);
     }
 
     @Test
@@ -2763,11 +2763,11 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 9, 99, 99),
                 cliGitAPIImplTest.new VersionTest(false, 2, 0,  1,  0)
         };
-        cliGitAPIImplTest.doTest("git version 2.0.0.rc0", versions);
-        cliGitAPIImplTest.doTest("git version 2.0.0.rc2", versions);
-        cliGitAPIImplTest.doTest("git version 2.0.0", versions);
-        cliGitAPIImplTest.doTest("git version 2.0", versions); // mythical version
-        cliGitAPIImplTest.doTest("git version 2", versions);   // mythical version
+        cliGitAPIImplTest.assertVersionOutput("git version 2.0.0.rc0", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 2.0.0.rc2", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 2.0.0", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 2.0", versions); // mythical version
+        cliGitAPIImplTest.assertVersionOutput("git version 2", versions);   // mythical version
     }
 
     @Test
@@ -2780,7 +2780,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 8, 99, 99),
                 cliGitAPIImplTest.new VersionTest(false, 1, 9,  1,  0)
         };
-        cliGitAPIImplTest.doTest("git version 1.9.0", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.9.0", versions);
     }
 
     @Test
@@ -2793,7 +2793,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 7, 99, 0),
                 cliGitAPIImplTest.new VersionTest(false, 1, 8,  1, 0)
         };
-        cliGitAPIImplTest.doTest("git version 1.8.0.msysgit.0", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.8.0.msysgit.0", versions);
     }
 
     @Test
@@ -2806,7 +2806,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 8, 3, 99),
                 cliGitAPIImplTest.new VersionTest(false, 1, 8, 4,  1)
         };
-        cliGitAPIImplTest.doTest("git version 1.8.4.msysgit.0", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.8.4.msysgit.0", versions);
     }
 
     @Test
@@ -2819,7 +2819,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 8, 5, 1),
                 cliGitAPIImplTest.new VersionTest(false, 1, 8, 5, 3)
         };
-        cliGitAPIImplTest.doTest("git version 1.8.5.2.msysgit.0", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.8.5.2.msysgit.0", versions);
     }
 
     @Test
@@ -2832,7 +2832,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 8, 99, 0),
                 cliGitAPIImplTest.new VersionTest(false, 1, 9,  0, 1)
         };
-        cliGitAPIImplTest.doTest("git version 1.9.0.msysgit.0", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.9.0.msysgit.0", versions);
     }
 
     @Test
@@ -2845,7 +2845,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 9, 1, 99),
                 cliGitAPIImplTest.new VersionTest(false, 1, 9, 2,  1)
         };
-        cliGitAPIImplTest.doTest("git version 1.9.2.msysgit.0", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.9.2.msysgit.0", versions);
     }
 
     @Test
@@ -2858,7 +2858,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 9, 3, 99),
                 cliGitAPIImplTest.new VersionTest(false, 1, 9, 4,  1)
         };
-        cliGitAPIImplTest.doTest("git version 1.9.4.msysgit.0", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.9.4.msysgit.0", versions);
     }
 
     @Test
@@ -2871,7 +2871,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  2, 5, 0, 0),
                 cliGitAPIImplTest.new VersionTest(false, 2, 5, 0, 2)
         };
-        cliGitAPIImplTest.doTest("git version 2.5.0.windows.1", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 2.5.0.windows.1", versions);
     }
 
     @Test
@@ -2886,7 +2886,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(false, 2, 10, 1, 2),
                 cliGitAPIImplTest.new VersionTest(false, 2, 10, 2, 0)
         };
-        cliGitAPIImplTest.doTest("git version 2.10.1.windows.1", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 2.10.1.windows.1", versions);
     }
 
     @Test
@@ -2899,7 +2899,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 8, 2, 0),
                 cliGitAPIImplTest.new VersionTest(false, 1, 8, 2, 2)
         };
-        cliGitAPIImplTest.doTest("git version 1.8.2.1", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.8.2.1", versions);
     }
 
     @Test
@@ -2913,7 +2913,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(false, 1, 7, 1,  1),
                 cliGitAPIImplTest.new VersionTest(false, 1, 7, 2,  0)
         };
-        cliGitAPIImplTest.doTest("git version 1.7.1", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.7.1", versions);
     }
 
     @Test
@@ -2926,7 +2926,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 8, 4, 4),
                 cliGitAPIImplTest.new VersionTest(false, 1, 8, 4, 6)
         };
-        cliGitAPIImplTest.doTest("git version 1.8.4.5", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.8.4.5", versions);
     }
 
     @Test
@@ -2939,7 +2939,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  1, 8, 3, 1),
                 cliGitAPIImplTest.new VersionTest(false, 1, 8, 3, 3)
         };
-        cliGitAPIImplTest.doTest("git version 1.8.3.2", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 1.8.3.2", versions);
     }
 
     @Test
@@ -2952,7 +2952,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  2, 2, 1, 0),
                 cliGitAPIImplTest.new VersionTest(false, 2, 2, 3, 0)
         };
-        cliGitAPIImplTest.doTest("git version 2.2.2", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 2.2.2", versions);
     }
 
     @Test
@@ -2965,7 +2965,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(true,  2, 2, 9, 0),
                 cliGitAPIImplTest.new VersionTest(false, 2, 3, 1, 0)
         };
-        cliGitAPIImplTest.doTest("git version 2.3.0", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 2.3.0", versions);
     }
 
     @Test
@@ -2980,7 +2980,7 @@ public class GitClientTest {
                 cliGitAPIImplTest.new VersionTest(false, 2, 4, 0, 0),
                 cliGitAPIImplTest.new VersionTest(false, 3, 0, 0, 0)
         };
-        cliGitAPIImplTest.doTest("git version 2.3.5", versions);
+        cliGitAPIImplTest.assertVersionOutput("git version 2.3.5", versions);
     }
 
     @Test


### PR DESCRIPTION
## Reduce code scanner warnings

Annotate HTTP accessible method with RequirePOST.  Since the method is only needed from a POST context, it should be annotated with @RequirePOST.  The method does not invoke any risky code that might make it a security risk, but it is not useful as a GET method, so require that it must be called with POST.

Also renames several test methods to avoid warnings due to poorly named test methods.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Reduce warnings