### PR TITLE
Migrating Tests From JUnit 3 (GitAPITesCase) to JUnit 4 (GitAPITest)

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITesJGITNotInitialized.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITesJGITNotInitialized.java
@@ -1,0 +1,214 @@
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.IGitAPI;
+import hudson.util.StreamTaskListener;
+import org.apache.commons.lang.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@RunWith(Parameterized.class)
+public class GitAPITesJGITNotInitialized {
+    @Rule
+    public GitClientSampleRepoRule repo = new GitClientSampleRepoRule();
+
+    @Rule
+    public GitClientSampleRepoRule secondRepo = new GitClientSampleRepoRule();
+
+    @Rule
+    public GitClientSampleRepoRule thirdRepo = new GitClientSampleRepoRule();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private int logCount = 0;
+    private final Random random = new Random();
+    private static final String LOGGING_STARTED = "Logging started";
+    private LogHandler handler = null;
+    private TaskListener listener;
+    private final String gitImplName;
+
+    private String revParseBranchName = null;
+
+    private int checkoutTimeout = -1;
+    private int cloneTimeout = -1;
+    private int fetchTimeout = -1;
+    private int submoduleUpdateTimeout = -1;
+
+
+    WorkspaceWithRepo workspace;
+
+    private GitClient testGitClient;
+    private File testGitDir;
+    private CliGitCommand cliGitCommand;
+
+    public GitAPITesJGITNotInitialized(final String gitImplName) { this.gitImplName = gitImplName; }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection gitObjects() {
+        List<Object[]> arguments = new ArrayList<>();
+        String[] gitImplNames = {"jgit", "jgitapache"};
+        for (String gitImplName : gitImplNames) {
+            Object[] item = {gitImplName};
+            arguments.add(item);
+        }
+        return arguments;
+    }
+
+    @BeforeClass
+    public static void loadLocalMirror() throws Exception {
+        /* Prime the local mirror cache before other tests run */
+        /* Allow 2-5 second delay before priming the cache */
+        /* Allow other tests a better chance to prime the cache */
+        /* 2-5 second delay is small compared to execution time of this test */
+        Random random = new Random();
+        Thread.sleep((2 + random.nextInt(4)) * 1000L); // Wait 2-5 seconds before priming the cache
+        TaskListener mirrorListener = StreamTaskListener.fromStdout();
+        File tempDir = Files.createTempDirectory("PrimeGITAPITest").toFile();
+        WorkspaceWithRepo cache = new WorkspaceWithRepo(tempDir, "git", mirrorListener);
+        cache.localMirror();
+        Util.deleteRecursive(tempDir);
+    }
+
+    @Before
+    public void setUpRepositories() throws Exception {
+        revParseBranchName = null;
+        checkoutTimeout = -1;
+        cloneTimeout = -1;
+        fetchTimeout = -1;
+        submoduleUpdateTimeout = -1;
+
+        Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);
+        handler = new LogHandler();
+        handler.setLevel(Level.ALL);
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        logger.setLevel(Level.ALL);
+        listener = new hudson.util.LogTaskListener(logger, Level.ALL);
+        listener.getLogger().println(LOGGING_STARTED);
+
+        workspace = new WorkspaceWithRepo(repo.getRoot(), gitImplName, listener);
+
+        testGitClient = workspace.getGitClient();
+        testGitDir = workspace.getGitFileDir();
+        cliGitCommand = workspace.getCliGitCommand();
+    }
+
+    @After
+    public void afterTearDown() throws Exception {
+        try {
+            String messages = StringUtils.join(handler.getMessages(), ";");
+            assertTrue("Logging not started: " + messages, handler.containsMessageSubstring(LOGGING_STARTED));
+            assertCheckoutTimeout();
+            assertCloneTimeout();
+            assertFetchTimeout();
+            assertSubmoduleUpdateTimeout();
+            assertRevParseCalls(revParseBranchName);
+        } finally {
+            handler.close();
+        }
+    }
+
+    private void assertCheckoutTimeout() {
+        if (checkoutTimeout > 0) {
+            assertSubstringTimeout("git checkout", checkoutTimeout);
+        }
+    }
+
+    private void assertCloneTimeout() {
+        if (cloneTimeout > 0) {
+            // clone_() uses "git fetch" internally, not "git clone"
+            assertSubstringTimeout("git fetch", cloneTimeout);
+        }
+    }
+
+    private void assertFetchTimeout() {
+        if (fetchTimeout > 0) {
+            assertSubstringTimeout("git fetch", fetchTimeout);
+        }
+    }
+
+    private void assertSubmoduleUpdateTimeout() {
+        if (submoduleUpdateTimeout > 0) {
+            assertSubstringTimeout("git submodule update", submoduleUpdateTimeout);
+        }
+    }
+
+    private void assertSubstringTimeout(final String substring, int expectedTimeout) {
+        if (!(testGitClient instanceof CliGitAPIImpl)) { // Timeout only implemented in CliGitAPIImpl
+            return;
+        }
+        List<String> messages = handler.getMessages();
+        List<String> substringMessages = new ArrayList<>();
+        List<String> substringTimeoutMessages = new ArrayList<>();
+        final String messageRegEx = ".*\\b" + substring + "\\b.*"; // the expected substring
+        final String timeoutRegEx = messageRegEx
+                + " [#] timeout=" + expectedTimeout + "\\b.*"; // # timeout=<value>
+        for (String message : messages) {
+            if (message.matches(messageRegEx)) {
+                substringMessages.add(message);
+            }
+            if (message.matches(timeoutRegEx)) {
+                substringTimeoutMessages.add(message);
+            }
+        }
+        assertThat(messages, is(not(empty())));
+        assertThat(substringMessages, is(not(empty())));
+        assertThat(substringTimeoutMessages, is(not(empty())));
+        assertEquals(substringMessages, substringTimeoutMessages);
+    }
+
+    /* JENKINS-33258 detected many calls to git rev-parse. This checks
+     * those calls are not being made. The createRevParseBranch call
+     * creates a branch whose name is unknown to the tests. This
+     * checks that the branch name is not mentioned in a call to
+     * git rev-parse.
+     */
+    private void assertRevParseCalls(String branchName) {
+        if (revParseBranchName == null) {
+            return;
+        }
+        String messages = StringUtils.join(handler.getMessages(), ";");
+        // Linux uses rev-parse without quotes
+        assertFalse("git rev-parse called: " + messages, handler.containsMessageSubstring("rev-parse " + branchName));
+        // Windows quotes the rev-parse argument
+        assertFalse("git rev-parse called: " + messages, handler.containsMessageSubstring("rev-parse \"" + branchName));
+    }
+
+    @Test
+    public void testGetSubmoduleUrl() throws Exception {
+        workspace.cloneRepo(workspace, workspace.localMirror());
+        workspace.launchCommand("git", "checkout", "tests/getSubmodules");
+        testGitClient.submoduleInit();
+
+        IGitAPI igit = (IGitAPI) testGitClient;
+        assertEquals("https://github.com/puppetlabs/puppetlabs-firewall.git", igit.getSubmoduleUrl("modules/firewall"));
+
+        thrown.expect(GitException.class);
+        igit.getSubmoduleUrl("bogus");
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -816,13 +816,9 @@ public class GitAPITest {
     @Test
     public void testRevparseThrowsExpectedException() throws Exception {
         workspace.commitEmpty("init");
-        try {
-            testGitClient.revParse("unknown-rev-to-parse");
-            fail("Did not throw exception");
-        } catch (GitException ge) {
-            final String msg = ge.getMessage();
-            assertTrue("Wrong exception: " + msg, msg.contains("unknown-rev-to-parse"));
-        }
+        thrown.expect(GitException.class);
+        thrown.expectMessage("unknown-to-rev-parse");
+        testGitClient.revParse("unknown-to-rev-parse");
     }
 
     @Test
@@ -1006,12 +1002,9 @@ public class GitAPITest {
         workspace.touch(testGitDir, "file", "content2");
         testGitClient.add("file");
         testGitClient.commit("commit2");
-        try {
-            testGitClient.merge().setStrategy(MergeCommand.Strategy.RESOLVE).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch1")).execute();
-            fail();
-        } catch (GitException ge) {
-            //expected
-        }
+
+        thrown.expect(GitException.class);
+        testGitClient.merge().setStrategy(MergeCommand.Strategy.RESOLVE).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch1")).execute();
     }
 
     @Issue("JENKINS-12402")

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -890,23 +890,6 @@ public abstract class GitAPITestCase extends TestCase {
         }
     }
 
-    /* Opening a git repository in a directory with a symbolic git file instead
-     * of a git directory should function properly.
-     */
-    public void test_with_repository_works_with_submodule() throws Exception {
-        w = clone(localMirror());
-        assertSubmoduleDirs(w.repo, false, false);
-
-        /* Checkout a branch which includes submodules (in modules directory) */
-        String subBranch = w.git instanceof CliGitAPIImpl ? "tests/getSubmodules" : "tests/getSubmodules-jgit";
-        String subRefName = "origin/" + subBranch;
-        w.git.checkout().ref(subRefName).branch(subBranch).execute();
-        w.git.submoduleInit();
-        w.git.submoduleUpdate().recursive(true).execute();
-        assertSubmoduleRepository(new File(w.repo, "modules/ntp"));
-        assertSubmoduleRepository(new File(w.repo, "modules/firewall"));
-    }
-
     private void assertSubmoduleRepository(File submoduleDir) throws Exception {
         /* Get a client directly on the submoduleDir */
         GitClient submoduleClient = setupGitAPI(submoduleDir);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -652,38 +652,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals("Working SHA1 != bare SHA1", workHead2, bareHead2);
         assertEquals("Working SHA1 != bare SHA1", w.git.getHeadRev(w.repoPath(), "master"), bare.git.getHeadRev(bare.repoPath(), "master"));
     }
-
-    @NotImplementedInJGit
-    public void test_push_from_shallow_clone() throws Exception {
-        WorkingArea r = new WorkingArea();
-        r.init();
-        r.commitEmpty("init");
-        r.touch("file1");
-        r.git.add("file1");
-        r.git.commit("commit1");
-        r.launchCommand("git", "checkout", "-b", "other");
-
-        w.init();
-        w.launchCommand("git", "remote", "add", "origin", r.repoPath());
-        w.launchCommand("git", "pull", "--depth=1", "origin", "master");
-
-        w.touch("file2");
-        w.git.add("file2");
-        w.git.commit("commit2");
-        ObjectId sha1 = w.head();
-
-        try {
-            w.git.push("origin", "master");
-            assertTrue("git < 1.9.0 can push from shallow repository", w.cgit().isAtLeastVersion(1, 9, 0, 0));
-            String remoteSha1 = r.launchCommand("git", "rev-parse", "master").substring(0, 40);
-            assertEquals(sha1.name(), remoteSha1);
-        } catch (GitException e) {
-            // expected for git cli < 1.9.0
-            assertExceptionMessageContains(e, "push from shallow repository");
-            assertFalse("git >= 1.9.0 can't push from shallow repository", w.cgit().isAtLeastVersion(1, 9, 0, 0));
-        }
-    }
-
+    
     /**
      * Command line git clean as implemented in CliGitAPIImpl does not remove
      * untracked submodules or files contained in untracked submodule dirs.
@@ -919,29 +888,6 @@ public abstract class GitAPITestCase extends TestCase {
             assertSubmoduleDirs(w.repo, true, true);
             assertSubmoduleContents(w.repo);
         }
-    }
-
-    /* Submodule checkout in JGit does not support renamed submodules.
-     * The test branch intentionally includes a renamed submodule, so this test
-     * is not run with JGit.
-     */
-    @NotImplementedInJGit
-    public void test_submodule_checkout_simple() throws Exception {
-        w = clone(localMirror());
-        assertSubmoduleDirs(w.repo, false, false);
-
-        /* Checkout a branch which includes submodules (in modules directory) */
-        String subBranch = "tests/getSubmodules";
-        String subRefName = "origin/" + subBranch;
-        w.git.checkout().ref(subRefName).branch(subBranch).execute();
-        assertSubmoduleDirs(w.repo, true, false);
-
-        w.git.submoduleUpdate().recursive(true).execute();
-        assertSubmoduleDirs(w.repo, true, true);
-        assertSubmoduleContents(w.repo);
-        assertSubmoduleRepository(new File(w.repo, "modules/ntp"));
-        assertSubmoduleRepository(new File(w.repo, "modules/firewall"));
-        assertSubmoduleRepository(new File(w.repo, "modules/sshkeys"));
     }
 
     /* Opening a git repository in a directory with a symbolic git file instead

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1415,24 +1415,6 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals(expected, symlinkValue);
     }
 
-
-
-    @NotImplementedInCliGit // Until submodule rename is fixed
-    public void test_getSubmoduleUrl() throws Exception {
-        w = clone(localMirror());
-        w.launchCommand("git", "checkout", "tests/getSubmodules");
-        w.git.submoduleInit();
-
-        assertEquals("https://github.com/puppetlabs/puppetlabs-firewall.git", w.igit().getSubmoduleUrl("modules/firewall"));
-
-        try {
-            w.igit().getSubmoduleUrl("bogus");
-            fail();
-        } catch (GitException e) {
-            // expected
-        }
-    }
-
     @Deprecated
     public void test_merge_refspec() throws Exception {
         w.init();
@@ -1495,35 +1477,6 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.setRemoteUrl("origin", remoteUrl);
         assertEquals("Wrong origin default remote", "origin", w.igit().getDefaultRemote("origin"));
         assertEquals("Wrong invalid default remote", "origin", w.igit().getDefaultRemote("invalid"));
-    }
-
-    /**
-     * Checks that the ChangelogCommand abort() API does not write
-     * output to the destination.  Does not check that the abort() API
-     * releases resources.
-     */
-    public void test_changelog_abort() throws InterruptedException, IOException
-    {
-        final String logMessage = "changelog-abort-test-commit";
-        w.init();
-        w.touch("file-changelog-abort", "changelog abort file contents " + java.util.UUID.randomUUID().toString());
-        w.git.add("file-changelog-abort");
-        w.git.commit(logMessage);
-        String sha1 = w.git.revParse("HEAD").name();
-        ChangelogCommand changelogCommand = w.git.changelog();
-        StringWriter writer = new StringWriter();
-        changelogCommand.to(writer);
-
-        /* Abort the changelog, confirm no content was written */
-        changelogCommand.abort();
-        assertEquals("aborted changelog wrote data", "", writer.toString());
-
-        /* Execute the changelog, confirm expected content was written */
-        changelogCommand = w.git.changelog();
-        changelogCommand.to(writer);
-        changelogCommand.execute();
-        assertTrue("No log message in " + writer.toString(), writer.toString().contains(logMessage));
-        assertTrue("No SHA1 in " + writer.toString(), writer.toString().contains(sha1));
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCliGitNotIntialized.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCliGitNotIntialized.java
@@ -1,0 +1,359 @@
+package org.jenkinsci.plugins.gitclient;
+
+import hudson.EnvVars;
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+import hudson.util.StreamTaskListener;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Git API Test which are solely for CLI git,
+ * but doesn't need an initialized working repo.
+ * These tests are not implemented for JGit.
+ */
+
+@RunWith(Parameterized.class)
+public class GitAPITestCliGitNotIntialized {
+    @Rule
+    public GitClientSampleRepoRule repo = new GitClientSampleRepoRule();
+
+    @Rule
+    public GitClientSampleRepoRule secondRepo = new GitClientSampleRepoRule();
+
+    @Rule
+    public GitClientSampleRepoRule thirdRepo = new GitClientSampleRepoRule();
+
+    private int logCount = 0;
+    private final Random random = new Random();
+    private static final String LOGGING_STARTED = "Logging started";
+    private LogHandler handler = null;
+    private TaskListener listener;
+    private final String gitImplName;
+
+    private String revParseBranchName = null;
+
+    private int checkoutTimeout = -1;
+    private int cloneTimeout = -1;
+    private int fetchTimeout = -1;
+    private int submoduleUpdateTimeout = -1;
+
+
+    WorkspaceWithRepo workspace;
+
+    private GitClient testGitClient;
+    private File testGitDir;
+    private CliGitCommand cliGitCommand;
+
+    public GitAPITestCliGitNotIntialized(final String gitImplName) {
+        this.gitImplName = gitImplName;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection gitObjects() {
+        List<Object[]> arguments = new ArrayList<>();
+        String[] gitImplNames = {"git"};
+        for (String gitImplName : gitImplNames) {
+            Object[] item = {gitImplName};
+            arguments.add(item);
+        }
+        return arguments;
+    }
+
+    @BeforeClass
+    public static void loadLocalMirror() throws Exception {
+        /* Prime the local mirror cache before other tests run */
+        /* Allow 2-5 second delay before priming the cache */
+        /* Allow other tests a better chance to prime the cache */
+        /* 2-5 second delay is small compared to execution time of this test */
+        Random random = new Random();
+        Thread.sleep((2 + random.nextInt(4)) * 1000L); // Wait 2-5 seconds before priming the cache
+        TaskListener mirrorListener = StreamTaskListener.fromStdout();
+        File tempDir = Files.createTempDirectory("PrimeGITAPITest").toFile();
+        WorkspaceWithRepo cache = new WorkspaceWithRepo(tempDir, "git", mirrorListener);
+        cache.localMirror();
+        Util.deleteRecursive(tempDir);
+    }
+
+    @Before
+    public void setUpRepositories() throws Exception {
+        revParseBranchName = null;
+        checkoutTimeout = -1;
+        cloneTimeout = -1;
+        fetchTimeout = -1;
+        submoduleUpdateTimeout = -1;
+
+        Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);
+        handler = new LogHandler();
+        handler.setLevel(Level.ALL);
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        logger.setLevel(Level.ALL);
+        listener = new hudson.util.LogTaskListener(logger, Level.ALL);
+        listener.getLogger().println(LOGGING_STARTED);
+
+        workspace = new WorkspaceWithRepo(repo.getRoot(), gitImplName, listener);
+
+        testGitClient = workspace.getGitClient();
+        testGitDir = workspace.getGitFileDir();
+        cliGitCommand = workspace.getCliGitCommand();
+    }
+
+    @After
+    public void afterTearDown() throws Exception {
+        try {
+            String messages = StringUtils.join(handler.getMessages(), ";");
+            assertTrue("Logging not started: " + messages, handler.containsMessageSubstring(LOGGING_STARTED));
+            assertCheckoutTimeout();
+            assertCloneTimeout();
+            assertFetchTimeout();
+            assertSubmoduleUpdateTimeout();
+            assertRevParseCalls(revParseBranchName);
+        } finally {
+            handler.close();
+        }
+    }
+
+    private void assertCheckoutTimeout() {
+        if (checkoutTimeout > 0) {
+            assertSubstringTimeout("git checkout", checkoutTimeout);
+        }
+    }
+
+    private void assertCloneTimeout() {
+        if (cloneTimeout > 0) {
+            // clone_() uses "git fetch" internally, not "git clone"
+            assertSubstringTimeout("git fetch", cloneTimeout);
+        }
+    }
+
+    private void assertFetchTimeout() {
+        if (fetchTimeout > 0) {
+            assertSubstringTimeout("git fetch", fetchTimeout);
+        }
+    }
+
+    private void assertSubmoduleUpdateTimeout() {
+        if (submoduleUpdateTimeout > 0) {
+            assertSubstringTimeout("git submodule update", submoduleUpdateTimeout);
+        }
+    }
+
+    private void assertSubstringTimeout(final String substring, int expectedTimeout) {
+        if (!(testGitClient instanceof CliGitAPIImpl)) { // Timeout only implemented in CliGitAPIImpl
+            return;
+        }
+        List<String> messages = handler.getMessages();
+        List<String> substringMessages = new ArrayList<>();
+        List<String> substringTimeoutMessages = new ArrayList<>();
+        final String messageRegEx = ".*\\b" + substring + "\\b.*"; // the expected substring
+        final String timeoutRegEx = messageRegEx
+                + " [#] timeout=" + expectedTimeout + "\\b.*"; // # timeout=<value>
+        for (String message : messages) {
+            if (message.matches(messageRegEx)) {
+                substringMessages.add(message);
+            }
+            if (message.matches(timeoutRegEx)) {
+                substringTimeoutMessages.add(message);
+            }
+        }
+        assertThat(messages, is(not(empty())));
+        assertThat(substringMessages, is(not(empty())));
+        assertThat(substringTimeoutMessages, is(not(empty())));
+        assertEquals(substringMessages, substringTimeoutMessages);
+    }
+
+    /* JENKINS-33258 detected many calls to git rev-parse. This checks
+     * those calls are not being made. The createRevParseBranch call
+     * creates a branch whose name is unknown to the tests. This
+     * checks that the branch name is not mentioned in a call to
+     * git rev-parse.
+     */
+    private void assertRevParseCalls(String branchName) {
+        if (revParseBranchName == null) {
+            return;
+        }
+        String messages = StringUtils.join(handler.getMessages(), ";");
+        // Linux uses rev-parse without quotes
+        assertFalse("git rev-parse called: " + messages, handler.containsMessageSubstring("rev-parse " + branchName));
+        // Windows quotes the rev-parse argument
+        assertFalse("git rev-parse called: " + messages, handler.containsMessageSubstring("rev-parse \"" + branchName));
+    }
+
+    /* Submodule checkout in JGit does not support renamed submodules.
+     * The test branch intentionally includes a renamed submodule, so this test
+     * is not run with JGit.
+     */
+    @Test
+    public void testSubmoduleCheckoutSimple() throws Exception {
+        workspace.cloneRepo(workspace, workspace.localMirror());
+        assertSubmoduleDirs(testGitDir, false, false);
+
+        /* Checkout a branch which includes submodules (in modules directory) */
+        String subBranch = "tests/getSubmodules";
+        String subRefName = "origin/" + subBranch;
+        testGitClient.checkout().ref(subRefName).branch(subBranch).execute();
+        assertSubmoduleDirs(testGitDir, true, false);
+
+        testGitClient.submoduleUpdate().recursive(true).execute();
+        assertSubmoduleDirs(testGitDir, true, true);
+        assertSubmoduleContents(testGitDir);
+        assertSubmoduleRepository(new File(testGitDir, "modules/ntp"));
+        assertSubmoduleRepository(new File(testGitDir, "modules/firewall"));
+        assertSubmoduleRepository(new File(testGitDir, "modules/sshkeys"));
+    }
+
+    private void assertSubmoduleRepository(File submoduleDir) throws Exception {
+        /* Get a client directly on the submoduleDir */
+        GitClient submoduleClient = setupGitAPI(submoduleDir);
+
+        /* Assert that when we invoke the repository callback it gets a
+         * functioning repository object
+         */
+        submoduleClient.withRepository((final Repository repo, VirtualChannel channel) -> {
+            assertTrue(repo.getDirectory() + " is not a valid repository",
+                    repo.getObjectDatabase().exists());
+            return null;
+        });
+    }
+
+    protected GitClient setupGitAPI(File ws) throws Exception {
+        setCliGitDefaults();
+        return Git.with(listener, new EnvVars()).in(ws).using(gitImplName).getClient();
+    }
+
+    private static boolean cliGitDefaultsSet = false;
+
+    private void setCliGitDefaults() throws Exception {
+        if (!cliGitDefaultsSet) {
+            CliGitCommand gitCmd = new CliGitCommand(null);
+        }
+        cliGitDefaultsSet = true;
+    }
+
+    private void assertSubmoduleContents(File repo) throws IOException {
+        final File modulesDir = new File(repo, "modules");
+
+        final File sshkeysDir = new File(modulesDir, "sshkeys");
+        final File sshkeysModuleFile = new File(sshkeysDir, "Modulefile");
+        assertFileExists(sshkeysModuleFile);
+
+        final File keeperFile = new File(modulesDir, "keeper");
+        final String keeperContent = "";
+        assertFileExists(keeperFile);
+        assertFileContents(keeperFile, keeperContent);
+
+        final File ntpDir = new File(modulesDir, "ntp");
+        final File ntpContributingFile = new File(ntpDir, "CONTRIBUTING.md");
+        final String ntpContributingContent = "Puppet Labs modules on the Puppet Forge are open projects";
+        assertFileExists(ntpContributingFile);
+        assertFileContains(ntpContributingFile, ntpContributingContent); /* Check substring in file */
+    }
+
+    private void assertFileContains(File file, String expectedContent) throws IOException {
+        assertFileExists(file);
+        final String fileContent = FileUtils.readFileToString(file, "UTF-8");
+        final String message = file + " does not contain '" + expectedContent + "', contains '" + fileContent + "'";
+        assertTrue(message, fileContent.contains(expectedContent));
+    }
+
+    private void assertFileContents(File file, String expectedContent) throws IOException {
+        assertFileExists(file);
+        final String fileContent = FileUtils.readFileToString(file, "UTF-8");
+        assertEquals(file + " wrong content", expectedContent, fileContent);
+    }
+
+    private void assertSubmoduleDirs(File repo, boolean dirsShouldExist, boolean filesShouldExist) throws IOException {
+        final File modulesDir = new File(repo, "modules");
+        final File ntpDir = new File(modulesDir, "ntp");
+        final File firewallDir = new File(modulesDir, "firewall");
+        final File keeperFile = new File(modulesDir, "keeper");
+        final File ntpContributingFile = new File(ntpDir, "CONTRIBUTING.md");
+        final File sshkeysDir = new File(modulesDir, "sshkeys");
+        final File sshkeysModuleFile = new File(sshkeysDir, "Modulefile");
+        if (dirsShouldExist) {
+            assertDirExists(modulesDir);
+            assertDirExists(ntpDir);
+            assertDirExists(firewallDir);
+            assertDirExists(sshkeysDir);
+            /* keeperFile is in the submodules branch, but is a plain file */
+            assertFileExists(keeperFile);
+        } else {
+            assertDirNotFound(modulesDir);
+            assertDirNotFound(ntpDir);
+            assertDirNotFound(firewallDir);
+            assertDirNotFound(sshkeysDir);
+            /* keeperFile is in the submodules branch, but is a plain file */
+            assertFileNotFound(keeperFile);
+        }
+        if (filesShouldExist) {
+            assertFileExists(ntpContributingFile);
+            assertFileExists(sshkeysModuleFile);
+        } else {
+            assertFileNotFound(ntpContributingFile);
+            assertFileNotFound(sshkeysModuleFile);
+        }
+    }
+
+    private void assertDirNotFound(File dir) {
+        assertFileNotFound(dir);
+    }
+
+    private void assertFileNotFound(File file) {
+        assertFalse(file + " found, peer files: " + listDir(file.getParentFile()), file.exists());
+    }
+
+    private void assertDirExists(File dir) {
+        assertFileExists(dir);
+        assertTrue(dir + " is not a directory", dir.isDirectory());
+    }
+
+    private void assertFileExists(File file) {
+        assertTrue(file + " not found, peer files: " + listDir(file.getParentFile()), file.exists());
+    }
+
+    private String listDir(File dir) {
+        if (dir == null || !dir.exists()) {
+            return "";
+        }
+        File[] files = dir.listFiles();
+        if (files == null) {
+            return "";
+        }
+        StringBuilder fileList = new StringBuilder();
+        for (File file : files) {
+            fileList.append(file.getName());
+            fileList.append(',');
+        }
+        if (fileList.length() > 0) {
+            fileList.deleteCharAt(fileList.length() - 1);
+        }
+        return fileList.toString();
+    }
+}


### PR DESCRIPTION
## [JENKINS-60940](https://issues.jenkins-ci.org/browse/JENKINS-60940) - Migrating Tests From JUnit 3 (GitAPITesCase) to JUnit 4 (GitAPITest)

Migrated Tests:
- Submodule Checkout Simple
- Repository works with Submodule
- GetSubmoduleURL
- Changelog Abort

Added a new java class GitAPITestJGITNotInitialized, which contains tests for JGIT and JGITApache where a initialized working repository is not needed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Tests (non-breaking change which updates dependencies or improves infrastructure)