### PR TITLE
[JENKINS-38699] Limit CLI git operations to the workspace

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -236,6 +236,12 @@ public class GitAPI extends CliGitAPIImpl {
     }
 
     /** {@inheritDoc} */
+    @Override
+    public boolean hasGitRepo(boolean checkParentDirectories) throws GitException, InterruptedException {
+        return Git.USE_CLI ? super.hasGitRepo(checkParentDirectories) :  jgit.hasGitRepo(checkParentDirectories);
+    }
+
+    /** {@inheritDoc} */
     public boolean isCommitInRepo(ObjectId commit) throws GitException, InterruptedException {
         return Git.USE_CLI ? super.isCommitInRepo(commit) :  jgit.isCommitInRepo(commit);
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -339,9 +339,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     @Override
     public boolean hasGitRepo() throws GitException, InterruptedException {
         if (hasGitRepo(".git")) {
-            // Check if this is a valid git repo with --is-inside-work-tree
+            // Check if this is a valid git repo with --resolve-git-dir
             try {
-                launchCommand("rev-parse", "--is-inside-work-tree");
+                launchCommand("rev-parse", "--resolve-git-dir",workspace.getAbsolutePath()+File.separator+".git");
             } catch (Exception ex) {
                 ex.printStackTrace(listener.error("Workspace has a .git repository, but it appears to be corrupt."));
                 return false;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -341,7 +341,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         if (hasGitRepo(".git")) {
             // Check if this is a valid git repo with --resolve-git-dir
             try {
-                launchCommand("rev-parse", "--resolve-git-dir",workspace.getAbsolutePath()+File.separator+".git");
+                launchCommand("rev-parse", "--resolve-git-dir",
+                        workspace.getAbsolutePath() + File.separator + ".git");
             } catch (Exception ex) {
                 ex.printStackTrace(listener.error("Workspace has a .git repository, but it appears to be corrupt."));
                 return false;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -330,7 +330,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /**
-     * hasGitRepo.
+     * Returns true if the current workspace has a git repository.
      *
      * @return true if this workspace has a git repository
      * @throws hudson.plugins.git.GitException if underlying git operation fails.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -192,6 +192,18 @@ public interface GitClient {
     boolean hasGitRepo() throws GitException, InterruptedException;
 
     /**
+     * Return true if the current workspace has a git repository.
+     * If checkParentDirectories is true, searches parent directories.
+     * If checkParentDirectories is false, checks workspace directory only.
+     *
+     * @param checkParentDirectories if true, search upward for a git repository
+     * @return true if this workspace has a git repository
+     * @throws hudson.plugins.git.GitException if underlying git operation fails.
+     * @throws java.lang.InterruptedException if interrupted.
+     */
+    boolean hasGitRepo(boolean checkParentDirectories) throws GitException, InterruptedException;
+
+    /**
      * isCommitInRepo.
      *
      * @param commit a {@link org.eclipse.jgit.lib.ObjectId} object.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -183,7 +183,7 @@ public interface GitClient {
     void commit(String message, PersonIdent author, PersonIdent committer) throws GitException, InterruptedException;
 
     /**
-     * hasGitRepo.
+     * Return true if the current workspace has a git repository.
      *
      * @return true if this workspace has a git repository
      * @throws hudson.plugins.git.GitException if underlying git operation fails.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1742,20 +1742,20 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         if (!checkParentDirectories) { // JGit hasGitRepo() does not check parent directories
             return hasGitRepo();
         }
-        if (!hasGitRepo(".git")) {
-            return false;
-        }
-        try (Repository repo = getRepository()) {
-            if (repo.getObjectDatabase().exists()) {
-                return true;
+        if (hasGitRepo(".git")) {
+            try (Repository repo = getRepository()) {
+                if (repo.getObjectDatabase().exists()) {
+                    return true;
+                }
+                /* Emulate command line git searching up the file system hierarchy */
+                FileRepositoryBuilder repositoryBuilder = new FileRepositoryBuilder();
+                FileRepositoryBuilder parentRepoBuilder = repositoryBuilder.findGitDir(workspace);
+                return parentRepoBuilder.getGitDir() != null;
+            } catch (GitException e) {
+                return false;
             }
-            /* Emulate command line git searching up the file system hierarchy */
-            FileRepositoryBuilder repositoryBuilder = new FileRepositoryBuilder();
-            FileRepositoryBuilder parentRepoBuilder = repositoryBuilder.findGitDir(workspace);
-            return parentRepoBuilder.getGitDir() != null;
-        } catch (GitException e) {
-            return false;
         }
+        return false;
     }
 
     private boolean hasGitRepo(String gitDirectory) throws GitException {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1746,13 +1746,6 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             return false;
         }
         try (Repository repo = getRepository()) {
-            if (repo.isBare()) {
-                return true;
-            }
-            File dotGitDir = repo.getDirectory();
-            if (dotGitDir == null || !dotGitDir.isDirectory()) {
-                return false;
-            }
             if (repo.getObjectDatabase().exists()) {
                 return true;
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -91,6 +91,7 @@ import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.revwalk.filter.MaxCountRevFilter;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.submodule.SubmoduleWalk;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.FetchConnection;
@@ -121,8 +122,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.plugins.git.GitObject;
 import org.eclipse.jgit.api.RebaseCommand.Operation;
 import org.eclipse.jgit.api.RebaseResult;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * GitClient pure Java implementation using JGit.
@@ -1715,6 +1714,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /**
      * Returns true if the current workspace has a git repository.
+     * Does not search parent directories for a repository.
      *
      * @return true if this workspace has a git repository
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
@@ -1725,6 +1725,55 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             return repo.getObjectDatabase().exists();
         } catch (GitException e) {
             return false;
+        }
+    }
+
+    /**
+     * Returns true if the current workspace has a git repository.
+     * If checkParentDirectories is true, searches parent directories.
+     * If checkParentDirectories is false, checks workspace directory only.
+     *
+     * @param checkParentDirectories if true, search upwards for a git repository
+     * @return true if this workspace has a git repository
+     * @throws hudson.plugins.git.GitException if underlying git operation fails.
+     */
+    @Override
+    public boolean hasGitRepo(boolean checkParentDirectories) throws GitException {
+        if (!checkParentDirectories) { // JGit hasGitRepo() does not check parent directories
+            return hasGitRepo();
+        }
+        if (!hasGitRepo(".git")) {
+            return false;
+        }
+        try (Repository repo = getRepository()) {
+            if (repo.isBare()) {
+                return true;
+            }
+            File dotGitDir = repo.getDirectory();
+            if (dotGitDir == null || !dotGitDir.isDirectory()) {
+                return false;
+            }
+            if (repo.getObjectDatabase().exists()) {
+                return true;
+            }
+            /* Emulate command line git searching up the file system hierarchy */
+            FileRepositoryBuilder repositoryBuilder = new FileRepositoryBuilder();
+            FileRepositoryBuilder parentRepoBuilder = repositoryBuilder.findGitDir(workspace);
+            return parentRepoBuilder.getGitDir() != null;
+        } catch (GitException e) {
+            return false;
+        }
+    }
+
+    private boolean hasGitRepo(String gitDirectory) throws GitException {
+        try {
+            File dotGit = new File(workspace, gitDirectory);
+            return dotGit.exists();
+        } catch (SecurityException ex) {
+            throw new GitException("Security error when trying to check for .git. Are you sure you have correct permissions?",
+                                   ex);
+        } catch (Exception e) {
+            throw new GitException("Couldn't check for .git", e);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1714,7 +1714,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /**
-     * hasGitRepo.
+     * Returns true if the current workspace has a git repository.
      *
      * @return true if this workspace has a git repository
      * @throws hudson.plugins.git.GitException if underlying git operation fails.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -274,7 +274,7 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
     }
 
     /**
-     * hasGitRepo.
+     * Returns true if the current workspace has a git repository.
      *
      * @return true if this workspace has a git repository
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
@@ -282,6 +282,21 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
      */
     public boolean hasGitRepo() throws GitException, InterruptedException {
         return proxy.hasGitRepo();
+    }
+
+    /**
+     * Returns true if the current workspace has a git repository.
+     * If checkParentDirectories is true, searches parent directories.
+     * If checkParentDirectories is false, checks workspace directory only.
+     *
+     * @param checkParentDirectories if true, search upward for a git repository
+     * @return true if this workspace has a git repository
+     * @throws hudson.plugins.git.GitException if underlying git operation fails.
+     * @throws java.lang.InterruptedException if interrupted.
+     */
+    @Override
+    public boolean hasGitRepo(boolean checkParentDirectories) throws GitException, InterruptedException {
+        return proxy.hasGitRepo(checkParentDirectories);
     }
 
     /** {@inheritDoc} */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -624,6 +624,7 @@ public class GitClientTest {
         tempDir.toFile().delete();
     }
 
+    @Issue("JENKINS-38699")
     @Test
     public void testHasGitRepoNestedDir() throws Exception {
         File childDir = tempFolder.newFolder("parentDir", "childDir");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -21,6 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -603,13 +604,92 @@ public class GitClientTest {
     @Issue("JENKINS-38699")
     @Test
     public void test_worktree() throws Exception {
-        File badGitDir = tempFolder.newFolder("parentDir", "childDir", ".git");
-        assertEquals(".git", badGitDir.getName());
-        assertEquals("childDir", badGitDir.getParentFile().getName());
-        assertEquals("parentDir", badGitDir.getParentFile().getParentFile().getName());
-        gitClient.init_().workspace(badGitDir.getParentFile().getParentFile().getAbsolutePath()).execute();
-        GitClient childDirClient = Git.with(TaskListener.NULL, new EnvVars()).in((badGitDir.getParentFile())).using(gitImplName).getClient();
-        assertFalse("Empty .git directory in " + badGitDir.getParentFile().getName(), childDirClient.hasGitRepo());
+        File childDir = tempFolder.newFolder("parentDir", "childDir");
+        gitClient.init_().workspace(childDir.getParentFile().getAbsolutePath()).execute();
+        GitClient childDirClient = Git.with(TaskListener.NULL, new EnvVars()).in((childDir)).using(gitImplName).getClient();
+        assertFalse("Expected no .git directory in " + childDir.getName(), childDirClient.hasGitRepo(false));
+        File badGitDir = new File(childDir, ".git");
+        assertThat(badGitDir, is(not(anExistingDirectory()))); // .git directory should not exist yet
+        assertTrue("Failed to create empty .git directory", badGitDir.mkdir());
+        assertFalse("Empty .git directory in reports initialized in " + childDir.getName(), childDirClient.hasGitRepo(false));
+    }
+
+    @Test
+    public void testHasGitRepoFalse() throws Exception {
+        Path tempDir = Files.createTempDirectory("git-client-hasGitRepo");
+        GitClient noRepoClient = Git.with(TaskListener.NULL, new EnvVars()).in(tempDir.toFile()).using(gitImplName).getClient();
+        assertFalse("New empty temp dir has a git repo(1)", noRepoClient.hasGitRepo());
+        assertFalse("New empty temp dir has a git repo(2)", noRepoClient.hasGitRepo(false));
+        assertFalse("New empty temp dir has a git repo(3)", noRepoClient.hasGitRepo(true));
+        tempDir.toFile().delete();
+    }
+
+    @Test
+    public void testHasGitRepoNestedDir() throws Exception {
+        File childDir = tempFolder.newFolder("parentDir", "childDir");
+        File parentDir = childDir.getParentFile();
+
+        GitClient parentDirClient = Git.with(TaskListener.NULL, new EnvVars()).in(parentDir).using(gitImplName).getClient();
+        assertFalse("Unexpected has git repo before init(1)", parentDirClient.hasGitRepo());
+        assertFalse("Unexpected has git repo before init(2)", parentDirClient.hasGitRepo(true));
+        assertFalse("Unexpected has git repo before init(3)", parentDirClient.hasGitRepo(false));
+
+        parentDirClient.init();
+        assertTrue("Missing git repo after init(1)", parentDirClient.hasGitRepo());
+        assertTrue("Missing git repo after init(2)", parentDirClient.hasGitRepo(true));
+        assertTrue("Missing git repo after init(3)", parentDirClient.hasGitRepo(false));
+
+        GitClient childDirClient = Git.with(TaskListener.NULL, new EnvVars()).in(childDir).using(gitImplName).getClient();
+        assertFalse("Unexpected has child git repo before child init(1)", childDirClient.hasGitRepo());
+        assertFalse("Unexpected has child git repo before child init(2)", childDirClient.hasGitRepo(true));
+        assertFalse("Unexpected has child git repo before child init(3)", childDirClient.hasGitRepo(false));
+
+        File childGitDir = new File(childDir, ".git");
+        boolean dirCreated = childGitDir.mkdir();
+        assertTrue("Failed to create empty .git dir in childDir", dirCreated);
+        if (gitImplName.equals("git")) {
+            // JENKINS-38699 - if an empty .git directory exists, CLI git searches upwards to perform operations
+            assertTrue("Missing parent git repo before child init(1)", childDirClient.hasGitRepo());
+        } else {
+            // JENKINS-38699 - if an empty .git directory exists, JGit does NOT search upwards to perform operations
+            assertFalse("Unexpected parent git repo detected by JGit before child init(1)", childDirClient.hasGitRepo());
+        }
+        assertTrue("Missing parent git repo before child init(2)", childDirClient.hasGitRepo(true));
+        assertFalse("Unexpected has child repo before child init(3)", childDirClient.hasGitRepo(false));
+
+        childDirClient.init();
+        assertTrue("Missing git repo after child init(1)", childDirClient.hasGitRepo());
+        assertTrue("Missing git repo after child init(2)", childDirClient.hasGitRepo(true));
+        assertTrue("Missing git repo after child init(3)", childDirClient.hasGitRepo(false));
+    }
+
+    @Issue("JENKINS-38699")
+    @Test
+    public void testHasGitRepoCheckParentDirectories() throws Exception {
+        File childDir = tempFolder.newFolder("grandParentDir", "parentDir", "childDir");
+        File parentDir = childDir.getParentFile();
+        File grandParentDir = parentDir.getParentFile();
+        gitClient.init_().workspace(grandParentDir.getAbsolutePath()).execute();
+
+        GitClient childDirClient = Git.with(TaskListener.NULL, new EnvVars()).in((childDir)).using(gitImplName).getClient();
+        assertFalse("Expected no .git directory in " + childDir.getName(), childDirClient.hasGitRepo());
+        assertFalse("Expected no .git directory in " + childDir.getName(), childDirClient.hasGitRepo(false));
+        assertFalse("No '.git' directory in childDir and yet parent repository found " + childDir.getName(), childDirClient.hasGitRepo(true));
+
+        File badGitDir = new File(childDir, ".git");
+        assertThat(badGitDir, is(not(anExistingDirectory()))); // .git directory should not exist yet
+        boolean badGitDirCreated = badGitDir.mkdir();
+        assertTrue("Failed to create empty .git directory", badGitDirCreated);
+        assertThat(badGitDir, is(anExistingDirectory())); // .git directory should exist
+
+        if (gitImplName.equals("git")) {
+            assertTrue("Empty .git directory not initialized in " + childDir.getName(), childDirClient.hasGitRepo());
+        } else {
+            assertFalse("Empty .git directory initialized in " + childDir.getName(), childDirClient.hasGitRepo());
+        }
+
+        assertFalse("Empty .git directory in reports initialized in " + childDir.getName(), childDirClient.hasGitRepo(false));
+        assertTrue("Expected repo in grandparent " + grandParentDir.getName(), childDirClient.hasGitRepo(true));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -598,16 +598,18 @@ public class GitClientTest {
         assertTrue(emptyDir.exists());
         GitClient emptyClient = Git.with(TaskListener.NULL, new EnvVars()).in(emptyDir).using(gitImplName).getClient();
         assertFalse("Empty repo '" + emptyDir.getAbsolutePath() + "' initialized", emptyClient.hasGitRepo());
+    }
 
+    @Issue("JENKINS-38699")
+    @Test
+    public void test_worktree() throws Exception {
         File badGitDir = tempFolder.newFolder("parentDir", "childDir", ".git");
         assertEquals(".git", badGitDir.getName());
         assertEquals("childDir", badGitDir.getParentFile().getName());
         assertEquals("parentDir", badGitDir.getParentFile().getParentFile().getName());
         gitClient.init_().workspace(badGitDir.getParentFile().getParentFile().getAbsolutePath()).execute();
-        File gitDir = gitClient.withRepository((repo, channel) -> repo.getDirectory());
-        assertTrue("Missing " + gitDir, gitDir.isDirectory());
         GitClient childDirClient = Git.with(TaskListener.NULL, new EnvVars()).in((badGitDir.getParentFile())).using(gitImplName).getClient();
-        assertFalse("Empty repo '" + badGitDir.getParentFile() + "' initialized", childDirClient.hasGitRepo());
+        assertFalse("Empty .git directory in " + badGitDir.getParentFile().getName(), childDirClient.hasGitRepo());
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -598,6 +598,16 @@ public class GitClientTest {
         assertTrue(emptyDir.exists());
         GitClient emptyClient = Git.with(TaskListener.NULL, new EnvVars()).in(emptyDir).using(gitImplName).getClient();
         assertFalse("Empty repo '" + emptyDir.getAbsolutePath() + "' initialized", emptyClient.hasGitRepo());
+
+        File badGitDir = tempFolder.newFolder("parentDir", "childDir", ".git");
+        assertEquals(".git", badGitDir.getName());
+        assertEquals("childDir", badGitDir.getParentFile().getName());
+        assertEquals("parentDir", badGitDir.getParentFile().getParentFile().getName());
+        gitClient.init_().workspace(badGitDir.getParentFile().getParentFile().getAbsolutePath()).execute();
+        File gitDir = gitClient.withRepository((repo, channel) -> repo.getDirectory());
+        assertTrue("Missing " + gitDir, gitDir.isDirectory());
+        GitClient childDirClient = Git.with(TaskListener.NULL, new EnvVars()).in((badGitDir.getParentFile())).using(gitImplName).getClient();
+        assertFalse("Empty repo '" + badGitDir.getParentFile() + "' initialized", childDirClient.hasGitRepo());
     }
 
     @Test


### PR DESCRIPTION
[JENKINS-38699](https://issues.jenkins-ci.org/browse/JENKINS-38699) - Validate .git directory with --resolve-git-dir

As the validation of a git repository presently is checked using `git rev-parse --is-inside-work-tree` but if the .git directory is corrupted then current repository's parent directories are searched for a valid .git directory. To limit/confine the traversal, `--is-inside-work-tree` is replaced by `--resolve-git-dir` which check if path to the .git directory of the current git repository is valid.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

Switched from the original implementation as a breaking change to instead add a new API that allows the caller to define if parent directories should be searched for a git repository.  Retains the existing behavior for the CLI git implementation (searching parent directories if the workspace contains a `.git` directory) and the existing behavior of the JGit implementation (never searching parent directories).  Retains the previous implementation and includes a statement in the javadoc about the behavioral difference between the CLI git and JGit implementations of `hasGitRepo()`.