### PR TITLE
Improve terminology

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -353,7 +353,7 @@
 == 1.6.4 (March 6, 2014)
 
 * Add NTLM authentication (for Team Foundation Server git implementation)
-* Support branch change detection in branches using namespaces (e.g. develop1/master)
+* Support branch change detection in branches using namespaces (e.g. develop1/branch-name)
 * Replace obsolete Apache HttpClient with Apache HttpComponents
 * Require at least Jenkins 1.509 so that authentication can be tested
 * QA improvements (more tests, findbugs warnings fixes, etc.)

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -180,7 +180,7 @@ public interface IGitAPI extends GitClient {
     /**
      * Merge commits from revspec into the current branch.
      *
-     * @param revSpec the revision specification to be merged (for example, origin/master)
+     * @param revSpec the revision specification to be merged (for example, origin/main)
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImpl.java
@@ -238,7 +238,7 @@ abstract class LegacyCompatibleGitAPIImpl extends AbstractGitAPIImpl implements 
      * TODO: Currently only for specs starting with "refs/heads/" the implementation is correct.
      * All others branch specs should also be normalized to "refs/heads/" in order to get unambiguous results.
      * To achieve this it is necessary to identify remote names in the branch spec and to discuss how
-     * to handle clashes (e.g. "remoteName/master" for branch "master" (refs/heads/master) in remote "remoteName" and branch "remoteName/master" (refs/heads/remoteName/master)).
+     * to handle clashes (e.g. "remoteName/main" for branch "main" (refs/heads/main) in remote "remoteName" and branch "remoteName/main" (refs/heads/remoteName/main)).
      * <br><br>
      * Existing behavior is intentionally being retained so that
      * current use cases are not disrupted by a behavioral change.
@@ -247,10 +247,10 @@ abstract class LegacyCompatibleGitAPIImpl extends AbstractGitAPIImpl implements 
      * <table>
      * <caption>Branch Spec Normalization Examples</caption>
      * <tr><th>branch spec</th><th>normalized</th></tr>
-     * <tr><td><code>master</code></td><td><code>master*</code></td></tr>
+     * <tr><td><code>main</code></td><td><code>main*</code></td></tr>
      * <tr><td><code>feature1</code></td><td><code>feature1*</code></td></tr>
-     * <tr><td><code>feature1/master</code></td><td><div style="color:red">master <code>feature1/master</code>*</div></td></tr>
-     * <tr><td><code>origin/master</code></td><td><code>master*</code></td></tr>
+     * <tr><td><code>feature1/main</code></td><td><div style="color:red">main <code>feature1/main</code>*</div></td></tr>
+     * <tr><td><code>origin/main</code></td><td><code>main*</code></td></tr>
      * <tr><td><code>repo2/feature1</code></td><td><code>feature1*</code></td></tr>
      * <tr><td><code>refs/heads/feature1</code></td><td><code>refs/heads/feature1</code></td></tr>
      * <tr><td valign="top">origin/namespaceA/fix15</td>

--- a/src/test/java/hudson/plugins/git/BranchTest.java
+++ b/src/test/java/hudson/plugins/git/BranchTest.java
@@ -20,9 +20,11 @@ public class BranchTest {
     private final Ref branchRef;
     private final Branch branchFromRef;
 
+    private static final String REMOTE_BRANCH_NAME = "origin/master";
+
     public BranchTest() {
         this.branchSHA1 = "fa71f704f9b90fa1f857d1623f3fe33fa2277ca9";
-        this.branchName = "origin/master";
+        this.branchName = REMOTE_BRANCH_NAME;
         this.branchHead = ObjectId.fromString(branchSHA1);
         this.refPrefix = "refs/remotes/";
         this.branchRef = new ObjectIdRef.PeeledNonTag(Ref.Storage.NEW, refPrefix + branchName, branchHead);

--- a/src/test/java/jmh/benchmark/GitClientRedundantFetchBenchmark.java
+++ b/src/test/java/jmh/benchmark/GitClientRedundantFetchBenchmark.java
@@ -22,6 +22,9 @@ import java.util.concurrent.TimeUnit;
 
 public class GitClientRedundantFetchBenchmark {
 
+    public static final String DEFAULT_BRANCH_REFSPEC = "+refs/heads/master:refs/remotes/origin/master";
+    public static final String ALL_BRANCHES_REFSPEC = "+refs/heads/*:refs/remotes/origin/*";
+
     @State(Scope.Thread)
     public static class ClientState {
 
@@ -83,11 +86,11 @@ public class GitClientRedundantFetchBenchmark {
             gitDir = tmp.newFolder();
             gitClient = Git.with(TaskListener.NULL, new EnvVars()).in(gitDir).using(gitExe).getClient();
 
-            // fetching just master branch
-            narrowRefSpecs.add(new RefSpec("+refs/heads/master:refs/remotes/origin/master"));
+            // fetching just only the contents of the default branch
+            narrowRefSpecs.add(new RefSpec(DEFAULT_BRANCH_REFSPEC));
 
             // wide refspec
-            wideRefSpecs.add(new RefSpec("+refs/heads/*:refs/remotes/origin/*"));
+            wideRefSpecs.add(new RefSpec(ALL_BRANCHES_REFSPEC));
 
             // initialize the test folder for git fetch
             gitClient.clone_().url(urIish.toString()).execute();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -227,7 +227,7 @@ public class CredentialsTest {
         List<Object[]> repos = new ArrayList<>();
         String[] implementations = isCredentialsSupported() ? new String[]{"git", "jgit", "jgitapache"} : new String[]{"jgit", "jgitapache"};
         for (String implementation : implementations) {
-            /* Add master repository as authentication test with private
+            /* Add upstream repository as authentication test with private
              * key of current user.  Try to test at least one
              * authentication case, even if there is no repos.json file in
              * the external directory.

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -81,6 +81,8 @@ public class GitAPITest {
 
     private String revParseBranchName = null;
 
+    private static final String DEFAULT_BRANCH_NAME = "master";
+
     private int checkoutTimeout = -1;
     private int cloneTimeout = -1;
     private int fetchTimeout = -1;
@@ -264,7 +266,7 @@ public class GitAPITest {
         workspace.commitEmpty("init");
         testGitClient.branch("test");
         String branches = workspace.launchCommand("git", "branch", "-l");
-        assertTrue("master branch not listed", branches.contains("master"));
+        assertTrue("default branch not listed", branches.contains(DEFAULT_BRANCH_NAME));
         assertTrue("test branch not listed", branches.contains("test"));
     }
 
@@ -357,7 +359,7 @@ public class GitAPITest {
         testGitClient.branch("test");
         testGitClient.branch("another");
         Set<Branch> branches = testGitClient.getBranches();
-        assertBranchesExist(branches, "master", "test", "another");
+        assertBranchesExist(branches, DEFAULT_BRANCH_NAME, "test", "another");
         assertEquals(3, branches.size());
     }
 
@@ -596,21 +598,21 @@ public class GitAPITest {
         testGitClient.setRemoteUrl("origin", bare.getGitFileDir().getAbsolutePath());
         Set<Branch> remoteBranchesEmpty = testGitClient.getRemoteBranches();
         assertThat(remoteBranchesEmpty, is(empty()));
-//        testGitClient.push().ref("master").to(new URIish("origin")).execute();
-        testGitClient.push("origin", "master");
-        ObjectId bareCommit1 = bare.getGitClient().getHeadRev(bare.getGitFileDir().getAbsolutePath(), "master");
+//        testGitClient.push().ref(DEFAULT_BRANCH_NAME).to(new URIish("origin")).execute();
+        testGitClient.push("origin", DEFAULT_BRANCH_NAME);
+        ObjectId bareCommit1 = bare.getGitClient().getHeadRev(bare.getGitFileDir().getAbsolutePath(), DEFAULT_BRANCH_NAME);
         assertEquals("bare != working", commit1, bareCommit1);
-        assertEquals(commit1, bare.getGitClient().getHeadRev(bare.getGitFileDir().getAbsolutePath(), "refs/heads/master"));
+        assertEquals(commit1, bare.getGitClient().getHeadRev(bare.getGitFileDir().getAbsolutePath(), "refs/heads/" + DEFAULT_BRANCH_NAME));
 
         /* Add tag1 to working repo without pushing it to bare repo */
         workspace.tag("tag1");
         assertTrue("tag1 wasn't created", testGitClient.tagExists("tag1"));
         assertEquals("tag1 points to wrong commit", commit1, testGitClient.revParse("tag1"));
-        testGitClient.push().ref("master").to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(false).execute();
+        testGitClient.push().ref(DEFAULT_BRANCH_NAME).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(false).execute();
         assertFalse("tag1 pushed unexpectedly", bare.launchCommand("git", "tag").contains("tag1"));
 
         /* Push tag1 to bare repo */
-        testGitClient.push().ref("master").to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).execute();
+        testGitClient.push().ref(DEFAULT_BRANCH_NAME).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).execute();
         assertTrue("tag1 not pushed", bare.launchCommand("git", "tag").contains("tag1"));
 
         /* Create a new commit, move tag1 to that commit, attempt push */
@@ -622,7 +624,7 @@ public class GitAPITest {
         assertTrue("tag1 wasn't created", testGitClient.tagExists("tag1"));
         assertEquals("tag1 points to wrong commit", commit2, testGitClient.revParse("tag1"));
         try {
-            testGitClient.push().ref("master").to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).execute();
+            testGitClient.push().ref(DEFAULT_BRANCH_NAME).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).execute();
             /* JGit does not throw exception updating existing tag - ugh */
             /* CliGit before 1.8 does not throw exception updating existing tag - ugh */
             if (testGitClient instanceof CliGitAPIImpl && workspace.cgit().isAtLeastVersion(1,8,0,0)) {
@@ -633,7 +635,7 @@ public class GitAPITest {
         }
 
         try {
-            testGitClient.push().ref("master").to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).force(false).execute();
+            testGitClient.push().ref(DEFAULT_BRANCH_NAME).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).force(false).execute();
             /* JGit does not throw exception updating existing tag - ugh */
             /* CliGit before 1.8 does not throw exception updating existing tag - ugh */
             if (testGitClient instanceof CliGitAPIImpl && workspace.cgit().isAtLeastVersion(1,8,0,0)) {
@@ -642,7 +644,7 @@ public class GitAPITest {
         } catch (GitException ge) {
             assertThat(ge.getMessage(), containsString("already exists"));
         }
-        testGitClient.push().ref("master").to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).force(true).execute();
+        testGitClient.push().ref(DEFAULT_BRANCH_NAME).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).force(true).execute();
 
         /* Add tag to working repo without pushing it to the bare
          * repo, tests the default behavior when tags() is not added
@@ -650,7 +652,7 @@ public class GitAPITest {
          */
         workspace.tag("tag3");
         assertTrue("tag3 wasn't created", testGitClient.tagExists("tag3"));
-        testGitClient.push().ref("master").to(new URIish(bare.getGitFileDir().getAbsolutePath())).execute();
+        testGitClient.push().ref(DEFAULT_BRANCH_NAME).to(new URIish(bare.getGitFileDir().getAbsolutePath())).execute();
         assertFalse("tag3 was pushed", bare.launchCommand("git", "tag").contains("tag3"));
 
         /* Add another tag to working repo and push tags to the bare repo */
@@ -660,7 +662,7 @@ public class GitAPITest {
         testGitClient.commit("commit2");
         workspace.tag("tag2");
         assertTrue("tag2 wasn't created", testGitClient.tagExists("tag2"));
-        testGitClient.push().ref("master").to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).execute();
+        testGitClient.push().ref(DEFAULT_BRANCH_NAME).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).execute();
         assertTrue("tag1 wasn't pushed", bare.launchCommand("git", "tag").contains("tag1"));
         assertTrue("tag2 wasn't pushed", bare.launchCommand("git", "tag").contains("tag2"));
         assertTrue("tag3 wasn't pushed", bare.launchCommand("git", "tag").contains("tag3"));
@@ -688,7 +690,7 @@ public class GitAPITest {
         workspace.cgit().commit(anotherBranchCommitMessage + "\r");
 
         branches = testGitClient.getBranches();
-        assertBranchesExist(branches, "master", "test", "another");
+        assertBranchesExist(branches, DEFAULT_BRANCH_NAME, "test", "another");
         assertEquals(3, branches.size());
         String output = workspace.launchCommand("git", "branch", "-v", "--no-abbrev");
         assertTrue("git branch -v --no-abbrev missing test commit msg: '" + output + "'", output.contains(testBranchCommitMessage));
@@ -715,7 +717,7 @@ public class GitAPITest {
         workspace.launchCommand("git", "remote", "add", "origin", remote.getGitFileDir().getAbsolutePath());
         workspace.launchCommand("git", "fetch", "origin");
         Set<Branch> branches = testGitClient.getRemoteBranches();
-        assertBranchesExist(branches, "origin/master", "origin/test", "origin/another");
+        assertBranchesExist(branches, "origin/" + DEFAULT_BRANCH_NAME, "origin/test", "origin/another");
         assertEquals(3, branches.size());
     }
 
@@ -835,8 +837,8 @@ public class GitAPITest {
         remote.initBareRepo(remote.getGitClient(), true);
         workspace.launchCommand("git", "remote", "add", "origin", remote.getGitFileDir().getAbsolutePath());
 
-        testGitClient.push("origin", "master");
-        String remoteSha1 = remote.launchCommand("git", "rev-parse", "master").substring(0, 40);
+        testGitClient.push("origin", DEFAULT_BRANCH_NAME);
+        String remoteSha1 = remote.launchCommand("git", "rev-parse", DEFAULT_BRANCH_NAME).substring(0, 40);
         assertEquals(sha1.name(), remoteSha1);
     }
 
@@ -884,9 +886,9 @@ public class GitAPITest {
         workspace1.commitEmpty("c");
         workspace1.launchCommand("git", "remote", "add", "origin", teamWorkspace.getGitFileDir().getAbsolutePath());
 
-        workspace1.launchCommand("git", "push", "origin", "master:b1");
-        workspace1.launchCommand("git", "push", "origin", "master:b2");
-        workspace1.launchCommand("git", "push", "origin", "master");
+        workspace1.launchCommand("git", "push", "origin", DEFAULT_BRANCH_NAME + ":b1");
+        workspace1.launchCommand("git", "push", "origin", DEFAULT_BRANCH_NAME + ":b2");
+        workspace1.launchCommand("git", "push", "origin", DEFAULT_BRANCH_NAME);
 
         workspace2.launchCommand("git", "remote", "add", "origin", teamWorkspace.getGitFileDir().getAbsolutePath());
         workspace2.launchCommand("git", "fetch", "origin");
@@ -894,7 +896,7 @@ public class GitAPITest {
         // at this point both ws1&ws2 have several remote tracking branches
 
         workspace1.launchCommand("git", "push", "origin", ":b1");
-        workspace1.launchCommand("git", "push", "origin", "master:b3");
+        workspace1.launchCommand("git", "push", "origin", DEFAULT_BRANCH_NAME + ":b3");
 
         workspace2.getGitClient().prune(new RemoteConfig(new Config(),"origin"));
 
@@ -978,7 +980,7 @@ public class GitAPITest {
         workspace.touch(testGitDir, "file", "content1");
         testGitClient.add("file");
         testGitClient.commit("commit1");
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         testGitClient.branch("branch2");
         testGitClient.checkout().ref("branch2").execute();
         workspace.touch(testGitDir,"file", "content2");
@@ -997,7 +999,7 @@ public class GitAPITest {
         workspace.touch(testGitDir, "file", "content1");
         testGitClient.add("file");
         testGitClient.commit("commit1");
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         testGitClient.branch("branch2");
         testGitClient.checkout().ref("branch2").execute();
         workspace.touch(testGitDir, "file", "content2");
@@ -1019,7 +1021,7 @@ public class GitAPITest {
         testGitClient.commit("commit1");
         final ObjectId branch1 = workspace.head();
 
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         testGitClient.branch("branch2");
         testGitClient.checkout().ref("branch2").execute();
         workspace.touch(testGitDir, "file2", "content2");
@@ -1027,15 +1029,15 @@ public class GitAPITest {
         testGitClient.commit("commit2");
         final ObjectId branch2 = workspace.head();
 
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
 
-        // The first merge is a fast-forward, master moves to branch1
+        // The first merge is a fast-forward, default branch moves to branch1
         testGitClient.merge().setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch1")).execute();
-        assertEquals("Fast-forward merge failed. master and branch1 should be the same.", workspace.head(), branch1);
+        assertEquals("Fast-forward merge failed. default branch and branch1 should be the same.", workspace.head(), branch1);
 
         // The second merge calls for fast-forward (FF), but a merge commit will result
         // This tests that calling for FF gracefully falls back to a commit merge
-        // master moves to a new commit ahead of branch1 and branch2
+        // default branch moves to a new commit ahead of branch1 and branch2
         testGitClient.merge().setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch2")).execute();
         // The merge commit (head) should have branch2 and branch1 as parents
         List<ObjectId> revList = testGitClient.revList("HEAD^1");
@@ -1054,7 +1056,7 @@ public class GitAPITest {
         testGitClient.commit("commit1");
         final ObjectId branch1 = workspace.head();
 
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         testGitClient.branch("branch2");
         testGitClient.checkout().ref("branch2").execute();
         workspace.touch(testGitDir, "file2", "content2");
@@ -1062,11 +1064,11 @@ public class GitAPITest {
         testGitClient.commit("commit2");
         final ObjectId branch2 = workspace.head();
 
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
 
-        // The first merge is a fast-forward only (FF_ONLY), master moves to branch1
+        // The first merge is a fast-forward only (FF_ONLY), default branch moves to branch1
         testGitClient.merge().setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.FF_ONLY).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch1")).execute();
-        assertEquals("Fast-forward merge failed. master and branch1 should be the same but aren't.", workspace.head(), branch1);
+        assertEquals("Fast-forward merge failed. Default branch and branch1 should be the same but aren't.", workspace.head(), branch1);
 
         // The second merge calls for fast-forward only (FF_ONLY), but a merge commit is required, hence it is expected to fail
         try {
@@ -1074,7 +1076,7 @@ public class GitAPITest {
             fail("Exception not thrown: the fast-forward only mode should have failed");
         } catch (GitException ge) {
             // expected
-            assertEquals("Fast-forward merge abort failed. master and branch1 should still be the same as the merge was aborted.",workspace.head(),branch1);
+            assertEquals("Fast-forward merge abort failed. Default branch and branch1 should still be the same as the merge was aborted.",workspace.head(),branch1);
         }
     }
 
@@ -1089,7 +1091,7 @@ public class GitAPITest {
         testGitClient.commit("commit1");
         final ObjectId branch1 = workspace.head();
 
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         testGitClient.branch("branch2");
         testGitClient.checkout().ref("branch2").execute();
         workspace.touch(testGitDir, "file2", "content2");
@@ -1097,7 +1099,7 @@ public class GitAPITest {
         testGitClient.commit("commit2");
         final ObjectId branch2 = workspace.head();
 
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
 
         // The first merge is normally a fast-forward, but we're calling for a merge commit which is expected to work
         testGitClient.merge().setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch1")).execute();
@@ -1136,8 +1138,8 @@ public class GitAPITest {
         testGitClient.add("file2");
         testGitClient.commit("commit2");
 
-        //Merge branch1 with master, squashing both commits
-        testGitClient.checkout().ref("master").execute();
+        //Merge branch1 with default branch, squashing both commits
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         testGitClient.merge().setSquash(true).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch1")).execute();
 
         //Compare commit counts of before and after commiting the merge, should be  one due to the squashing of commits.
@@ -1164,9 +1166,9 @@ public class GitAPITest {
         testGitClient.add("file2");
         testGitClient.commit("commit2");
 
-        //Merge branch1 with master, without squashing commits.
+        //Merge branch1 with default branch, without squashing commits.
         //Compare commit counts of before and after commiting the merge, should be two due to the no squashing of commits.
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         final int commitCountBefore = testGitClient.revList("HEAD").size();
         testGitClient.merge().setSquash(false).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch1")).execute();
         final int commitCountAfter = testGitClient.revList("HEAD").size();
@@ -1185,9 +1187,9 @@ public class GitAPITest {
         testGitClient.add("file1");
         testGitClient.commit("commit1");
 
-        //Merge branch1 with master, without committing the merge.
+        //Merge branch1 with default branch, without committing the merge.
         //Compare commit counts of before and after the merge, should be zero due to the lack of autocommit.
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         final int commitCountBefore = testGitClient.revList("HEAD").size();
         testGitClient.merge().setCommit(false).setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch1")).execute();
         final int commitCountAfter = testGitClient.revList("HEAD").size();
@@ -1206,9 +1208,9 @@ public class GitAPITest {
         testGitClient.add("file1");
         testGitClient.commit("commit1");
 
-        //Merge branch1 with master, without committing the merge.
+        //Merge branch1 with default branch, without committing the merge.
         //Compare commit counts of before and after the merge, should be two due to the commit of the file and the commit of the merge.
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         final int commitCountBefore = testGitClient.revList("HEAD").size();
         testGitClient.merge().setCommit(true).setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch1")).execute();
         final int commitCountAfter = testGitClient.revList("HEAD").size();
@@ -1227,8 +1229,8 @@ public class GitAPITest {
         testGitClient.add("file1");
         testGitClient.commit("commit1");
 
-        //Merge branch1 into master
-        testGitClient.checkout().ref("master").execute();
+        //Merge branch1 into default branch
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         final String mergeMessage = "Merge message to be tested.";
         testGitClient.merge().setMessage(mergeMessage).setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF).setRevisionToMerge(testGitClient.getHeadRev(testGitDir.getAbsolutePath(), "branch1")).execute();
         //Obtain last commit message
@@ -1253,10 +1255,10 @@ public class GitAPITest {
     public void testRebasePassesWithoutConflict() throws Exception {
         workspace.commitEmpty("init");
 
-        //First commit to master
-        workspace.touch(testGitDir, "master_file", "master1");
-        testGitClient.add("master_file");
-        testGitClient.commit("commit-master1");
+        //First commit to default branch
+        workspace.touch(testGitDir, "default_branch_file", "default_branch1");
+        testGitClient.add("default_branch_file");
+        testGitClient.commit("commit-default_branch1");
 
         //Create a feature branch and make a commit
         testGitClient.branch("feature1");
@@ -1265,17 +1267,17 @@ public class GitAPITest {
         testGitClient.add("feature_file");
         testGitClient.commit("commit-feature1");
 
-        //Second commit to master
-        testGitClient.checkout().ref("master").execute();
-        workspace.touch(testGitDir, "master_file", "master2");
-        testGitClient.add("master_file");
-        testGitClient.commit("commit-master2");
+        //Second commit to default branch
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
+        workspace.touch(testGitDir, "default_branch_file", "default_branch2");
+        testGitClient.add("default_branch_file");
+        testGitClient.commit("commit-default_branch2");
 
-        //Rebase feature commit onto master
+        //Rebase feature commit onto default branch
         testGitClient.checkout().ref("feature1").execute();
-        testGitClient.rebase().setUpstream("master").execute();
+        testGitClient.rebase().setUpstream(DEFAULT_BRANCH_NAME).execute();
 
-        assertThat("Should've rebased feature1 onto master", testGitClient.revList("feature1").contains(testGitClient.revParse("master")));
+        assertThat("Should've rebased feature1 onto default branch", testGitClient.revList("feature1").contains(testGitClient.revParse(DEFAULT_BRANCH_NAME)));
         assertEquals("HEAD should be on the rebased branch", testGitClient.revParse("HEAD").name(), testGitClient.revParse("feature1").name());
         assertThat("Rebased file should be present in the worktree", testGitClient.getWorkTree().child("feature_file").exists());
     }
@@ -1284,10 +1286,10 @@ public class GitAPITest {
     public void testRebaseFailsWithConflict() throws Exception {
         workspace.commitEmpty("init");
 
-        // First commit to master
-        workspace.touch(testGitDir, "file", "master1");
+        // First commit to default branch
+        workspace.touch(testGitDir, "file", "default_branch1");
         testGitClient.add("file");
-        testGitClient.commit("commit-master1");
+        testGitClient.commit("commit-default-branch1");
 
         //Create a feature branch and make a commit
         testGitClient.branch("feature1");
@@ -1296,16 +1298,16 @@ public class GitAPITest {
         testGitClient.add("file");
         testGitClient.commit("commit-feature1");
 
-        //Second commit to master
-        testGitClient.checkout().ref("master").execute();
-        workspace.touch(testGitDir, "file", "master2");
+        //Second commit to default branch
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
+        workspace.touch(testGitDir, "file", "default-branch2");
         testGitClient.add("file");
-        testGitClient.commit("commit-master2");
+        testGitClient.commit("commit-default-branch2");
 
-        // Rebase feature commit onto master
+        // Rebase feature commit onto default branch
         testGitClient.checkout().ref("feature1").execute();
         try {
-            testGitClient.rebase().setUpstream("master").execute();
+            testGitClient.rebase().setUpstream(DEFAULT_BRANCH_NAME).execute();
             fail("Rebase did not throw expected GitException");
         } catch (GitException ge) {
             assertEquals("HEAD not reset to the feature branch.", testGitClient.revParse("HEAD").name(), testGitClient.revParse("feature1").name());
@@ -1328,49 +1330,49 @@ public class GitAPITest {
     public void testJenkins11177() throws Exception {
         workspace.commitEmpty("init");
         final ObjectId base = workspace.head();
-        final ObjectId master = testGitClient.revParse("master");
-        assertEquals(base, master);
+        final ObjectId defaultBranchObjectId = testGitClient.revParse(DEFAULT_BRANCH_NAME);
+        assertEquals(base, defaultBranchObjectId);
 
-        /* Make reference to master ambiguous, verify it is reported ambiguous by rev-parse */
-        workspace.tag("master");
-        final String revParse = workspace.launchCommand("git", "rev-parse", "master");
+        /* Make reference to default branch ambiguous, verify it is reported ambiguous by rev-parse */
+        workspace.tag(DEFAULT_BRANCH_NAME);
+        final String revParse = workspace.launchCommand("git", "rev-parse", DEFAULT_BRANCH_NAME);
         assertTrue("'" + revParse + "' does not contain 'ambiguous'", revParse.contains("ambiguous"));
-        final ObjectId masterTag = testGitClient.revParse("refs/tags/master");
-        assertEquals("masterTag != head", workspace.head(), masterTag);
+        final ObjectId ambiguousTag = testGitClient.revParse("refs/tags/" + DEFAULT_BRANCH_NAME);
+        assertEquals("ambiguousTag != head", workspace.head(), ambiguousTag);
 
-        /* Get reference to ambiguous master */
-        final ObjectId ambiguous = testGitClient.revParse("master");
-        assertEquals("ambiguous != master", ambiguous.toString(), master.toString());
+        /* Get reference to ambiguous branch name */
+        final ObjectId ambiguous = testGitClient.revParse(DEFAULT_BRANCH_NAME);
+        assertEquals("ambiguous != default branch", ambiguous.toString(), defaultBranchObjectId.toString());
 
-        /* Exploring JENKINS-20991 ambigous revision breaks checkout */
-        workspace.touch(testGitDir, "file-master", "content-master");
-        testGitClient.add("file-master");
-        testGitClient.commit("commit1-master");
-        final ObjectId masterTip = workspace.head();
+        /* Exploring JENKINS-20991 ambiguous revision breaks checkout */
+        workspace.touch(testGitDir, "file-default-branch", "content-default-branch");
+        testGitClient.add("file-default-branch");
+        testGitClient.commit("commit1-default-branch");
+        final ObjectId defaultBranchTip = workspace.head();
 
-        workspace.launchCommand("git", "branch", "branch1", masterTip.name());
+        workspace.launchCommand("git", "branch", "branch1", defaultBranchTip.name());
         workspace.launchCommand("git", "checkout", "branch1");
         workspace.touch(testGitDir, "file1", "content1");
         testGitClient.add("file1");
         testGitClient.commit("commit1-branch1");
         final ObjectId branch1 = workspace.head();
 
-        /* JGit checks out the masterTag, while CliGit checks out
-         * master branch.  It is risky that there are different
+        /* JGit checks out the tag, while CliGit checks out
+         * the branch.  It is risky that there are different
          * behaviors between the two implementations, but when a
          * reference is ambiguous, it is safe to assume that
          * resolution of the ambiguous reference is an implementation
          * specific detail. */
-        testGitClient.checkout().ref("master").execute();
+        testGitClient.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         final String messageDetails =
                 ", head=" + workspace.head().name() +
-                ", masterTip=" + masterTip.name() +
-                ", masterTag=" + masterTag.name() +
+                ", defaultBranchTip=" + defaultBranchTip.name() +
+                ", ambiguousTag=" + ambiguousTag.name() +
                 ", branch1=" + branch1.name();
         if (testGitClient instanceof CliGitAPIImpl) {
-            assertEquals("head != master branch" + messageDetails, masterTip, workspace.head());
+            assertEquals("head != default branch" + messageDetails, defaultBranchTip, workspace.head());
         } else {
-            assertEquals("head != master tag" + messageDetails, masterTag, workspace.head());
+            assertEquals("head != ambiguous tag" + messageDetails, ambiguousTag, workspace.head());
         }
     }
 
@@ -1438,7 +1440,7 @@ public class GitAPITest {
         workspace.commitEmpty("c1");
         workspace.tag("t1");
         workspace.commitEmpty("c2");
-        List<ObjectId> revList = testGitClient.revList("master");
+        List<ObjectId> revList = testGitClient.revList(DEFAULT_BRANCH_NAME);
         assertEquals("Wrong list size: " + revList, 2, revList.size());
     }
 
@@ -1499,7 +1501,7 @@ public class GitAPITest {
         testGitClient.checkout().ref("t").execute();
         assertTrue(testGitClient.hasGitModules());
 
-        workspace.launchCommand("git", "fetch", workspace.localMirror(), "master:t2");
+        workspace.launchCommand("git", "fetch", workspace.localMirror(), DEFAULT_BRANCH_NAME + ":t2");
         testGitClient.checkout().ref("t2").execute();
         assertFalse(testGitClient.hasGitModules());
         IGitAPI igit = (IGitAPI) testGitClient;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -93,6 +93,9 @@ public abstract class GitAPITestCase extends TestCase {
     private LogHandler handler = null;
     private int logCount = 0;
     private static final String LOGGING_STARTED = "Logging started";
+    private static final String DEFAULT_BRANCH_NAME = "master";
+    private static final String DEFAULT_JGIT_BRANCH_NAME = Constants.MASTER;
+    private static final String DEFAULT_REMOTE_BRANCH_NAME = "origin/" + DEFAULT_BRANCH_NAME;
 
     private String revParseBranchName = null;
 
@@ -626,11 +629,11 @@ public abstract class GitAPITestCase extends TestCase {
         assertEquals("Wrong remote URL", w.git.getRemoteUrl("origin"), bare.repoPath());
 
         /* Push to bare repo */
-        w.git.push("origin", "master");
+        w.git.push("origin", DEFAULT_BRANCH_NAME);
         /* JGitAPIImpl revParse fails unexpectedly when used here */
-        ObjectId bareHead = w.git instanceof CliGitAPIImpl ? bare.head() : ObjectId.fromString(bare.launchCommand("git", "rev-parse", "master").substring(0, 40));
+        ObjectId bareHead = w.git instanceof CliGitAPIImpl ? bare.head() : ObjectId.fromString(bare.launchCommand("git", "rev-parse", DEFAULT_BRANCH_NAME).substring(0, 40));
         assertEquals("Heads don't match", workHead, bareHead);
-        assertEquals("Heads don't match", w.git.getHeadRev(w.repoPath(), "master"), bare.git.getHeadRev(bare.repoPath(), "master"));
+        assertEquals("Heads don't match", w.git.getHeadRev(w.repoPath(), DEFAULT_BRANCH_NAME), bare.git.getHeadRev(bare.repoPath(), DEFAULT_BRANCH_NAME));
 
         /* Commit a new file */
         w.touch("file1");
@@ -641,13 +644,13 @@ public abstract class GitAPITestCase extends TestCase {
         Config config = new Config();
         config.fromText(w.contentOf(".git/config"));
         RemoteConfig origin = new RemoteConfig(config, "origin");
-        w.igit().push(origin, "master");
+        w.igit().push(origin, DEFAULT_BRANCH_NAME);
 
         /* JGitAPIImpl revParse fails unexpectedly when used here */
-        ObjectId workHead2 = w.git instanceof CliGitAPIImpl ? w.head() : ObjectId.fromString(w.launchCommand("git", "rev-parse", "master").substring(0, 40));
-        ObjectId bareHead2 = w.git instanceof CliGitAPIImpl ? bare.head() : ObjectId.fromString(bare.launchCommand("git", "rev-parse", "master").substring(0, 40));
+        ObjectId workHead2 = w.git instanceof CliGitAPIImpl ? w.head() : ObjectId.fromString(w.launchCommand("git", "rev-parse", DEFAULT_BRANCH_NAME).substring(0, 40));
+        ObjectId bareHead2 = w.git instanceof CliGitAPIImpl ? bare.head() : ObjectId.fromString(bare.launchCommand("git", "rev-parse", DEFAULT_BRANCH_NAME).substring(0, 40));
         assertEquals("Working SHA1 != bare SHA1", workHead2, bareHead2);
-        assertEquals("Working SHA1 != bare SHA1", w.git.getHeadRev(w.repoPath(), "master"), bare.git.getHeadRev(bare.repoPath(), "master"));
+        assertEquals("Working SHA1 != bare SHA1", w.git.getHeadRev(w.repoPath(), DEFAULT_BRANCH_NAME), bare.git.getHeadRev(bare.repoPath(), DEFAULT_BRANCH_NAME));
     }
     
     /**
@@ -796,9 +799,9 @@ public abstract class GitAPITestCase extends TestCase {
             assertDirNotFound(sshkeysDir);
         }
 
-        /* Checkout master branch - will leave submodule files untracked */
-        w.git.checkout().ref("origin/master").execute();
-        // w.git.checkout().ref("origin/master").branch("master").execute();
+        /* Checkout default remote branch - will leave submodule files untracked */
+        w.git.checkout().ref(DEFAULT_REMOTE_BRANCH_NAME).execute();
+        // w.git.checkout().ref(DEFAULT_REMOTE_BRANCH_NAME).branch(DEFAULT_BRANCH_NAME).execute();
         if (w.git instanceof CliGitAPIImpl) {
             /* CLI git clean will not remove untracked submodules */
             assertDirExists(ntpDir);
@@ -1036,7 +1039,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.init(); // empty repository
 
         // create a new GIT repo.
-        //   master -- <file1>C  <file2>C
+        //   default branch -- <file1>C  <file2>C
         WorkingArea r = new WorkingArea(createTempDirectoryWithoutSpaces());
         r.init();
         r.touch("file1", "content1");
@@ -1056,11 +1059,11 @@ public abstract class GitAPITestCase extends TestCase {
         // Make sure that the new file doesn't exist in the repo with remoteTracking
         String subFile = subModDir + File.separator + "file2";
         w.git.submoduleUpdate().recursive(true).remoteTracking(false).execute();
-        assertFalse("file2 exists and should not because we didn't update to the tip of the branch (master).", w.exists(subFile));
+        assertFalse("file2 exists and should not because we didn't update to the tip of the default branch.", w.exists(subFile));
 
         // Run submodule update with remote tracking
         w.git.submoduleUpdate().recursive(true).remoteTracking(true).execute();
-        assertTrue("file2 does not exist and should because we updated to the top of the branch (master).", w.exists(subFile));
+        assertTrue("file2 does not exist and should because we updated to the tip of the default branch.", w.exists(subFile));
         assertFixSubmoduleUrlsThrows();
     }
 
@@ -1071,16 +1074,16 @@ public abstract class GitAPITestCase extends TestCase {
      */
     private void base_checkout_replaces_tracked_changes(boolean defineBranch) throws Exception {
         w.git.clone_().url(localMirror()).repositoryName("JENKINS-23424").execute();
-        w.git.checkout().ref("JENKINS-23424/master").branch("master").execute();
+        w.git.checkout().ref("JENKINS-23424/" + DEFAULT_BRANCH_NAME).branch(DEFAULT_BRANCH_NAME).execute();
         if (defineBranch) {
-            w.git.checkout().branch("master").ref("JENKINS-23424/master").deleteBranchIfExist(true).execute();
+            w.git.checkout().branch(DEFAULT_BRANCH_NAME).ref("JENKINS-23424/" + DEFAULT_BRANCH_NAME).deleteBranchIfExist(true).execute();
         } else {
-            w.git.checkout().ref("JENKINS-23424/master").deleteBranchIfExist(true).execute();
+            w.git.checkout().ref("JENKINS-23424/" + DEFAULT_BRANCH_NAME).deleteBranchIfExist(true).execute();
         }
 
         /* Confirm first checkout */
         String pomContent = w.contentOf("pom.xml");
-        assertTrue("Missing inceptionYear ref in master pom : " + pomContent, pomContent.contains("inceptionYear"));
+        assertTrue("Missing inceptionYear ref in pom : " + pomContent, pomContent.contains("inceptionYear"));
         assertFalse("Found untracked file", w.file("untracked-file").exists());
 
         /* Modify the pom file by adding a comment */
@@ -1133,7 +1136,7 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_submodule_tags_not_fetched_into_parent() throws Exception {
         w.git.clone_().url(localMirror()).repositoryName("origin").execute();
         checkoutTimeout = 1 + random.nextInt(60 * 24);
-        w.git.checkout().ref("origin/master").branch("master").timeout(checkoutTimeout).execute();
+        w.git.checkout().ref(DEFAULT_REMOTE_BRANCH_NAME).branch(DEFAULT_BRANCH_NAME).timeout(checkoutTimeout).execute();
 
         String tagsBefore = w.launchCommand("git", "tag");
         Set<String> tagNamesBefore = w.git.getTagNames(null);
@@ -1229,7 +1232,7 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_submodule_update_shallow() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();
-        w.git.checkout().branch("master").ref("origin/master").execute();
+        w.git.checkout().branch(DEFAULT_BRANCH_NAME).ref(DEFAULT_REMOTE_BRANCH_NAME).execute();
         w.git.submoduleInit();
         w.git.submoduleUpdate().shallow(true).execute();
 
@@ -1238,15 +1241,15 @@ public abstract class GitAPITestCase extends TestCase {
         String shallow = Paths.get(".git", "modules", "submodule", "shallow").toString();
         assertEquals("shallow file existence: " + shallow, hasShallowSubmoduleSupport, w.exists(shallow));
 
-        int localSubmoduleCommits = w.cgit().subGit("submodule").revList("master").size();
-        int remoteSubmoduleCommits = remote.cgit().subGit("dir-submodule").revList("master").size();
+        int localSubmoduleCommits = w.cgit().subGit("submodule").revList(DEFAULT_BRANCH_NAME).size();
+        int remoteSubmoduleCommits = remote.cgit().subGit("dir-submodule").revList(DEFAULT_BRANCH_NAME).size();
         assertEquals("submodule commit count didn't match", hasShallowSubmoduleSupport ? 1 : remoteSubmoduleCommits, localSubmoduleCommits);
     }
 
     public void test_submodule_update_shallow_with_depth() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();
-        w.git.checkout().branch("master").ref("origin/master").execute();
+        w.git.checkout().branch(DEFAULT_BRANCH_NAME).ref(DEFAULT_REMOTE_BRANCH_NAME).execute();
         w.git.submoduleInit();
         w.git.submoduleUpdate().shallow(true).depth(2).execute();
 
@@ -1255,8 +1258,8 @@ public abstract class GitAPITestCase extends TestCase {
         String shallow = Paths.get(".git", "modules", "submodule", "shallow").toString();
         assertEquals("shallow file existence: " + shallow, hasShallowSubmoduleSupport, w.exists(shallow));
 
-        int localSubmoduleCommits = w.cgit().subGit("submodule").revList("master").size();
-        int remoteSubmoduleCommits = remote.cgit().subGit("dir-submodule").revList("master").size();
+        int localSubmoduleCommits = w.cgit().subGit("submodule").revList(DEFAULT_BRANCH_NAME).size();
+        int remoteSubmoduleCommits = remote.cgit().subGit("dir-submodule").revList(DEFAULT_BRANCH_NAME).size();
         assertEquals("submodule commit count didn't match", hasShallowSubmoduleSupport ? 2 : remoteSubmoduleCommits, localSubmoduleCommits);
     }
 
@@ -1287,7 +1290,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.init(); // empty repository
 
         // create a new GIT repo.
-        //    master  -- <file1>C
+        //    default branch  -- <file1>C
         //    branch1 -- <file1>C <file2>C
         //    branch2 -- <file1>C <file3>C
         WorkingArea r = new WorkingArea(createTempDirectoryWithoutSpaces());
@@ -1301,14 +1304,14 @@ public abstract class GitAPITestCase extends TestCase {
         r.touch("file2", "content2");
         r.git.add("file2");
         r.git.commit("submod-commit2");
-        r.git.checkout().ref("master").execute();
+        r.git.checkout().ref(DEFAULT_BRANCH_NAME).execute();
 
         r.git.branch("branch2");
         r.git.checkout().ref("branch2").execute();
         r.touch("file3", "content3");
         r.git.add("file3");
         r.git.commit("submod-commit3");
-        r.git.checkout().ref("master").execute();
+        r.git.checkout().ref(DEFAULT_BRANCH_NAME).execute();
 
         // Setup variables for use in tests
         String submodDir = "submod1" + java.util.UUID.randomUUID().toString();
@@ -1316,7 +1319,7 @@ public abstract class GitAPITestCase extends TestCase {
         String subFile2 = submodDir + File.separator + "file2";
         String subFile3 = submodDir + File.separator + "file3";
 
-        // Add new GIT repo to w, at the master branch
+        // Add new GIT repo to w, at the default branch
         w.git.addSubmodule(r.repoPath(), submodDir);
         w.git.submoduleInit();
         assertTrue("file1 does not exist and should be we imported the submodule.", w.exists(subFile1));
@@ -1334,8 +1337,8 @@ public abstract class GitAPITestCase extends TestCase {
         assertFalse("file2 exists and should not because not on 'branch1'", w.exists(subFile2));
         assertTrue("file3 does not exist and should because on branch2", w.exists(subFile3));
 
-        // Switch to master
-        w.git.submoduleUpdate().remoteTracking(true).useBranch(submodDir, "master").timeout(submoduleUpdateTimeout).execute();
+        // Switch to default branch
+        w.git.submoduleUpdate().remoteTracking(true).useBranch(submodDir, DEFAULT_BRANCH_NAME).timeout(submoduleUpdateTimeout).execute();
         assertFalse("file2 exists and should not because not on 'branch1'", w.exists(subFile2));
         assertFalse("file3 exists and should not because not on 'branch2'", w.exists(subFile3));
     }
@@ -1367,27 +1370,27 @@ public abstract class GitAPITestCase extends TestCase {
         workingArea.git.clone_().url(w.repoPath()).execute();
 
         checkoutTimeout = 1 + random.nextInt(60 * 24);
-        workingArea.git.checkout().ref("origin/master").branch("master").deleteBranchIfExist(true).sparseCheckoutPaths(Arrays.asList("dir1")).timeout(checkoutTimeout).execute();
+        workingArea.git.checkout().ref(DEFAULT_REMOTE_BRANCH_NAME).branch(DEFAULT_BRANCH_NAME).deleteBranchIfExist(true).sparseCheckoutPaths(Arrays.asList("dir1")).timeout(checkoutTimeout).execute();
         assertTrue(workingArea.exists("dir1"));
         assertFalse(workingArea.exists("dir2"));
         assertFalse(workingArea.exists("dir3"));
 
-        workingArea.git.checkout().ref("origin/master").branch("master").deleteBranchIfExist(true).sparseCheckoutPaths(Arrays.asList("dir2")).timeout(checkoutTimeout).execute();
+        workingArea.git.checkout().ref(DEFAULT_REMOTE_BRANCH_NAME).branch(DEFAULT_BRANCH_NAME).deleteBranchIfExist(true).sparseCheckoutPaths(Arrays.asList("dir2")).timeout(checkoutTimeout).execute();
         assertFalse(workingArea.exists("dir1"));
         assertTrue(workingArea.exists("dir2"));
         assertFalse(workingArea.exists("dir3"));
 
-        workingArea.git.checkout().ref("origin/master").branch("master").deleteBranchIfExist(true).sparseCheckoutPaths(Arrays.asList("dir1", "dir2")).timeout(checkoutTimeout).execute();
+        workingArea.git.checkout().ref(DEFAULT_REMOTE_BRANCH_NAME).branch(DEFAULT_BRANCH_NAME).deleteBranchIfExist(true).sparseCheckoutPaths(Arrays.asList("dir1", "dir2")).timeout(checkoutTimeout).execute();
         assertTrue(workingArea.exists("dir1"));
         assertTrue(workingArea.exists("dir2"));
         assertFalse(workingArea.exists("dir3"));
 
-        workingArea.git.checkout().ref("origin/master").branch("master").deleteBranchIfExist(true).sparseCheckoutPaths(Collections.<String>emptyList()).timeout(checkoutTimeout).execute();
+        workingArea.git.checkout().ref(DEFAULT_REMOTE_BRANCH_NAME).branch(DEFAULT_BRANCH_NAME).deleteBranchIfExist(true).sparseCheckoutPaths(Collections.<String>emptyList()).timeout(checkoutTimeout).execute();
         assertTrue(workingArea.exists("dir1"));
         assertTrue(workingArea.exists("dir2"));
         assertTrue(workingArea.exists("dir3"));
 
-        workingArea.git.checkout().ref("origin/master").branch("master").deleteBranchIfExist(true).sparseCheckoutPaths(null)
+        workingArea.git.checkout().ref(DEFAULT_REMOTE_BRANCH_NAME).branch(DEFAULT_BRANCH_NAME).deleteBranchIfExist(true).sparseCheckoutPaths(null)
             .timeout(checkoutTimeout)
             .execute();
         assertTrue(workingArea.exists("dir1"));
@@ -1416,9 +1419,9 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_merge_refspec() throws Exception {
         w.init();
         w.commitEmpty("init");
-        w.touch("file-master", "content-master");
-        w.git.add("file-master");
-        w.git.commit("commit1-master");
+        w.touch("file-default-branch", "content-default-branch");
+        w.git.add("file-default-branch");
+        w.git.commit("commit1-default-branch");
         final ObjectId base = w.head();
 
         w.git.branch("branch1");
@@ -1428,7 +1431,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.commit("commit1-branch1");
         final ObjectId branch1 = w.head();
 
-        w.launchCommand("git", "branch", "branch2", "master");
+        w.launchCommand("git", "branch", "branch2", DEFAULT_BRANCH_NAME);
         w.git.checkout().ref("branch2").execute();
         File f = w.touch("file2", "content2");
         w.git.add("file2");
@@ -1491,8 +1494,8 @@ public abstract class GitAPITestCase extends TestCase {
         StandardUsernamePasswordCredentials testCredential = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "bad-id", "bad-desc", "bad-user", "bad-password");
         remoteGit.addDefaultCredentials(testCredential);
         Map<String, ObjectId> heads = remoteGit.getHeadRev(remoteMirrorURL);
-        ObjectId master = w.git.getHeadRev(remoteMirrorURL, "refs/heads/master");
-        assertEquals("URL is " + remoteMirrorURL + ", heads is " + heads, master, heads.get("refs/heads/master"));
+        ObjectId defaultBranch = w.git.getHeadRev(remoteMirrorURL, "refs/heads/" + DEFAULT_BRANCH_NAME);
+        assertEquals("URL is " + remoteMirrorURL + ", heads is " + heads, defaultBranch, heads.get("refs/heads/" + DEFAULT_BRANCH_NAME));
     }
 
     /**
@@ -1512,11 +1515,11 @@ public abstract class GitAPITestCase extends TestCase {
         final String[][] checkBranchSpecs =
         //TODO: Fix and enable test
         {
-            {"a_tests/b_namespace1/master", commits.getProperty("refs/heads/a_tests/b_namespace1/master")},
-            // {"a_tests/b_namespace2/master", commits.getProperty("refs/heads/a_tests/b_namespace2/master")},
-            // {"a_tests/b_namespace3/master", commits.getProperty("refs/heads/a_tests/b_namespace3/master")},
-            // {"b_namespace3/master", commits.getProperty("refs/heads/b_namespace3/master")},
-            // {"master", commits.getProperty("refs/heads/master")},
+            {"a_tests/b_namespace1/" + DEFAULT_BRANCH_NAME, commits.getProperty("refs/heads/a_tests/b_namespace1/" + DEFAULT_BRANCH_NAME)},
+            // {"a_tests/b_namespace2/" + DEFAULT_BRANCH_NAME, commits.getProperty("refs/heads/a_tests/b_namespace2/" + DEFAULT_BRANCH_NAME)},
+            // {"a_tests/b_namespace3/" + DEFAULT_BRANCH_NAME, commits.getProperty("refs/heads/a_tests/b_namespace3/" + DEFAULT_BRANCH_NAME)},
+            // {"b_namespace3/" + DEFAULT_BRANCH_NAME, commits.getProperty("refs/heads/b_namespace3/" + DEFAULT_BRANCH_NAME)},
+            // {DEFAULT_BRANCH_NAME, commits.getProperty("refs/heads/" + DEFAULT_BRANCH_NAME)},
         };
 
         for(String[] branch : checkBranchSpecs) {
@@ -1540,11 +1543,11 @@ public abstract class GitAPITestCase extends TestCase {
         final String remote = tempRemoteDir.getAbsolutePath();
 
         final String[][] checkBranchSpecs = {
-                {"refs/heads/master", commits.getProperty("refs/heads/master")},
-                {"refs/heads/a_tests/b_namespace1/master", commits.getProperty("refs/heads/a_tests/b_namespace1/master")},
-                {"refs/heads/a_tests/b_namespace2/master", commits.getProperty("refs/heads/a_tests/b_namespace2/master")},
-                {"refs/heads/a_tests/b_namespace3/master", commits.getProperty("refs/heads/a_tests/b_namespace3/master")},
-                {"refs/heads/b_namespace3/master", commits.getProperty("refs/heads/b_namespace3/master")}
+                {"refs/heads/" + DEFAULT_BRANCH_NAME, commits.getProperty("refs/heads/" + DEFAULT_BRANCH_NAME)},
+                {"refs/heads/a_tests/b_namespace1/" + DEFAULT_BRANCH_NAME, commits.getProperty("refs/heads/a_tests/b_namespace1/" + DEFAULT_BRANCH_NAME)},
+                {"refs/heads/a_tests/b_namespace2/" + DEFAULT_BRANCH_NAME, commits.getProperty("refs/heads/a_tests/b_namespace2/" + DEFAULT_BRANCH_NAME)},
+                {"refs/heads/a_tests/b_namespace3/" + DEFAULT_BRANCH_NAME, commits.getProperty("refs/heads/a_tests/b_namespace3/" + DEFAULT_BRANCH_NAME)},
+                {"refs/heads/b_namespace3/" + DEFAULT_BRANCH_NAME, commits.getProperty("refs/heads/b_namespace3/" + DEFAULT_BRANCH_NAME)}
                 };
 
         for(String[] branch : checkBranchSpecs) {
@@ -1559,7 +1562,7 @@ public abstract class GitAPITestCase extends TestCase {
      */
     public void test_getRemoteReferences() throws Exception {
         Map<String, ObjectId> references = w.git.getRemoteReferences(remoteMirrorURL, null, false, false);
-        assertTrue(references.containsKey("refs/heads/master"));
+        assertTrue(references.containsKey("refs/heads/" + DEFAULT_BRANCH_NAME));
         assertTrue(references.containsKey("refs/tags/git-client-1.0.0"));
     }
 
@@ -1568,10 +1571,10 @@ public abstract class GitAPITestCase extends TestCase {
      */
     public void test_getRemoteReferences_withLimitReferences() throws Exception {
         Map<String, ObjectId> references = w.git.getRemoteReferences(remoteMirrorURL, null, true, false);
-        assertTrue(references.containsKey("refs/heads/master"));
+        assertTrue(references.containsKey("refs/heads/" + DEFAULT_BRANCH_NAME));
         assertTrue(!references.containsKey("refs/tags/git-client-1.0.0"));
         references = w.git.getRemoteReferences(remoteMirrorURL, null, false, true);
-        assertTrue(!references.containsKey("refs/heads/master"));
+        assertTrue(!references.containsKey("refs/heads/" + DEFAULT_BRANCH_NAME));
         assertTrue(references.containsKey("refs/tags/git-client-1.0.0"));
         for (String key : references.keySet()) {
             assertTrue(!key.endsWith("^{}"));
@@ -1582,11 +1585,11 @@ public abstract class GitAPITestCase extends TestCase {
      * Test getRemoteReferences with matching pattern
      */
     public void test_getRemoteReferences_withMatchingPattern() throws Exception {
-        Map<String, ObjectId> references = w.git.getRemoteReferences(remoteMirrorURL, "refs/heads/master", true, false);
-        assertTrue(references.containsKey("refs/heads/master"));
+        Map<String, ObjectId> references = w.git.getRemoteReferences(remoteMirrorURL, "refs/heads/" + DEFAULT_BRANCH_NAME, true, false);
+        assertTrue(references.containsKey("refs/heads/" + DEFAULT_BRANCH_NAME));
         assertTrue(!references.containsKey("refs/tags/git-client-1.0.0"));
         references = w.git.getRemoteReferences(remoteMirrorURL, "git-client-*", false, true);
-        assertTrue(!references.containsKey("refs/heads/master"));
+        assertTrue(!references.containsKey("refs/heads/" + DEFAULT_BRANCH_NAME));
         for (String key : references.keySet()) {
             assertTrue(key.startsWith("refs/tags/git-client"));
         }
@@ -1606,7 +1609,7 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_getRemoteSymbolicReferences() throws Exception {
         if (!hasWorkingGetRemoteSymbolicReferences()) return; // JUnit 3 replacement for assumeThat
         Map<String, String> references = w.git.getRemoteSymbolicReferences(remoteMirrorURL, null);
-        assertThat(references, hasEntry(is(Constants.HEAD), is(Constants.R_HEADS + Constants.MASTER)));
+        assertThat(references, hasEntry(is(Constants.HEAD), is(Constants.R_HEADS + DEFAULT_JGIT_BRANCH_NAME)));
     }
 
     protected abstract boolean hasWorkingGetRemoteSymbolicReferences();
@@ -1617,7 +1620,7 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_getRemoteSymbolicReferences_withMatchingPattern() throws Exception {
         if (!hasWorkingGetRemoteSymbolicReferences()) return; // JUnit 3 replacement for assumeThat
         Map<String, String> references = w.git.getRemoteSymbolicReferences(remoteMirrorURL, Constants.HEAD);
-        assertThat(references, hasEntry(is(Constants.HEAD), is(Constants.R_HEADS + Constants.MASTER)));
+        assertThat(references, hasEntry(is(Constants.HEAD), is(Constants.R_HEADS + DEFAULT_JGIT_BRANCH_NAME)));
         assertThat(references.size(), is(1));
     }
 
@@ -1680,24 +1683,26 @@ public abstract class GitAPITestCase extends TestCase {
     }
 
     private void check_headRev(String repoURL, ObjectId expectedId) throws InterruptedException, IOException {
-        final ObjectId originMaster = w.git.getHeadRev(repoURL, "origin/master");
-        assertEquals("origin/master mismatch", expectedId, originMaster);
+        final ObjectId originDefaultBranch = w.git.getHeadRev(repoURL, DEFAULT_REMOTE_BRANCH_NAME);
+        assertEquals("origin default branch mismatch", expectedId, originDefaultBranch);
 
-        final ObjectId simpleMaster = w.git.getHeadRev(repoURL, "master");
-        assertEquals("simple master mismatch", expectedId, simpleMaster);
+        final ObjectId simpleDefaultBranch = w.git.getHeadRev(repoURL, DEFAULT_BRANCH_NAME);
+        assertEquals("simple default branch mismatch", expectedId, simpleDefaultBranch);
 
-        final ObjectId wildcardSCMMaster = w.git.getHeadRev(repoURL, "*/master");
-        assertEquals("wildcard SCM master mismatch", expectedId, wildcardSCMMaster);
+        final ObjectId wildcardSCMDefaultBranch = w.git.getHeadRev(repoURL, "*/" + DEFAULT_BRANCH_NAME);
+        assertEquals("wildcard SCM default branch mismatch", expectedId, wildcardSCMDefaultBranch);
 
         /* This assertion may fail if the localMirror has more than
          * one branch matching the wildcard expression in the call to
          * getHeadRev.  The expression is chosen to be unlikely to
          * match with typical branch names, while still matching a
          * known branch name. Should be fine so long as no one creates
-         * branches named like master-master or new-master on the
-         * remote repo */
-        final ObjectId wildcardEndMaster = w.git.getHeadRev(repoURL, "origin/m*aste?");
-        assertEquals("wildcard end master mismatch", expectedId, wildcardEndMaster);
+         * branches named like main-default-branch or new-default-branch on the
+         * remote repo.
+         * 'origin/main' becomes 'origin/m*i?'
+         */
+        final ObjectId wildcardEndDefaultBranch = w.git.getHeadRev(repoURL, DEFAULT_REMOTE_BRANCH_NAME.replace('a', '*').replace('t', '?').replace('n', '?'));
+        assertEquals("wildcard end default branch mismatch", expectedId, wildcardEndDefaultBranch);
     }
 
     public void test_getHeadRev_localMirror() throws Exception {
@@ -1705,15 +1710,15 @@ public abstract class GitAPITestCase extends TestCase {
     }
 
     public void test_getHeadRev_remote() throws Exception {
-        String lsRemote = w.launchCommand("git", "ls-remote", "-h", remoteMirrorURL, "refs/heads/master");
+        String lsRemote = w.launchCommand("git", "ls-remote", "-h", remoteMirrorURL, "refs/heads/" + DEFAULT_BRANCH_NAME);
         ObjectId lsRemoteId = ObjectId.fromString(lsRemote.substring(0, 40));
         check_headRev(remoteMirrorURL, lsRemoteId);
     }
 
     public void test_getHeadRev_current_directory() throws Exception {
         w = clone(localMirror());
-        w.git.checkout().ref("master").execute();
-        final ObjectId master = w.head();
+        w.git.checkout().ref(DEFAULT_BRANCH_NAME).execute();
+        final ObjectId defaultBranch = w.head();
 
         w.git.branch("branch1");
         w.git.checkout().ref("branch1").execute();
@@ -1723,7 +1728,7 @@ public abstract class GitAPITestCase extends TestCase {
         final ObjectId branch1 = w.head();
 
         Map<String, ObjectId> heads = w.git.getHeadRev(w.repoPath());
-        assertEquals(master, heads.get("refs/heads/master"));
+        assertEquals(defaultBranch, heads.get("refs/heads/" + DEFAULT_BRANCH_NAME));
         assertEquals(branch1, heads.get("refs/heads/branch1"));
 
         check_headRev(w.repoPath(), getMirrorHead());
@@ -1735,8 +1740,8 @@ public abstract class GitAPITestCase extends TestCase {
          * which matched the key.
          */
         w = clone(localMirror());
-        w.git.checkout().ref("master").execute();
-        final ObjectId master = w.head();
+        w.git.checkout().ref(DEFAULT_BRANCH_NAME).execute();
+        final ObjectId defaultBranch = w.head();
 
         w.git.branch("branch1");
         w.git.checkout().ref("branch1").execute();
@@ -1745,7 +1750,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.commit("commit1-branch1");
         final ObjectId branch1 = w.head();
 
-        w.launchCommand("git", "branch", "branch.2", "master");
+        w.launchCommand("git", "branch", "branch.2", DEFAULT_BRANCH_NAME);
         w.git.checkout().ref("branch.2").execute();
         File f = w.touch("file.2", "content2");
         w.git.add("file.2");
@@ -1754,7 +1759,7 @@ public abstract class GitAPITestCase extends TestCase {
         assertTrue("file.2 does not exist", f.exists());
 
         Map<String,ObjectId> heads = w.git.getHeadRev(w.repoPath());
-        assertEquals("Wrong master in " + heads, master, heads.get("refs/heads/master"));
+        assertEquals("Wrong default branch in " + heads, defaultBranch, heads.get("refs/heads/" + DEFAULT_BRANCH_NAME));
         assertEquals("Wrong branch1 in " + heads, branch1, heads.get("refs/heads/branch1"));
         assertEquals("Wrong branch.2 in " + heads, branchDot2, heads.get("refs/heads/branch.2"));
 
@@ -1830,7 +1835,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.add("changelog-file");
         w.git.commit("changelog-commit-message");
         String sha1 = w.git.revParse("HEAD").name();
-        check_bounded_changelog_sha1(sha1Prev, sha1, "master");
+        check_bounded_changelog_sha1(sha1Prev, sha1, DEFAULT_BRANCH_NAME);
     }
 
     public void test_show_revision_for_single_commit() throws Exception {
@@ -1882,8 +1887,8 @@ public abstract class GitAPITestCase extends TestCase {
             // Leaks an open file - unclear why
             w.git.clone_().url(gitUrl).repositoryName("origin").reference(localMirror()).execute();
         }
-        String cgitAllLogEntries = w.cgit().getAllLogEntries("origin/master");
-        String igitAllLogEntries = w.igit().getAllLogEntries("origin/master");
+        String cgitAllLogEntries = w.cgit().getAllLogEntries(DEFAULT_REMOTE_BRANCH_NAME);
+        String igitAllLogEntries = w.igit().getAllLogEntries(DEFAULT_REMOTE_BRANCH_NAME);
         if (!cgitAllLogEntries.equals(igitAllLogEntries)) {
             return; // JUnit 3 does not honor @Ignore annotation
         }
@@ -1907,13 +1912,13 @@ public abstract class GitAPITestCase extends TestCase {
         final List<RefSpec> refspecs = Collections.singletonList(new RefSpec(
                 "refs/heads/*:refs/remotes/origin/*"));
         final String remoteBranch = getRemoteBranchPrefix() + Constants.DEFAULT_REMOTE_NAME + "/"
-                + Constants.MASTER;
-        final String bothBranches = Constants.MASTER + "," + remoteBranch;
+                + DEFAULT_JGIT_BRANCH_NAME;
+        final String bothBranches = DEFAULT_JGIT_BRANCH_NAME + "," + remoteBranch;
         w.git.fetch_().from(remote, refspecs).execute();
         checkoutTimeout = 1 + random.nextInt(60 * 24);
-        w.git.checkout().ref(Constants.MASTER).timeout(checkoutTimeout).execute();
+        w.git.checkout().ref(DEFAULT_JGIT_BRANCH_NAME).timeout(checkoutTimeout).execute();
 
-        assertEquals(Constants.MASTER,
+        assertEquals(DEFAULT_JGIT_BRANCH_NAME,
                 formatBranches(w.git.getBranchesContaining(c1.name(), false)));
         assertEquals(bothBranches, formatBranches(w.git.getBranchesContaining(c1.name(), true)));
 
@@ -1927,7 +1932,7 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_checkout_null_ref() throws Exception {
         w = clone(localMirror());
         String branches = w.launchCommand("git", "branch", "-l");
-        assertTrue("master branch not current branch in " + branches, branches.contains("* master"));
+        assertTrue("default branch not current branch in " + branches, branches.contains("* " + DEFAULT_BRANCH_NAME));
         final String branchName = "test-checkout-null-ref-branch-" + java.util.UUID.randomUUID().toString();
         branches = w.launchCommand("git", "branch", "-l");
         assertFalse("test branch originally listed in " + branches, branches.contains(branchName));
@@ -1939,7 +1944,7 @@ public abstract class GitAPITestCase extends TestCase {
     public void test_checkout() throws Exception {
         w = clone(localMirror());
         String branches = w.launchCommand("git", "branch", "-l");
-        assertTrue("master branch not current branch in " + branches, branches.contains("* master"));
+        assertTrue("default branch not current branch in " + branches, branches.contains("* " + DEFAULT_BRANCH_NAME));
         final String branchName = "test-checkout-branch-" + java.util.UUID.randomUUID().toString();
         branches = w.launchCommand("git", "branch", "-l");
         assertFalse("test branch originally listed in " + branches, branches.contains(branchName));
@@ -1957,7 +1962,7 @@ public abstract class GitAPITestCase extends TestCase {
         w = clone(localMirror());
 
         checkoutTimeout = 1 + random.nextInt(60 * 24);
-        w.git.checkout().branch("master").ref("origin/master").timeout(checkoutTimeout).deleteBranchIfExist(true).execute();
+        w.git.checkout().branch(DEFAULT_BRANCH_NAME).ref(DEFAULT_REMOTE_BRANCH_NAME).timeout(checkoutTimeout).deleteBranchIfExist(true).execute();
     }
 
     public void test_revList_remote_branch() throws Exception {
@@ -1997,7 +2002,7 @@ public abstract class GitAPITestCase extends TestCase {
         File lock = new File(w.repo, ".git/index.lock");
         try {
             FileUtils.touch(lock);
-            w.git.checkoutBranch("somebranch", "master");
+            w.git.checkoutBranch("somebranch", DEFAULT_BRANCH_NAME);
             fail();
         } catch (GitLockFailedException e) {
             // expected
@@ -2162,8 +2167,8 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.commit("commit-1");
         String commitSha1 = w.git.revParse("HEAD").name();
 
-        // Merge branch-1 into master
-        w.git.checkout().ref("master").execute();
+        // Merge branch-1 into default branch
+        w.git.checkout().ref(DEFAULT_BRANCH_NAME).execute();
         String mergeMessage = "Merge message to be tested.";
         w.git.merge().setMessage(mergeMessage).setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF).setRevisionToMerge(w.git.getHeadRev(w.repoPath(), "branch-1")).execute();
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1555,52 +1555,6 @@ public abstract class GitAPITestCase extends TestCase {
     }
 
     /**
-     * Test getHeadRev with branch names which SHOULD BE reserved by Git, but ARE NOT.<br/>
-     * E.g. it is possible to create the following LOCAL (!) branches:<br/>
-     * <ul>
-     *   <li> origin/master
-     *   <li> remotes/origin/master
-     *   <li> refs/heads/master
-     *   <li> refs/remotes/origin/master
-     * </ul>
-     *
-     * TODO: This does not work yet! Fix behaviour and enable test!
-     */
-    public void test_getHeadRev_reservedBranchNames() throws Exception {
-        /* REMARK: Local branch names in this test are called exactly like follows!
-         *   e.g. origin/master means the branch is called "origin/master", it does NOT mean master branch in remote "origin".
-         *   or refs/heads/master means branch called "refs/heads/master" ("refs/heads/refs/heads/master" in the end).
-         */
-
-        setTimeoutVisibleInCurrentTest(false);
-        File tempRemoteDir = temporaryDirectoryAllocator.allocate();
-        extract(new ZipFile("src/test/resources/specialBranchRepo.zip"), tempRemoteDir);
-        Properties commits = parseLsRemote(new File("src/test/resources/specialBranchRepo.ls-remote"));
-        w = clone(tempRemoteDir.getAbsolutePath());
-
-        /*
-         * The first entry in the String[2] is the branch name (as specified in the job config).
-         * The second entry is the expected commit.
-         */
-        final String[][] checkBranchSpecs = {};
-//TODO: Fix and enable test
-//                {
-//                {"master", commits.getProperty("refs/heads/master")},
-//                {"origin/master", commits.getProperty("refs/heads/master")},
-//                {"remotes/origin/master", commits.getProperty("refs/heads/master")},
-//                {"refs/remotes/origin/master", commits.getProperty("refs/heads/refs/remotes/origin/master")},
-//                {"refs/heads/origin/master", commits.getProperty("refs/heads/origin/master")},
-//                {"refs/heads/master", commits.getProperty("refs/heads/master")},
-//                {"refs/heads/refs/heads/master", commits.getProperty("refs/heads/refs/heads/master")},
-//                {"refs/heads/refs/heads/refs/heads/master", commits.getProperty("refs/heads/refs/heads/refs/heads/master")},
-//                {"refs/tags/master", commits.getProperty("refs/tags/master^{}")}
-//                };
-        for(String[] branch : checkBranchSpecs) {
-          check_getHeadRev(tempRemoteDir.getAbsolutePath(), branch[0], ObjectId.fromString(branch[1]));
-        }
-    }
-
-    /**
      * Test getRemoteReferences with listing all references
      */
     public void test_getRemoteReferences() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
@@ -55,6 +55,8 @@ public class GitClientSecurityTest {
     /* Marker file used to check for SECURITY-1534 */
     private static String markerFileName = "/tmp/iwantmore-%d.pizza";
 
+    private static final String DEFAULT_BRANCH_NAME = "master";
+
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
     private File repoRoot = null;
@@ -203,7 +205,7 @@ public class GitClientSecurityTest {
         "--shallow-exclude=HEAD",
         "--unshallow",
         "--update-shallow",
-        "--negotiation-tip=master",
+        "--negotiation-tip=" + DEFAULT_BRANCH_NAME,
         "--dry-run",
         "--force",
         "-f",
@@ -280,7 +282,7 @@ public class GitClientSecurityTest {
         String expectedMessage = enableRemoteCheckUrl ? "Invalid remote URL: " + badRemoteUrl : badRemoteUrl.trim();
         GitException e = assertThrows(GitException.class,
                                       () -> {
-                                          gitClient.getHeadRev(badRemoteUrl, "master");
+                                          gitClient.getHeadRev(badRemoteUrl, DEFAULT_BRANCH_NAME);
                                       });
         assertThat(e.getMessage(), containsString(expectedMessage));
     }
@@ -293,7 +295,7 @@ public class GitClientSecurityTest {
         String expectedMessage = enableRemoteCheckUrl ? "Invalid remote URL: " + badRemoteUrl : badRemoteUrl.trim();
         GitException e = assertThrows(GitException.class,
                                       () -> {
-                                          gitClient.getRemoteReferences(badRemoteUrl, "*master", headsOnly, tagsOnly);
+                                          gitClient.getRemoteReferences(badRemoteUrl, "*" + DEFAULT_BRANCH_NAME, headsOnly, tagsOnly);
                                       });
         assertThat(e.getMessage(), containsString(expectedMessage));
     }
@@ -307,7 +309,7 @@ public class GitClientSecurityTest {
         String expectedMessage = enableRemoteCheckUrl ? "Invalid remote URL: " + badRemoteUrl : badRemoteUrl.trim();
         GitException e = assertThrows(GitException.class,
                                       () -> {
-                                          gitClient.getRemoteSymbolicReferences(badRemoteUrl, "master");
+                                          gitClient.getRemoteSymbolicReferences(badRemoteUrl, DEFAULT_BRANCH_NAME);
                                       });
         assertThat(e.getMessage(), containsString(expectedMessage));
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
@@ -40,6 +40,8 @@ public class LegacyCompatibleGitAPIImplTest {
     private final ObjectId gitClientCommit = ObjectId.fromString("d771d97f1e126b1b01ea214ef245d2d5f432200e");
     private final ObjectId taggedCommit = ObjectId.fromString("2db88a20bba8e98b6710f06213f3b60940a63c7c");
 
+    private static final String DEFAULT_BRANCH_NAME = "master";
+
     protected String gitImpl;
 
     public LegacyCompatibleGitAPIImplTest() {
@@ -163,7 +165,7 @@ public class LegacyCompatibleGitAPIImplTest {
     @Deprecated
     public void testShowRevisionTrackedFile() throws Exception {
         File trackedFile = commitTrackedFile();
-        ObjectId head = git.getHeadRev(repo.getPath(), "master");
+        ObjectId head = git.getHeadRev(repo.getPath(), DEFAULT_BRANCH_NAME);
         List<String> revisions = git.showRevision(new Revision(head));
         assertEquals("commit " + head.name(), revisions.get(0));
     }
@@ -234,15 +236,15 @@ public class LegacyCompatibleGitAPIImplTest {
 
     @Test
     public void testExtractBranchNameFromBranchSpec() {
-        assertEquals("master", git.extractBranchNameFromBranchSpec("master"));
-        assertEquals("master", git.extractBranchNameFromBranchSpec("origin/master"));
-        assertEquals("master", git.extractBranchNameFromBranchSpec("*/master"));
+        assertEquals(DEFAULT_BRANCH_NAME, git.extractBranchNameFromBranchSpec(DEFAULT_BRANCH_NAME));
+        assertEquals(DEFAULT_BRANCH_NAME, git.extractBranchNameFromBranchSpec("origin/" + DEFAULT_BRANCH_NAME));
+        assertEquals(DEFAULT_BRANCH_NAME, git.extractBranchNameFromBranchSpec("*/" + DEFAULT_BRANCH_NAME));
         assertEquals("maste*", git.extractBranchNameFromBranchSpec("ori*/maste*"));
-        assertEquals("refs/heads/master", git.extractBranchNameFromBranchSpec("remotes/origin/master"));
-        assertEquals("refs/heads/master", git.extractBranchNameFromBranchSpec("refs/heads/master"));
-        assertEquals("refs/heads/origin/master", git.extractBranchNameFromBranchSpec("refs/heads/origin/master"));
-        assertEquals("master", git.extractBranchNameFromBranchSpec("other/master"));
-        assertEquals("refs/heads/master", git.extractBranchNameFromBranchSpec("refs/remotes/origin/master"));
+        assertEquals("refs/heads/" + DEFAULT_BRANCH_NAME, git.extractBranchNameFromBranchSpec("remotes/origin/" + DEFAULT_BRANCH_NAME));
+        assertEquals("refs/heads/" + DEFAULT_BRANCH_NAME, git.extractBranchNameFromBranchSpec("refs/heads/" + DEFAULT_BRANCH_NAME));
+        assertEquals("refs/heads/origin/" + DEFAULT_BRANCH_NAME, git.extractBranchNameFromBranchSpec("refs/heads/origin/" + DEFAULT_BRANCH_NAME));
+        assertEquals(DEFAULT_BRANCH_NAME, git.extractBranchNameFromBranchSpec("other/" + DEFAULT_BRANCH_NAME));
+        assertEquals("refs/heads/" + DEFAULT_BRANCH_NAME, git.extractBranchNameFromBranchSpec("refs/remotes/origin/" + DEFAULT_BRANCH_NAME));
         assertEquals("refs/tags/mytag", git.extractBranchNameFromBranchSpec("refs/tags/mytag"));
     }
 }


### PR DESCRIPTION

## Improve terminology

Improve the terminology used in tests and Javadoc comments so that it describes use of the default branch name.

- Use better names for default branch
- Improve GitAPITest terminology
- Update changelog example branch name
- Use better branch name in Javadoc
- Use better branch name in comments
- Describe repository type more clearly
- Remove disabled experimental test
- Clarify default branch use in tests
- Clarify use of remote branch name in BranchTest
- Use default branch name constant in the test
- Use default branch name constant in test

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Test and docs improvement
