### PR TITLE
Use controller to refer to the Jenkins server

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ Prior release notes are recorded in the git client plugin repository link:CHANGE
 [#implementations]
 == Implementations
 
-The git client plugin default implementation requires that https://git-scm.com/downloads[command line git] is installed on the master and on every agent that will use git.
+The git client plugin default implementation requires that https://git-scm.com/downloads[command line git] is installed on the controller and on every agent that will use git.
 Command line git implementations working with large files should also install https://git-lfs.github.com/[git LFS].
 The command line git implementation is the canonical implementation of the git interfaces provided by the git client plugin.
 


### PR DESCRIPTION
## Remove outdated terminology

Replace 'master' with 'controller' when it refers to the Jenkins server.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Documentation
