### PR TITLE
Scope change of getSSHExecutable method

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2480,7 +2480,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return new File(parentPath + "\\ssh.exe");
     }
 
-    /* package */ File getSSHExecutable() {
+    public File getSSHExecutable() {
         // First check the GIT_SSH environment variable
         File sshexe = getFileFromEnv("GIT_SSH", "");
         if (sshexe != null && sshexe.exists()) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2479,7 +2479,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
         return new File(parentPath + "\\ssh.exe");
     }
-
+    /**
+     * Returns an executable file of ssh installed in Windows
+     *
+     * @return File The ssh executable file {@link java.io.File}
+     **/
     public File getSSHExecutable() {
         // First check the GIT_SSH environment variable
         File sshexe = getFileFromEnv("GIT_SSH", "");


### PR DESCRIPTION
## getSSHExecutable method scope conversion to public

The CliGitAPIImpl class provides a method `getSSHExecutable` which returns an executable file of ssh installed in Windows environment. Since this method has package-private scope thus restricting it's usage outside the plugin/package. To overcome this issue the method's scope is changed to public.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)

## Further comments
