### PR TITLE
Remove special case from JGit test

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -626,12 +626,8 @@ public abstract class GitAPITestCase extends TestCase {
         assertFalse(w.exists(fileName2));
         assertTrue(w.exists(dirName3));
 
-        if (workingArea.git instanceof CliGitAPIImpl || !isWindows()) {
-            // JGit 5.4.0 on Windows throws exception trying to clean submodule
-            w.git.clean(true);
-            assertFalse(w.exists(dirName3));
-        }
-
+        w.git.clean(true);
+        assertFalse(w.exists(dirName3));
     }
 
     @Issue({"JENKINS-20410", "JENKINS-27910", "JENKINS-22434"})


### PR DESCRIPTION
## Remove JGit special case, works as expected with current JGit

Works on my Windows computer in JGit 5.10.0

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Tests
