### PR TITLE
Require Jenkins 2.222.4 as minimum Jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.204.1</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version> <!-- Required for git plugin 4.5.0 -->
     <java.level>8</java.level>
     <jgit.version>5.10.0.202012080955-r</jgit.version>
     <configuration-as-code.version>1.36</configuration-as-code.version>
@@ -71,8 +71,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.204.x</artifactId>
-        <version>18</version>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>19</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require 2.222.4 as minimum Jenkins version

﻿One LTS version behind the current recommended Jenkins base version.

This is the same minimum Jenkins version required for git plugin 4.5.0.

58% of git client plugin installations are running Jenkins 2.222.4 or newer.

Over one third of the git client plugin installations are running the most recent git client plugin release (3.5.1).  The vast majority of those installations are running 2.222.4 or newer.  Users that are upgrading their git client plugin version are also upgrading their Jenkins versions.

Based on those results, updating the minimum Jenkins version from 2.204.x to 2.222.4 should have very little actual impact on users of the git client plugin.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
