### PR TITLE
Check the least Cli Git version required 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -300,7 +300,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * Compare the current cli git version with the required version.
      * Finds if the current cli git version is at-least the required version
      *
-     * Returns True if the current cli git version is al-least the required version
+     * Returns True if the current cli git version is at least the required version
      *
      * @param major required major version for command line git
      * @param minor required minor version for command line git

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -302,11 +302,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      *
      * Returns True if the current cli git version is al-least the required version
      *
-     * @param major ,required major version for cli git
-     * @param minor ,required minor version for cli git
-     * @param rev ,required revision for cli git
-     * @param bugfix ,required patches for cli git
-     * @return true if the cli git version is al-least the required version
+     * @param major required major version for command line git
+     * @param minor required minor version for command line git
+     * @param rev required revision for command line git
+     * @param bugfix required patches for command line git
+     * @return true if the command line git version is at least the required version
      **/
     public boolean compareLeastGitVersion(int major, int minor, int rev, int bugfix) {
         return isAtLeastVersion(major,minor,rev,bugfix);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -308,7 +308,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @param bugfix required patches for command line git
      * @return true if the command line git version is at least the required version
      **/
-    public boolean compareLeastGitVersion(int major, int minor, int rev, int bugfix) {
+    public boolean isCliGitVerAtLeast(int major, int minor, int rev, int bugfix) {
         return isAtLeastVersion(major,minor,rev,bugfix);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -298,9 +298,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /**
      * Compare the current cli git version with the required version.
-     * Finds if the current cli git version is at-least the required version
+     * Finds if the current cli git version is at-least the required version.
      *
-     * Returns True if the current cli git version is at least the required version
+     * Returns True if the current cli git version is at least the required version.
      *
      * @param major required major version for command line git
      * @param minor required minor version for command line git

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -297,6 +297,22 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /**
+     * Compare the current cli git version with the required version.
+     * Finds if the current cli git version is at-least the required version
+     *
+     * Returns True if the current cli git version is al-least the required version
+     *
+     * @param major ,required major version for cli git
+     * @param minor ,required minor version for cli git
+     * @param rev ,required revision for cli git
+     * @param bugfix ,required patches for cli git
+     * @return true if the cli git version is al-least the required version
+     **/
+    public boolean compareLeastGitVersion(int major, int minor, int rev, int bugfix) {
+        return isAtLeastVersion(major,minor,rev,bugfix);
+    }
+
+    /**
      * Constructor for CliGitAPIImpl.
      *
      * @param gitExe a {@link java.lang.String} object.
@@ -3828,4 +3844,5 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
         return tags;
     }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -83,7 +83,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
                         version.minor,
                         version.rev,
                         version.bugfix));
-                assertTrue("Failed " + msg, git.compareLeastGitVersion(
+                assertTrue("Failed " + msg, git.isCliGitVerAtLeast(
                         version.major,
                         version.minor,
                         version.rev,
@@ -94,7 +94,7 @@ public class CliGitAPIImplTest extends GitAPITestCase {
                         version.minor,
                         version.rev,
                         version.bugfix));
-                assertFalse("Passed " + msg, git.compareLeastGitVersion(
+                assertFalse("Passed " + msg, git.isCliGitVerAtLeast(
                         version.major,
                         version.minor,
                         version.rev,

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -83,8 +83,18 @@ public class CliGitAPIImplTest extends GitAPITestCase {
                         version.minor,
                         version.rev,
                         version.bugfix));
+                assertTrue("Failed " + msg, git.compareLeastGitVersion(
+                        version.major,
+                        version.minor,
+                        version.rev,
+                        version.bugfix));
             } else {
                 assertFalse("Passed " + msg, git.isAtLeastVersion(
+                        version.major,
+                        version.minor,
+                        version.rev,
+                        version.bugfix));
+                assertFalse("Passed " + msg, git.compareLeastGitVersion(
                         version.major,
                         version.minor,
                         version.rev,


### PR DESCRIPTION
## Compare the Cli Git version with the required Git version

The `CliGitAPIImpl` class provides a method `isAtLeastVersion` which returns true is the required git is at-least the cli git version. Since this method have package-private scope thus restricting it's usage outside the plugin/package. To overcome this issue a new public scoped method `compareLeastGitVersion` is create with similar working. 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
