### PR TITLE
Support sparse checkout with JGit

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2119,7 +2119,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertFalse("file3 exists and should not because not on 'branch2'", w.exists(subFile3));
     }
 
-    @NotImplementedInJGit
     public void test_sparse_checkout() throws Exception {
         /* Sparse checkout was added in git 1.7.0, but the checkout -f syntax
          * required by the plugin implementation does not work in git 1.7.1.

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
@@ -29,6 +29,7 @@ public class JGitAPIImplTest extends GitAPITestCase {
     /**
      * Override to run the test and assert its state.
      *
+     *
      * @throws Throwable if any exception is thrown
      */
     protected void runTest() throws Throwable {


### PR DESCRIPTION
## [JENKINS-45368](https://issues.jenkins.io/browse/JENKINS-45368) - Support sparse checkout with JGit

JGit 5.9.0 now includes support for an API that may support sparse checkout.  Use that API to implement sparse checkout in the git plugin.

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] New feature

## Further comments

N/A