### PR TITLE
Add "--first-parent" to "git log" for Jenkins

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1235,7 +1235,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     @Override
     public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput) throws GitException, InterruptedException {
-        ArgumentListBuilder args = new ArgumentListBuilder("log", "--full-history", "--no-abbrev", "--format=raw", "-M", "-m");
+        ArgumentListBuilder args = new ArgumentListBuilder("log", "--first-parent", "--full-history", "--no-abbrev", "--format=raw", "-M", "-m");
         if (useRawOutput) {
             args.add("--raw");
         }


### PR DESCRIPTION
We have been patching and building git-client with these changes for a few years and used them on our Jenkin servers.

This helps with git polling as the history is cleaner. For example a insertion followed by deletion does not trigger a build. We would like to contribute the fix to upstrem:

git log --first-parent --full-history --no-abbrev --format=raw -M -m --raw <previously-built-commit>..<feature-branch-merge-into-CI>

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [X] I have interactively tested my changes

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
