### PR TITLE
Use plugin bom for JCasC plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
     <jenkins.version>2.222.4</jenkins.version> <!-- Required for git plugin 4.5.0 -->
     <java.level>8</java.level>
     <jgit.version>5.10.0.202012080955-r</jgit.version>
-    <configuration-as-code.version>1.36</configuration-as-code.version>
     <slf4jVersion>1.7.26</slf4jVersion>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
@@ -286,13 +285,11 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Use plugin bom for JCasC version

Since other plugins are already using the plugin bom to require a specific version of the configuration as code plugin and this plugin is already using the plugin bom, there is very little benefit to continuing to separately manage the version of the configuration as code plugin that is optional with the git client plugin.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
