### PR TITLE
Migrating Tests From JUnit 3 (GitAPITesCase) to JUnit 4 (GitAPITest)

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -12,6 +12,7 @@ import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 import org.junit.Before;
@@ -1341,6 +1342,22 @@ public class GitAPITest {
 
         workspace.launchCommand("git", "tag", "-m", "test2", "t2");
         assertThat(workspace.launchCommand("git", "describe").trim(), sharesPrefix(testGitClient.describe("HEAD")));
+    }
+
+    @Test
+    public void testRevListTag() throws Exception {
+        workspace.commitEmpty("c1");
+        FileRepository repo = new FileRepository(new File(testGitDir, ".git"));
+        Ref commitRefC1 = repo.exactRef("HEAD");
+        workspace.tag("t1");
+        Ref tagRefT1 = repo.findRef("t1");
+        Ref head = repo.exactRef("HEAD");
+        assertEquals("head != t1", head.getObjectId(), tagRefT1.getObjectId());
+        workspace.commitEmpty("c2");
+        Ref commitRef2 = repo.exactRef("HEAD");
+        List<ObjectId> revList = testGitClient.revList("t1");
+        assertTrue("c1 not in revList", revList.contains(commitRefC1.getObjectId()));
+        assertEquals("wring list size: " + revList, 1, revList.size());
     }
 
     private void initializeWorkspace(WorkspaceWithRepo initWorkspace) throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -7,6 +7,7 @@ import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
 import hudson.util.StreamTaskListener;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.lib.Config;
@@ -15,6 +16,7 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -146,6 +148,87 @@ public class GitAPITest {
         testGitDir = workspace.getGitFileDir();
         cliGitCommand = workspace.getCliGitCommand();
         initializeWorkspace(workspace);
+    }
+
+    @After
+    public void afterTearDown() throws Exception {
+        try {
+            String messages = StringUtils.join(handler.getMessages(), ";");
+            assertTrue("Logging not started: " + messages, handler.containsMessageSubstring(LOGGING_STARTED));
+            assertCheckoutTimeout();
+            assertCloneTimeout();
+            assertFetchTimeout();
+            assertSubmoduleUpdateTimeout();
+            assertRevParseCalls(revParseBranchName);
+        } finally {
+            handler.close();
+        }
+    }
+
+    private void assertCheckoutTimeout() {
+        if (checkoutTimeout > 0) {
+            assertSubstringTimeout("git checkout", checkoutTimeout);
+        }
+    }
+
+    private void assertCloneTimeout() {
+        if (cloneTimeout > 0) {
+            // clone_() uses "git fetch" internally, not "git clone"
+            assertSubstringTimeout("git fetch", cloneTimeout);
+        }
+    }
+
+    private void assertFetchTimeout() {
+        if (fetchTimeout > 0) {
+            assertSubstringTimeout("git fetch", fetchTimeout);
+        }
+    }
+
+    private void assertSubmoduleUpdateTimeout() {
+        if (submoduleUpdateTimeout > 0) {
+            assertSubstringTimeout("git submodule update", submoduleUpdateTimeout);
+        }
+    }
+
+    private void assertSubstringTimeout(final String substring, int expectedTimeout) {
+        if (!(testGitClient instanceof CliGitAPIImpl)) { // Timeout only implemented in CliGitAPIImpl
+            return;
+        }
+        List<String> messages = handler.getMessages();
+        List<String> substringMessages = new ArrayList<>();
+        List<String> substringTimeoutMessages = new ArrayList<>();
+        final String messageRegEx = ".*\\b" + substring + "\\b.*"; // the expected substring
+        final String timeoutRegEx = messageRegEx
+                + " [#] timeout=" + expectedTimeout + "\\b.*"; // # timeout=<value>
+        for (String message : messages) {
+            if (message.matches(messageRegEx)) {
+                substringMessages.add(message);
+            }
+            if (message.matches(timeoutRegEx)) {
+                substringTimeoutMessages.add(message);
+            }
+        }
+        assertThat(messages, is(not(empty())));
+        assertThat(substringMessages, is(not(empty())));
+        assertThat(substringTimeoutMessages, is(not(empty())));
+        assertEquals(substringMessages, substringTimeoutMessages);
+    }
+
+    /* JENKINS-33258 detected many calls to git rev-parse. This checks
+     * those calls are not being made. The createRevParseBranch call
+     * creates a branch whose name is unknown to the tests. This
+     * checks that the branch name is not mentioned in a call to
+     * git rev-parse.
+     */
+    private void assertRevParseCalls(String branchName) {
+        if (revParseBranchName == null) {
+            return;
+        }
+        String messages = StringUtils.join(handler.getMessages(), ";");
+        // Linux uses rev-parse without quotes
+        assertFalse("git rev-parse called: " + messages, handler.containsMessageSubstring("rev-parse " + branchName));
+        // Windows quotes the rev-parse argument
+        assertFalse("git rev-parse called: " + messages, handler.containsMessageSubstring("rev-parse \"" + branchName));
     }
 
     private Collection<String> getBranchNames(Collection<Branch> branches) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -1360,6 +1360,15 @@ public class GitAPITest {
         assertEquals("wring list size: " + revList, 1, revList.size());
     }
 
+    @Test
+    public void testRevListLocalBranch() throws Exception {
+        workspace.commitEmpty("c1");
+        workspace.tag("t1");
+        workspace.commitEmpty("c2");
+        List<ObjectId> revList = testGitClient.revList("master");
+        assertEquals("Wrong list size: " + revList, 2, revList.size());
+    }
+
     private void initializeWorkspace(WorkspaceWithRepo initWorkspace) throws Exception {
         final GitClient initGitClient = initWorkspace.getGitClient();
         final CliGitCommand initCliGitCommand = initWorkspace.getCliGitCommand();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -1369,6 +1369,21 @@ public class GitAPITest {
         assertEquals("Wrong list size: " + revList, 2, revList.size());
     }
 
+    @Issue("JENKINS-20153")
+    @Test
+    public void testCheckOutBranchNull() throws Exception {
+        workspace.commitEmpty("c1");
+        String sha1 = testGitClient.revParse("HEAD").name();
+        workspace.commitEmpty("c2");
+
+        testGitClient.checkoutBranch(null, sha1);
+
+        assertEquals(workspace.head(), testGitClient.revParse(sha1));
+
+        Ref head = new FileRepository(new File(testGitDir, ".git")).exactRef("HEAD");
+        assertFalse(head.isSymbolic());
+    }
+
     private void initializeWorkspace(WorkspaceWithRepo initWorkspace) throws Exception {
         final GitClient initGitClient = initWorkspace.getGitClient();
         final CliGitCommand initCliGitCommand = initWorkspace.getCliGitCommand();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2212,15 +2212,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue("origin/1.4.x not in revList", revList.contains(branchRef.getObjectId()));
     }
 
-    public void test_revList_local_branch() throws Exception {
-        w.init();
-        w.commitEmpty("c1");
-        w.tag("t1");
-        w.commitEmpty("c2");
-        List<ObjectId> revList = w.git.revList("master");
-        assertEquals("Wrong list size: " + revList, 2, revList.size());
-    }
-
     @Issue("JENKINS-20153")
     public void test_checkoutBranch_null() throws Exception {
         w.init();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2212,21 +2212,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue("origin/1.4.x not in revList", revList.contains(branchRef.getObjectId()));
     }
 
-    @Issue("JENKINS-20153")
-    public void test_checkoutBranch_null() throws Exception {
-        w.init();
-        w.commitEmpty("c1");
-        String sha1 = w.git.revParse("HEAD").name();
-        w.commitEmpty("c2");
-
-        w.git.checkoutBranch(null, sha1);
-
-        assertEquals(w.head(),w.git.revParse(sha1));
-
-        Ref head = w.repo().exactRef("HEAD");
-        assertFalse(head.isSymbolic());
-    }
-
     private String formatBranches(List<Branch> branches) {
         Set<String> names = new TreeSet<>();
         for (Branch b : branches) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2220,28 +2220,6 @@ public abstract class GitAPITestCase extends TestCase {
         return Util.join(names,",");
     }
 
-    @Issue("JENKINS-18988")
-    public void test_localCheckoutConflict() throws Exception {
-        w.init();
-        w.touch("foo","old");
-        w.git.add("foo");
-        w.git.commit("c1");
-        w.tag("t1");
-
-        // delete the file from git
-        w.launchCommand("git", "rm", "foo");
-        w.git.commit("c2");
-        assertFalse(w.file("foo").exists());
-
-        // now create an untracked local file
-        w.touch("foo","new");
-
-        // this should overwrite foo
-        w.git.checkout().ref("t1").execute();
-
-        assertEquals("old",FileUtils.readFileToString(w.file("foo")));
-    }
-
     /* The less critical assertions do not respond the same for the
      * JGit and the CliGit implementation. They are implemented here
      * so that the current behavior is described in tests and can be

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -2212,21 +2212,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue("origin/1.4.x not in revList", revList.contains(branchRef.getObjectId()));
     }
 
-    public void test_revList_tag() throws Exception {
-        w.init();
-        w.commitEmpty("c1");
-        Ref commitRefC1 = w.repo().exactRef("HEAD");
-        w.tag("t1");
-        Ref tagRefT1 = w.repo().findRef("t1");
-        Ref head = w.repo().exactRef("HEAD");
-        assertEquals("head != t1", head.getObjectId(), tagRefT1.getObjectId());
-        w.commitEmpty("c2");
-        Ref commitRefC2 = w.repo().exactRef("HEAD");
-        List<ObjectId> revList = w.git.revList("t1");
-        assertTrue("c1 not in revList", revList.contains(commitRefC1.getObjectId()));
-        assertEquals("Wrong list size: " + revList, 1, revList.size());
-    }
-
     public void test_revList_local_branch() throws Exception {
         w.init();
         w.commitEmpty("c1");


### PR DESCRIPTION
## [JENKINS-60940](https://issues.jenkins-ci.org/browse/JENKINS-60940) - Migrating Tests From JUnit 3 (GitAPITesCase) to JUnit 4 (GitAPITest)

Tests Migrated in this PR:
- RevList Tag
- RevList Local Branch
- Checkout Branch Null

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Tests (non-breaking change which updates dependencies or improves infrastructure)
