### PR TITLE
[JENKINS-60940] - Migrating Test of GitAPITestCase from JUnit 3 to JUnit 4

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -259,6 +259,24 @@ public class GitAPITest {
         assertFalse(workspace.getGitClient().tagExists("unknown"));
     }
 
+    @Test
+    public void testGetTagMessage() throws Exception {
+        workspace.commitEmpty("init");
+        workspace.launchCommand("git", "tag", "test", "-m", "this-is-a-test");
+        assertEquals("this-is-a-test", workspace.getGitClient().getTagMessage("test"));
+    }
+
+    @Test
+    public void testGetTagMessageMultiLine() throws Exception {
+        workspace.commitEmpty("init");
+        workspace.launchCommand("git", "tag", "test", "-m", "test 123!\n* multi-line tag message\n padded ");
+
+        // Leading four spaces from each line should be stripped,
+        // but not the explicit single space before "padded",
+        // and the final errant space at the end should be trimmed
+        assertEquals("test 123!\n* multi-line tag message\n padded", workspace.getGitClient().getTagMessage("test"));
+    }
+
     /**
      * inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue
      */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -239,6 +239,18 @@ public class GitAPITest {
         assertEquals(3, branches.size());
     }
 
+    @Test
+    public void testListTagsStarFilter() throws Exception {
+        workspace.commitEmpty("init");
+        workspace.tag("test");
+        workspace.tag("another_test");
+        workspace.tag("yet_another");
+        Set<String> allTags = workspace.getGitClient().getTagNames("*");
+        assertTrue("tag 'test' not listed", allTags.contains("test"));
+        assertTrue("tag 'another_test' not listed", allTags.contains("another_test"));
+        assertTrue("tag 'yet_another' not listed", allTags.contains("yet_another"));
+    }
+
     /**
      * inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue
      */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -284,6 +284,18 @@ public class GitAPITest {
         assertTrue("test ref not created", workspace.launchCommand("git", "show-ref").contains("refs/testing/testref"));
     }
 
+    @Test
+    public void testDeleteRef() throws Exception {
+        workspace.commitEmpty("init");
+        workspace.getGitClient().ref("refs/testing/testref");
+        workspace.getGitClient().ref("refs/testing/anotherref");
+        workspace.getGitClient().deleteRef("refs/testing/testref");
+        String refs = workspace.launchCommand("git", "show-ref");
+        assertFalse("deleted test tag still present", refs.contains("refs/testing/testref"));
+        assertTrue("expected tag not listed", refs.contains("refs/testing/anotherref"));
+        workspace.getGitClient().deleteRef("refs/testing/testref"); //Double-deletes do nothing.
+    }
+
     /**
      * inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue
      */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -320,6 +320,15 @@ public class GitAPITest {
         assertTrue("ref yetanotherref not listed", allRefs.contains("refs/testing/nested/yetanotherref"));
     }
 
+    @Test
+    public void testRefExists() throws Exception {
+        workspace.commitEmpty("init");
+        workspace.getGitClient().ref("refs/testing/testref");
+        assertTrue(workspace.getGitClient().refExists("refs/testing/testref"));
+        assertFalse(workspace.getGitClient().refExists("refs/testing/testref_notfound"));
+        assertFalse(workspace.getGitClient().refExists("refs/testing2/yetanother"));
+    }
+
     /**
      * inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue
      */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -296,6 +296,18 @@ public class GitAPITest {
         workspace.getGitClient().deleteRef("refs/testing/testref"); //Double-deletes do nothing.
     }
 
+    @Test
+    public void testListRefsWithPrefix() throws Exception {
+        workspace.commitEmpty("init");
+        workspace.getGitClient().ref("refs/testing/testref");
+        workspace.getGitClient().ref("refs/testing/nested/anotherref");
+        workspace.getGitClient().ref("refs/testing/nested/yetanotherref");
+        Set<String> refs = workspace.getGitClient().getRefNames("refs/testing/nested/");
+        assertFalse("ref testref listed", refs.contains("refs/testing/testref"));
+        assertTrue("ref anotherref not listed", refs.contains("refs/testing/nested/anotherref"));
+        assertTrue("ref yetanotherref not listed", refs.contains("refs/testing/nested/yetanotherref"));
+    }
+
     /**
      * inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue
      */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -277,6 +277,13 @@ public class GitAPITest {
         assertEquals("test 123!\n* multi-line tag message\n padded", workspace.getGitClient().getTagMessage("test"));
     }
 
+    @Test
+    public void testCreateRef() throws Exception {
+        workspace.commitEmpty("init");
+        workspace.getGitClient().ref("refs/testing/testref");
+        assertTrue("test ref not created", workspace.launchCommand("git", "show-ref").contains("refs/testing/testref"));
+    }
+
     /**
      * inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue
      */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -251,6 +251,14 @@ public class GitAPITest {
         assertTrue("tag 'yet_another' not listed", allTags.contains("yet_another"));
     }
 
+    @Test
+    public void testTagExists() throws Exception {
+        workspace.commitEmpty("init");
+        workspace.tag("test");
+        assertTrue(workspace.getGitClient().tagExists("test"));
+        assertFalse(workspace.getGitClient().tagExists("unknown"));
+    }
+
     /**
      * inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue
      */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -308,6 +308,18 @@ public class GitAPITest {
         assertTrue("ref yetanotherref not listed", refs.contains("refs/testing/nested/yetanotherref"));
     }
 
+    @Test
+    public void testListRefsWithoutPrefix() throws Exception {
+        workspace.commitEmpty("init");
+        workspace.getGitClient().ref("refs/testing/testref");
+        workspace.getGitClient().ref("refs/testing/nested/anotherref");
+        workspace.getGitClient().ref("refs/testing/nested/yetanotherref");
+        Set<String> allRefs = workspace.getGitClient().getRefNames("");
+        assertTrue("ref testref not listed", allRefs.contains("refs/testing/testref"));
+        assertTrue("ref anotherref not listed", allRefs.contains("refs/testing/nested/anotherref"));
+        assertTrue("ref yetanotherref not listed", allRefs.contains("refs/testing/nested/yetanotherref"));
+    }
+
     /**
      * inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue
      */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -941,24 +941,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertNull("did not expect reference for invalid tag but got : " + invalidTagId, invalidTagId);
     }
 
-    public void test_get_tag_message() throws Exception {
-        w.init();
-        w.commitEmpty("init");
-        w.launchCommand("git", "tag", "test", "-m", "this-is-a-test");
-        assertEquals("this-is-a-test", w.git.getTagMessage("test"));
-    }
-
-    public void test_get_tag_message_multi_line() throws Exception {
-        w.init();
-        w.commitEmpty("init");
-        w.launchCommand("git", "tag", "test", "-m", "test 123!\n* multi-line tag message\n padded ");
-
-        // Leading four spaces from each line should be stripped,
-        // but not the explicit single space before "padded",
-        // and the final errant space at the end should be trimmed
-        assertEquals("test 123!\n* multi-line tag message\n padded", w.git.getTagMessage("test"));
-    }
-
     public void test_create_ref() throws Exception {
         w.init();
         w.commitEmpty("init");
@@ -968,7 +950,7 @@ public abstract class GitAPITestCase extends TestCase {
 
     public void test_delete_ref() throws Exception {
         w.init();
-        w.commitEmpty("init");
+            w.commitEmpty("init");
         w.git.ref("refs/testing/testref");
         w.git.ref("refs/testing/anotherref");
         w.git.deleteRef("refs/testing/testref");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -941,18 +941,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertNull("did not expect reference for invalid tag but got : " + invalidTagId, invalidTagId);
     }
 
-    public void test_list_refs_without_prefix() throws Exception {
-        w.init();
-        w.commitEmpty("init");
-        w.git.ref("refs/testing/testref");
-        w.git.ref("refs/testing/nested/anotherref");
-        w.git.ref("refs/testing/nested/yetanotherref");
-        Set<String> allRefs = w.git.getRefNames("");
-        assertTrue("ref testref not listed", allRefs.contains("refs/testing/testref"));
-        assertTrue("ref anotherref not listed", allRefs.contains("refs/testing/nested/anotherref"));
-        assertTrue("ref yetanotherref not listed", allRefs.contains("refs/testing/nested/yetanotherref"));
-    }
-
     public void test_ref_exists() throws Exception {
         w.init();
         w.commitEmpty("init");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -941,18 +941,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertNull("did not expect reference for invalid tag but got : " + invalidTagId, invalidTagId);
     }
 
-    public void test_delete_ref() throws Exception {
-        w.init();
-            w.commitEmpty("init");
-        w.git.ref("refs/testing/testref");
-        w.git.ref("refs/testing/anotherref");
-        w.git.deleteRef("refs/testing/testref");
-        String refs = w.launchCommand("git", "show-ref");
-        assertFalse("deleted test tag still present", refs.contains("refs/testing/testref"));
-        assertTrue("expected tag not listed", refs.contains("refs/testing/anotherref"));
-        w.git.deleteRef("refs/testing/testref");  // Double-deletes do nothing.
-    }
-
     public void test_list_refs_with_prefix() throws Exception {
         w.init();
         w.commitEmpty("init");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -940,7 +940,7 @@ public abstract class GitAPITestCase extends TestCase {
         ObjectId invalidTagId = w.git.getHeadRev(gitDir, "not-a-valid-tag");
         assertNull("did not expect reference for invalid tag but got : " + invalidTagId, invalidTagId);
     }
-
+    
     public void test_revparse_sha1_HEAD_or_tag() throws Exception {
         w.init();
         w.commitEmpty("init");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -894,16 +894,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue("tag 'yet_another' not listed", allTags.contains("yet_another"));
     }
 
-    public void test_list_branches_containing_ref() throws Exception {
-        w.init();
-        w.commitEmpty("init");
-        w.git.branch("test");
-        w.git.branch("another");
-        Set<Branch> branches = w.git.getBranches();
-        assertBranchesExist(branches, "master", "test", "another");
-        assertEquals(3, branches.size());
-    }
-
     @Issue("JENKINS-23299")
     public void test_create_tag() throws Exception {
         w.init();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -941,13 +941,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertNull("did not expect reference for invalid tag but got : " + invalidTagId, invalidTagId);
     }
 
-    public void test_create_ref() throws Exception {
-        w.init();
-        w.commitEmpty("init");
-        w.git.ref("refs/testing/testref");
-        assertTrue("test ref not created", w.launchCommand("git", "show-ref").contains("refs/testing/testref"));
-    }
-
     public void test_delete_ref() throws Exception {
         w.init();
             w.commitEmpty("init");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -941,18 +941,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertNull("did not expect reference for invalid tag but got : " + invalidTagId, invalidTagId);
     }
 
-    public void test_list_tags_star_filter() throws Exception {
-        w.init();
-        w.commitEmpty("init");
-        w.tag("test");
-        w.tag("another_test");
-        w.tag("yet_another");
-        Set<String> allTags = w.git.getTagNames("*");
-        assertTrue("tag 'test' not listed", allTags.contains("test"));
-        assertTrue("tag 'another_test' not listed", allTags.contains("another_test"));
-        assertTrue("tag 'yet_another' not listed", allTags.contains("yet_another"));
-    }
-
     public void test_tag_exists() throws Exception {
         w.init();
         w.commitEmpty("init");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -806,33 +806,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue("tag3 wasn't pushed", bare.launchCommand("git", "tag").contains("tag3"));
     }
 
-    @Issue("JENKINS-37794")
-    public void test_getTagNames_supports_slashes_in_tag_names() throws Exception {
-        w.init();
-        w.commitEmpty("init-getTagNames-supports-slashes");
-        w.git.tag("no-slash", "Tag without a /");
-        Set<String> tags = w.git.getTagNames(null);
-        assertThat(tags, hasItem("no-slash"));
-        assertThat(tags, not(hasItem("slashed/sample")));
-        assertThat(tags, not(hasItem("slashed/sample-with-short-comment")));
-
-        w.git.tag("slashed/sample", "Tag slashed/sample includes a /");
-        w.git.tag("slashed/sample-with-short-comment", "short comment");
-
-        for (String matchPattern : Arrays.asList("n*", "no-*", "*-slash", "*/sl*sa*", "*/sl*/sa*")) {
-            Set<String> latestTags = w.git.getTagNames(matchPattern);
-            assertThat(tags, hasItem("no-slash"));
-            assertThat(latestTags, not(hasItem("slashed/sample")));
-            assertThat(latestTags, not(hasItem("slashed/sample-with-short-comment")));
-        }
-
-        for (String matchPattern : Arrays.asList("s*", "slashed*", "sl*sa*", "slashed/*", "sl*/sa*", "slashed/sa*")) {
-            Set<String> latestTags = w.git.getTagNames(matchPattern);
-            assertThat(latestTags, hasItem("slashed/sample"));
-            assertThat(latestTags, hasItem("slashed/sample-with-short-comment"));
-        }
-    }
-
     @Issue("JENKINS-34309")
     public void test_list_branches() throws Exception {
         w.init();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -941,14 +941,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertNull("did not expect reference for invalid tag but got : " + invalidTagId, invalidTagId);
     }
 
-    public void test_tag_exists() throws Exception {
-        w.init();
-        w.commitEmpty("init");
-        w.tag("test");
-        assertTrue(w.git.tagExists("test"));
-        assertFalse(w.git.tagExists("unknown"));
-    }
-
     public void test_get_tag_message() throws Exception {
         w.init();
         w.commitEmpty("init");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -941,18 +941,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertNull("did not expect reference for invalid tag but got : " + invalidTagId, invalidTagId);
     }
 
-    public void test_list_refs_with_prefix() throws Exception {
-        w.init();
-        w.commitEmpty("init");
-        w.git.ref("refs/testing/testref");
-        w.git.ref("refs/testing/nested/anotherref");
-        w.git.ref("refs/testing/nested/yetanotherref");
-        Set<String> refs = w.git.getRefNames("refs/testing/nested/");
-        assertFalse("ref testref listed", refs.contains("refs/testing/testref"));
-        assertTrue("ref anotherref not listed", refs.contains("refs/testing/nested/anotherref"));
-        assertTrue("ref yetanotherref not listed", refs.contains("refs/testing/nested/yetanotherref"));
-    }
-
     public void test_list_refs_without_prefix() throws Exception {
         w.init();
         w.commitEmpty("init");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -941,15 +941,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertNull("did not expect reference for invalid tag but got : " + invalidTagId, invalidTagId);
     }
 
-    public void test_ref_exists() throws Exception {
-        w.init();
-        w.commitEmpty("init");
-        w.git.ref("refs/testing/testref");
-        assertTrue(w.git.refExists("refs/testing/testref"));
-        assertFalse(w.git.refExists("refs/testing/testref_notfound"));
-        assertFalse(w.git.refExists("refs/testing2/yetanother"));
-    }
-
     public void test_revparse_sha1_HEAD_or_tag() throws Exception {
         w.init();
         w.commitEmpty("init");


### PR DESCRIPTION
## [JENKINS-60940](https://issues.jenkins-ci.org/browse/JENKINS-60940) - Migrating Test of GitAPITestCase from JUnit 3 to JUnit 4

Tests Migrated: 
- testRefExists
- testListRefsWithoutPrefix
- testListRefsWithPrefix
- testDeleteRef
- testCreateRef
- testGetTagMessageMultiLine
- testGetTagMessage
- testTagExists
- testListTagsStarFilter
- testListBranchesContainingRef
- testGetTagNamesSupportsSlashesInTagNames
- testListTagsWithoutFilter
- testListTagsWithFilter
- testDeleteTag
- testDeleteBranch
- testCreateBranch
- testEmptyComment
- testGetRemoteUrl

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
