### PR TITLE
[JENKINS-64913] Label private key files on SELinux

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2184,7 +2184,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             w.println("cat " + unixArgEncodeFileName(passphrase.getAbsolutePath()));
         }
         ssh.setExecutable(true, true);
-        fixSELinuxLabel(ssh, "ssh_exec_t");
+        // fixSELinuxLabel(ssh, "ssh_exec_t");
         return ssh;
     }
 
@@ -2209,7 +2209,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             w.println("esac");
         }
         askpass.setExecutable(true, true);
-        fixSELinuxLabel(askpass, "ssh_exec_t");
+        // fixSELinuxLabel(askpass, "ssh_exec_t");
         return askpass;
     }
 
@@ -2394,17 +2394,18 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             w.println("ssh -i \"" + key.getAbsolutePath() + "\" -l \"" + user + "\" -o StrictHostKeyChecking=no \"$@\"");
         }
         ssh.setExecutable(true, true);
-        fixSELinuxLabel(ssh, "ssh_exec_t");
         //JENKINS-48258 git client plugin occasionally fails with "text file busy" error
         //The following creates a copy of the generated file and deletes the original
         //In case of a failure return the original and delete the copy
         String fromLocation = ssh.toString();
         String toLocation = ssh_copy.toString();
         //Copying ssh file
+        // fixSELinuxLabel(ssh, "ssh_exec_t");
         try {
             new ProcessBuilder("cp", fromLocation, toLocation).start().waitFor();
             isCopied = true;
             ssh_copy.setExecutable(true,true);
+            // fixSELinuxLabel(ssh_copy, "ssh_exec_t");
             //Deleting original file
             deleteTempFile(ssh);
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2394,7 +2394,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             w.println("ssh -i \"" + key.getAbsolutePath() + "\" -l \"" + user + "\" -o StrictHostKeyChecking=no \"$@\"");
         }
         ssh.setExecutable(true, true);
-        fixSELinuxLabel(key, "ssh_exec_t");
+        fixSELinuxLabel(ssh, "ssh_exec_t");
         //JENKINS-48258 git client plugin occasionally fails with "text file busy" error
         //The following creates a copy of the generated file and deletes the original
         //In case of a failure return the original and delete the copy

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2086,9 +2086,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 args.add("--type=ssh_home_t");
                 args.add(key.getPath());
                 Launcher.ProcStarter p = launcher.launch().cmds(args.toCommandArray());
-                int status;
-                String stdout;
-                String stderr;
+                int status = -1;
+                String stdout = "";
+                String stderr = "";
                 String command = gitExe + " " + StringUtils.join(args.toCommandArray(), " ");
 
                 try {
@@ -2105,6 +2105,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     stderr = stderrStream.toString(encoding);
                 } catch (Throwable e) {
                     listener.getLogger().println("Error performing chcon helper command: " + command + " :\n" + e.toString());
+                }
+                if (status > 0) {
+                    listener.getLogger().println("[WARNING] Failed (" + status + ") performing chcon helper command: " + command + ":\n" +
+                        (stdout.equals("") ? "" : ( "=== STDOUT:\n" + stdout + "\n====\n" )) +
+                        (stderr.equals("") ? "" : ( "=== STDERR:\n" + stderr + "\n====\n" )) +
+                        "IMPACT: if SELinux is enabled, access to temporary key file may be denied for git+ssh below");
                 }
             }
         } else {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2061,6 +2061,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
     }
 
+    @SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME",
+        justification = "Path operations below intentionally use absolute '/usr/bin/chcon' at this time (as delivered in relevant popular Linux distros)"
+        )
     private File createSshKeyFile(SSHUserPrivateKey sshUser) throws IOException, InterruptedException {
         File key = createTempFile("ssh", ".key");
         try (PrintWriter w = new PrintWriter(key, encoding)) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2074,7 +2074,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             // (uname, PATH leading to "chcon", etc)?
             ArgumentListBuilder args = new ArgumentListBuilder();
             args.add("/usr/bin/chcon");
-            args.add("-R");
             args.add("--type=" + label);
             args.add(key.getPath());
             Launcher.ProcStarter p = launcher.launch().cmds(args.toCommandArray());


### PR DESCRIPTION
## [JENKINS-64913](https://issues.jenkins-ci.org/browse/JENKINS-64913) - SSH on SELinux enforced systems does not trust unlabeled key files

As detailed in the JIRA ticket, on modern Linux systems which do activate SELinux used as Jenkins controller or build agents, it refuses to check out over git+ssh in setups that work otherwise when SELinux is not enforced. This PR explores active labeling of the temporary private key file so the ssh client would not refuse to read it on such systems.

At least initially, no unit tests are added because hitting this situation requires that a testing system is a modern Linux where `root` (human admin or their distro maintainer) ran `setenforce 1` and possibly other configuration activities.

The trigger for added logic is existence of `/usr/bin/chcon` (hardcoded at the moment, per common Linux distros I could look at), and it should be an inexpensive operation - useless but harmless if SELinux is not currently active on the box (which is something that can be toggled at run-time externally to Jenkins).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

The change is not very big, but rather complicated research led to it. It is detailed in the [JIRA ticket](https://issues.jenkins-ci.org/browse/JENKINS-64913).