### PR TITLE
Cleanup getInstance() references

### DIFF
--- a/src/main/java/hudson/plugins/git/GitTool.java
+++ b/src/main/java/hudson/plugins/git/GitTool.java
@@ -78,7 +78,7 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
      * @return default installation
      */
     public static GitTool getDefaultInstallation() {
-        Jenkins jenkinsInstance = Jenkins.getInstance();
+        Jenkins jenkinsInstance = Jenkins.get();
         DescriptorImpl gitTools = jenkinsInstance.getDescriptorByType(GitTool.DescriptorImpl.class);
         GitTool tool = gitTools.getInstallation(GitTool.DEFAULT);
         if (tool != null) {
@@ -104,7 +104,7 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
 
     @Override
     public DescriptorImpl getDescriptor() {
-        Jenkins jenkinsInstance = Jenkins.getInstance();
+        Jenkins jenkinsInstance = Jenkins.getInstanceOrNull();
         if (jenkinsInstance == null) {
             /* Throw AssertionError exception to match behavior of Jenkins.getDescriptorOrDie */
             throw new AssertionError("No Jenkins instance");
@@ -116,7 +116,7 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
     public static void onLoaded() {
         //Creates default tool installation if needed. Uses "git" or migrates data from previous versions
 
-        Jenkins jenkinsInstance = Jenkins.getInstance();
+        Jenkins jenkinsInstance = Jenkins.get();
         DescriptorImpl descriptor = (DescriptorImpl) jenkinsInstance.getDescriptor(GitTool.class);
         GitTool[] installations = getInstallations(descriptor);
 
@@ -154,7 +154,7 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
 
         @RequirePOST
         public FormValidation doCheckHome(@QueryParameter File value) {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             String path = value.getPath();
 
             return FormValidation.validateExecutable(path);
@@ -186,7 +186,7 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
         @SuppressWarnings("unchecked")
         public List<ToolDescriptor<? extends GitTool>> getApplicableDescriptors() {
             List<ToolDescriptor<? extends GitTool>> r = new ArrayList<>();
-            Jenkins jenkinsInstance = Jenkins.getInstance();
+            Jenkins jenkinsInstance = Jenkins.get();
             for (ToolDescriptor<?> td : jenkinsInstance.<ToolInstallation,ToolDescriptor<?>>getDescriptorList(ToolInstallation.class)) {
                 if (GitTool.class.isAssignableFrom(td.clazz)) { // This checks cast is allowed
                     r.add((ToolDescriptor<? extends GitTool>)td); // This is the unchecked cast

--- a/src/main/java/org/jenkinsci/plugins/gitclient/Git.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/Git.java
@@ -119,7 +119,7 @@ public class Git implements Serializable {
     public GitClient getClient() throws IOException, InterruptedException {
         jenkins.MasterToSlaveFileCallable<GitClient> callable = new GitAPIMasterToSlaveFileCallable();
         GitClient git = (repository!=null ? repository.act(callable) : callable.invoke(null,null));
-        Jenkins jenkinsInstance = Jenkins.getInstance();
+        Jenkins jenkinsInstance = Jenkins.getInstanceOrNull();
         if (jenkinsInstance != null && git != null)
             git.setProxy(jenkinsInstance.proxy);
         return git;


### PR DESCRIPTION
## Cleanup getInstance() references

Replace `Jenkins.getInstance()` with either `Jenkins.get()` or other appropriate non-deprecated replacement.

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [X] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [x] Bug fix (non-breaking change which fixes an issue)

@MarkEWaite 
