### PR TITLE
Adapt to xstream changes: change readResolve() from private to protected

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -56,7 +56,7 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
         return (hudson.plugins.git.IGitAPI)proxy;
     }
 
-    private Object readResolve() {
+    protected Object readResolve() {
         channel = Channel.current();
         return this;
     }


### PR DESCRIPTION
Similarly to https://github.com/jenkinsci/git-plugin/pull/1012 - Stemming from IRC discussion with @timja, it seems that for codebase running on Jenkins core after xstream changes (2.266+) the inherited private `readResolve()` methods that are a problem solved by making them protected: https://github.com/jenkinsci/jep/blob/f52f17b085293543a515f8c62fe458491f8e45c9/jep/228/README.adoc#inherited-private-serialization-methods

I do not know if this change really solves any issues, or how to confirm that at the moment.

Suggested by work and discussion on https://github.com/jenkinsci/envinject-plugin/pull/154