### PR TITLE
[JENKINS-60940] - Migration of GitAPITests from JUnit 3 to JUnit 4

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -1,0 +1,110 @@
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.model.TaskListener;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Git API Tests, eventual replacement for GitAPITestCase,
+ * Implemented in JUnit 4.
+ */
+
+@RunWith(Parameterized.class)
+public class GitAPITest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+    private File repoRoot = null;
+
+    private int logCount = 0;
+    private final Random random = new Random();
+    private static final String LOGGING_STARTED = "Logging started";
+    private LogHandler handler = null;
+    private TaskListener listener;
+    private final String gitImplName;
+
+    private String revParseBranchName = null;
+
+    private int checkoutTimeout = -1;
+    private int cloneTimeout = -1;
+    private int fetchTimeout = -1;
+    private int submoduleUpdateTimeout = -1;
+
+
+    WorkspaceWithRepo workspace;
+
+    private GitClient testGitClient;
+    private File testGitDir;
+    private CliGitCommand cliGitCommand;
+
+    public GitAPITest(final String gitImplName) {
+        this.gitImplName = gitImplName;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection gitObjects() {
+        List<Object[]> arguments = new ArrayList<>();
+        String[] gitImplNames = {"git", "jgit", "jgitapache"};
+        for (String gitImplName : gitImplNames) {
+            Object[] item = {gitImplName};
+            arguments.add(item);
+        }
+        return arguments;
+    }
+
+    @Before
+    public void setUpRepositories() throws Exception {
+        File repoRootTemp = tempFolder.newFolder();
+
+        revParseBranchName = null;
+        checkoutTimeout = -1;
+        cloneTimeout = -1;
+        fetchTimeout = -1;
+        submoduleUpdateTimeout = -1;
+
+        Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);
+        handler = new LogHandler();
+        handler.setLevel(Level.ALL);
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        logger.setLevel(Level.ALL);
+        listener = new hudson.util.LogTaskListener(logger, Level.ALL);
+        listener.getLogger().println(LOGGING_STARTED);
+
+        workspace = new WorkspaceWithRepo(repoRootTemp, gitImplName, listener);
+
+        testGitClient = workspace.getGitClient();
+        testGitDir = workspace.getGitFileDir();
+        cliGitCommand = workspace.getCliGitCommand();
+        testGitClient.init();
+        final String userName = "root";
+        final String emailAddress = "root@mydomain.com";
+        cliGitCommand.run("config", "user.name", userName);
+        cliGitCommand.run("config", "user.email", emailAddress);
+        testGitClient.setAuthor(userName, emailAddress);
+        testGitClient.setCommitter(userName, emailAddress);
+    }
+
+    @Test
+    public void testGetRemoteUrl() throws Exception {
+        workspace.launchCommand("git", "remote", "add", "origin", "https://github.com/jenkinsci/git-client-plugin.git");
+        workspace.launchCommand("git", "remote", "add", "ndeloof", "git@github.com:ndeloof/git-client-plugin.git");
+        String remoteUrl = workspace.getGitClient().getRemoteUrl("origin");
+        assertEquals("unexepected remote URL " + remoteUrl, "https://github.com/jenkinsci/git-client-plugin.git", remoteUrl);
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -602,14 +602,6 @@ public abstract class GitAPITestCase extends TestCase {
                      w.igit().getDefaultRemote("invalid"));
     }
 
-    public void test_getRemoteURL() throws Exception {
-        w.init();
-        w.launchCommand("git", "remote", "add", "origin", "https://github.com/jenkinsci/git-client-plugin.git");
-        w.launchCommand("git", "remote", "add", "ndeloof", "git@github.com:ndeloof/git-client-plugin.git");
-        String remoteUrl = w.git.getRemoteUrl("origin");
-        assertEquals("unexepected remote URL " + remoteUrl, "https://github.com/jenkinsci/git-client-plugin.git", remoteUrl);
-    }
-
     public void test_clean_with_parameter() throws Exception {
         w.init();
         w.commitEmpty("init");


### PR DESCRIPTION
## [JENKINS-60940](https://issues.jenkins-ci.org/browse/JENKINS-60940) - Migration of GitAPITests from JUnit 3 to JUnit 4

Added Class GitAPITest, for migration of GitAPITestCase from JUnit 3 to JUnit 4, added the first test getRemoteUrl

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
