### PR TITLE
Use JGit 5.10.0 ls-remote to get symbolic refs

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -2240,6 +2240,8 @@ public class GitClientTest {
         Files.write(Paths.get(readme.getAbsolutePath()), readmeText.getBytes());
         urlRepoClient.add("readme");
         urlRepoClient.commit("Added README to repo used as a submodule");
+        /* Enable long paths to prevent checkout failure on default Windows workspace with MSI installer */
+        enableLongPaths(urlRepoClient);
 
         // Add new repository as submodule to repository that ends in .url
         File repoHasSubmodule = new File(baseDir, "has-submodule.url");
@@ -2249,6 +2251,8 @@ public class GitClientTest {
         gitCmd = new CliGitCommand(repoHasSubmoduleClient);
         gitCmd.run("config", "user.name", "Vojtěch GitClientTest repo submodule Zweibrücken-Šafařík");
         gitCmd.run("config", "user.email", "email.from.git.client@example.com");
+        /* Enable long paths to prevent checkout failure on default Windows workspace with MSI installer */
+        enableLongPaths(repoHasSubmoduleClient);
         File hasSubmoduleReadme = new File(repoHasSubmodule, "readme");
         String hasSubmoduleReadmeText = "Repo has a submodule that includes .url in its directory name (" + random.nextInt() + ")";
         Files.write(Paths.get(hasSubmoduleReadme.getAbsolutePath()), hasSubmoduleReadmeText.getBytes());
@@ -2272,6 +2276,8 @@ public class GitClientTest {
         cloneGitClient.clone_().url(repoHasSubmodule.getAbsolutePath()).execute();
         String branch = "master";
         cloneGitClient.checkoutBranch(branch, "origin/" + branch);
+        /* Enable long paths to prevent checkout failure on default Windows workspace with MSI installer */
+        enableLongPaths(cloneGitClient);
         cloneGitClient.submoduleInit();
         cloneGitClient.submoduleUpdate().recursive(false).execute();
         assertSubmoduleStatus(cloneGitClient, true, moduleDirBaseName);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.gitclient;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import org.eclipse.jgit.transport.BasePackFetchConnection;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -16,13 +15,7 @@ public class JGitAPIImplTest extends GitAPITestCase {
 
     @Override
     protected boolean hasWorkingGetRemoteSymbolicReferences() {
-        try {
-            // TODO if JGit implement https://bugs.eclipse.org/bugs/show_bug.cgi?id=514052 we should switch to that
-            BasePackFetchConnection.class.getSuperclass().getDeclaredField("remoteCapablities");
-            return true;
-        } catch (NoSuchFieldException e) {
-            return false;
-        }
+        return true; // JGit 5.10 has getRemoteSymbolicReferences, prior did not
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitApacheAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitApacheAPIImplTest.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.gitclient;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import org.eclipse.jgit.transport.BasePackFetchConnection;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -16,13 +15,7 @@ public class JGitApacheAPIImplTest extends GitAPITestCase {
 
     @Override
     protected boolean hasWorkingGetRemoteSymbolicReferences() {
-        try {
-            // TODO if JGit implement https://bugs.eclipse.org/bugs/show_bug.cgi?id=514052 we should switch to that
-            BasePackFetchConnection.class.getSuperclass().getDeclaredField("remoteCapablities");
-            return true;
-        } catch (NoSuchFieldException e) {
-            return false;
-        }
+        return true; // JGit 5.10 gets remote symbolic references, prior did not
     }
 
     /**


### PR DESCRIPTION
## Use JGit lsRemote command now that symrefs are supported

The [JGIt 5.10.0 release notes](https://projects.eclipse.org/projects/technology.jgit/releases/5.10.0) announce that ls-remote now reports symrefs. [JGit enhancement 514052](https://www.eclip.se/514052) is implemented in JGit 5.10.0.  Use it to replace the earlier implementation that relied on reading internal data from JGit.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change
