### PR TITLE
[JENKINS-64913] CliGitAPIImpl.java: less noise with "/usr/bin/chcon"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2229,8 +2229,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     private void reportFailureClues() {
         if (!failureClues.isEmpty()) {
             listener.getLogger().println("ERROR: Git command failed, and previous operations logged the following error details:");
-            for (Instant ts : failureClues.keySet()) {
-                listener.getLogger().println("[" + ts.toString() + "]" + failureClues.get(ts) + "\n");
+            for (Map.Entry<Instant, String> entry : failureClues.entrySet()) {
+                listener.getLogger().println("[" + entry.getKey().toString() + "]" + entry.getValue() + "\n");
             }
             failureClues = new TreeMap(); // Flush to collect new errors and not report twice
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2185,7 +2185,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             int status = -1;
             String stdout = "";
             String stderr = "";
-            String command = gitExe + " " + StringUtils.join(args.toCommandArray(), " ");
+            String command = StringUtils.join(args.toCommandArray(), " ");
 
             try {
                 // JENKINS-13356: capture stdout and stderr separately


### PR DESCRIPTION
## [JENKINS-64913](https://issues.jenkins-ci.org/browse/JENKINS-64913) - revise the SELinux handling to be less noisy in optimal case

Previous PRs for JENKINS-64913 introduced basic support for SELinux, where key files for SSH may have to be labeled, and temporary files made by git-client-plugin were originally rejected. This new feature came with informational logging, especially noisy in case of failures.

As comments to the JIRA ticket exposed, there are systems and cases where SELinux is present, but "chcon" tool fails to modify labels, but yet somehow the rest of the git+ssh tooling does not mind using the key file as it is and so in the end noise about "chcon" failure is irrelevant.

This PR explores the idea of caching failure details of helpers (starting currently with this "chcon") and only flush them to build log if the actual git operation did not succeed.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

This change was not yet tested in practice. It seems there should be several cases covered, not all of these I can do on my own:
* git client on systems without SELinux (perhaps not Linux at all) => should not log any of this
* git client on systems with SELinux present but inactive => may briefly log detection and evaluation of SELinux setup
* git client on systems with SELinux present and active, requiring the key file label change and successfully applying that change => should briefly log detection and evaluation of SELinux setup and the running of chcon before git; no errors to report
* git client on systems with SELinux present and active, not succeeding (e.g. having the rights) to change it, but not really requiring the key file label change  => should briefly log detection and evaluation of SELinux setup and the running of chcon before git, but if git succeeded - should not detail the failure of chcon
* git client on systems with SELinux present and active, requiring the key file label change and NOT successfully applying that change => should briefly log detection and evaluation of SELinux setup and the running of chcon before git, but if any errors happen with both git and chcon only then should chcon issues be visible - during the report of git failure, to help troubleshoot it