### PR TITLE
Require Jenkins 2.249.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,14 +19,16 @@ It can fetch, checkout, branch, list, merge, and tag repositories.
 Refer to the https://javadoc.jenkins-ci.org/plugin/git-client/[API documentation] for specific API details.
 
 The https://javadoc.jenkins-ci.org/plugin/git-client/org/jenkinsci/plugins/gitclient/GitClient.html[GitClient interface] provides the primary entry points for git access.
-It supports username / password credentials and private key credentials using the https://plugins.jenkins.io/credentials[Jenkins credentials plugin].
+It supports username / password credentials for git repository access with HTTP and HTTPS protocols (for example, `+https://github.com/jenkinsci/git-client-plugin+` or `+http://git.example.com/your-repo.git+` ).
+It supports private key credentials for git repository access with SSH protocol (for example, `+git@github.com:jenkinsci/git-client-plugin.git+` or `+ssh://git@github.com/jenkinsci/git-client-plugin.git+` ).
+Credential support is provided by the https://plugins.jenkins.io/credentials[Jenkins credentials plugin].
 
 toc::[]
 
 [#changelog]
 == Changelog in https://github.com/jenkinsci/git-client-plugin/releases[GitHub Releases]
 
-Release notes are recorded in https://github.com/jenkinsci/git-client-plugin/releases[GitHub] beginning with git client plugin 2.8.1.
+Release notes have been recorded in https://github.com/jenkinsci/git-client-plugin/releases[GitHub] since git client plugin 2.8.1.
 Prior release notes are recorded in the git client plugin repository link:CHANGELOG.adoc#changelog-moved-to-github-releases[change log].
 
 [#implementations]
@@ -41,8 +43,7 @@ Command line git is *enabled by default* when the git client plugin is installed
 [#jgit]
 === JGit
 
-The git client plugin also includes two optional implementations that use https://www.eclipse.org/jgit/[Eclipse JGit].
-Eclipse JGit is a pure Java implementation of git.
+The git client plugin also includes two optional implementations ("jgit" and <<jgit-with-apache-http-client,"jgitapache">>) that use https://www.eclipse.org/jgit/[Eclipse JGit], a pure Java implementation of git.
 The JGit implementation in the git client plugin provides most of the functionality of the command line git implementation.
 When the JGit implementation is incomplete, the gap is noted in console logs.
 
@@ -93,6 +94,7 @@ It is best to disable Windows Credentials Manager when installing Git on Jenkins
 == Bug Reports
 
 Report issues and enhancements with the https://issues.jenkins-ci.org[Jenkins issue tracker].
+Please use the link:https://www.jenkins.io/participate/report-issue/["How to Report an Issue"] guidelines when reporting issues.
 
 [#contributing-to-the-plugin]
 == Contributing to the Plugin

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
     <jenkins.version>2.222.4</jenkins.version> <!-- Required for git plugin 4.5.0 -->
     <java.level>8</java.level>
     <jgit.version>5.10.0.202012080955-r</jgit.version>
-    <slf4jVersion>1.7.26</slf4jVersion>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>Medium</spotbugs.threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,6 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.2.0</version>
         <dependencies>
           <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.222.4</jenkins.version> <!-- Required for git plugin 4.5.0 -->
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
     <jgit.version>5.10.0.202012080955-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
@@ -69,7 +69,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
+        <artifactId>bom-2.249.x</artifactId>
         <version>25</version>
         <type>pom</type>
         <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </scm>
 
   <properties>
-    <revision>3.6.1</revision>
+    <revision>3.7.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>


### PR DESCRIPTION
## Require Jenkins 2.249.1 as minimum Jenkins version

Jenkins 2.249.1 is a recommended Jenkins base version.  More and more plugins are requiring it as a minimum version.

- Require Jenkins 2.249.1 as minimum version
- Use 3.7.0 as plugin base version
- Improve README for credentials, issue reporting, more
- Rely on spotbugs plugin version from parent pom
- Remove unused slf4jVersion property

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
