### PR TITLE
Exclude caffeine 3.0.0 and later from dep checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,7 @@ updates:
   - dependency-name: org.jenkins-ci.plugins:trilead-api
     versions:
     - ">= 1.0.6.a, < 1.0.7"
+  - dependency-name: com.github.ben-manes.caffeine:caffeine
+    # caffeine 3.0.0 and later requires JDK 11
+    versions:
+    - ">= 3.0.0"


### PR DESCRIPTION
## Exclude caffeine 3.0.0 and later from dependency checks

Caffeine 3.0.0 and later require Java 11.  We're not ready to require Java 11.

The caffeine library dependency resolves an upper bounds dependency error that comes from script-security plugin through the most recent bom.  After a future script-security plugin release, this exclusion and the dependencyManagement section for caffeine can be removed.

See https://github.com/jenkinsci/git-client-plugin/pull/704

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
