### PR TITLE
Reduce usages of Guava in tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -6,7 +6,6 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-import com.google.common.io.Files;
 import hudson.model.Fingerprint;
 import hudson.util.LogTaskListener;
 import java.io.File;
@@ -14,7 +13,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -25,6 +24,7 @@ import java.util.StringJoiner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteConfig;
@@ -194,7 +194,7 @@ public class CredentialsTest {
     private BasicSSHUserPrivateKey newPrivateKeyCredential(String username, File privateKey) throws IOException {
         CredentialsScope scope = CredentialsScope.GLOBAL;
         String id = "private-key-" + privateKey.getPath() + random.nextInt();
-        String privateKeyData = Files.toString(privateKey, Charset.forName("UTF-8"));
+        String privateKeyData = FileUtils.readFileToString(privateKey, StandardCharsets.UTF_8);
         BasicSSHUserPrivateKey.PrivateKeySource privateKeySource = new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(privateKeyData);
         String description = "private key from " + privateKey.getPath();
         if (this.passphrase != null) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
@@ -48,7 +48,7 @@ public class FilePermissionsTest {
     @BeforeClass
     public static void createTestRepo() throws IOException, InterruptedException {
         if (isWindows()) return;
-        repo = com.google.common.io.Files.createTempDir();
+        repo = Files.createTempDirectory(null).toFile();
         Git.with(listener, new hudson.EnvVars()).in(repo).getClient().init();
     }
 
@@ -98,7 +98,7 @@ public class FilePermissionsTest {
     }
 
     private static File cloneTestRepo(File repo) throws IOException, InterruptedException {
-        File newRepo = com.google.common.io.Files.createTempDir();
+        File newRepo = Files.createTempDirectory(null).toFile();
         GitClient git = Git.with(listener, new hudson.EnvVars()).in(newRepo).using("git").getClient();
         String repoURL = repo.toURI().toURL().toString();
         git.clone_().repositoryName("origin").url(repoURL).execute();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -47,7 +47,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import static java.util.stream.Collectors.toList;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -69,7 +69,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.TemporaryDirectoryAllocator;
 import org.objenesis.ObjenesisStd;
 
-import com.google.common.collect.Collections2;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.StandardCopyOption;
@@ -569,7 +568,7 @@ public abstract class GitAPITestCase extends TestCase {
     }
 
     private Collection<String> getBranchNames(Collection<Branch> branches) {
-        return branches.stream().map(Branch::getName).collect(toList());
+        return branches.stream().map(Branch::getName).collect(Collectors.toList());
     }
 
     private void assertBranchesExist(Set<Branch> branches, String ... names) throws InterruptedException {
@@ -1801,16 +1800,21 @@ public abstract class GitAPITestCase extends TestCase {
 
         List<String> revisionDetails = w.git.showRevision(from, to);
 
-        Collection<String> commits = Collections2.filter(revisionDetails, (String detail) -> detail.startsWith("commit "));
+        List<String> commits =
+                revisionDetails.stream()
+                        .filter(detail -> detail.startsWith("commit "))
+                        .collect(Collectors.toList());
         assertEquals(3, commits.size());
         assertTrue(commits.contains("commit 4f2964e476776cf59be3e033310f9177bedbf6a8"));
         // Merge commit is duplicated as have to capture changes that may have been made as part of merge
         assertTrue(commits.contains("commit b53374617e85537ec46f86911b5efe3e4e2fa54b (from 4f2964e476776cf59be3e033310f9177bedbf6a8)"));
         assertTrue(commits.contains("commit b53374617e85537ec46f86911b5efe3e4e2fa54b (from 45e76942914664ee19f31d90e6f2edbfe0d13a46)"));
 
-        Collection<String> diffs = Collections2.filter(revisionDetails, (String detail) -> detail.startsWith(":"));
-        Collection<String> paths = Collections2.transform(diffs, (String diff) -> diff.substring(diff.indexOf('\t')+1).trim() // Windows diff output ^M removed by trim()
-        );
+        List<String> paths =
+                revisionDetails.stream()
+                        .filter(detail -> detail.startsWith(":"))
+                        .map(diff -> diff.substring(diff.indexOf('\t') + 1).trim()) // Windows diff output ^M removed by trim()
+                        .collect(Collectors.toList());
 
         assertTrue(paths.contains(".gitignore"));
         // Some irrelevant changes will be listed due to merge commit
@@ -1835,12 +1839,18 @@ public abstract class GitAPITestCase extends TestCase {
 
         List<String> revisionDetails = w.git.showRevision(from, to, useRawOutput);
 
-        Collection<String> commits = Collections2.filter(revisionDetails, (String detail) -> detail.startsWith("commit "));
+        List<String> commits =
+                revisionDetails.stream()
+                        .filter(detail -> detail.startsWith("commit "))
+                        .collect(Collectors.toList());
         assertEquals(2, commits.size());
         assertTrue(commits.contains("commit 4f2964e476776cf59be3e033310f9177bedbf6a8"));
         assertTrue(commits.contains("commit b53374617e85537ec46f86911b5efe3e4e2fa54b"));
 
-        Collection<String> diffs = Collections2.filter(revisionDetails, (String detail) -> detail.startsWith(":"));
+        List<String> diffs =
+                revisionDetails.stream()
+                        .filter(detail -> detail.startsWith(":"))
+                        .collect(Collectors.toList());
 
         assertTrue(diffs.isEmpty());
     }
@@ -1868,7 +1878,10 @@ public abstract class GitAPITestCase extends TestCase {
         w = clone(localMirror());
         ObjectId to = ObjectId.fromString("51de9eda47ca8dcf03b2af58dfff7355585f0d0c");
         List<String> revisionDetails = w.git.showRevision(null, to);
-        Collection<String> commits = Collections2.filter(revisionDetails, (String detail) -> detail.startsWith("commit "));
+        List<String> commits =
+                revisionDetails.stream()
+                        .filter(detail -> detail.startsWith("commit "))
+                        .collect(Collectors.toList());
         assertEquals(1, commits.size());
         assertTrue(commits.contains("commit 51de9eda47ca8dcf03b2af58dfff7355585f0d0c"));
     }
@@ -1881,7 +1894,10 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.commit("first");
         ObjectId first = w.head();
         List<String> revisionDetails = w.git.showRevision(first);
-        Collection<String> commits = Collections2.filter(revisionDetails, (String detail) -> detail.startsWith("commit "));
+        List<String> commits =
+                revisionDetails.stream()
+                        .filter(detail -> detail.startsWith("commit "))
+                        .collect(Collectors.toList());
         assertTrue("Commits '" + commits + "' missing " + first.getName(), commits.contains("commit " + first.getName()));
         assertEquals("Commits '" + commits + "' wrong size", 1, commits.size());
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.gitclient;
 
-import com.google.common.collect.Lists;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
@@ -17,7 +16,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -1295,7 +1293,7 @@ public class GitClientTest {
             String remote = fetchLFSTestRepo(branch);
             assertEmptyWorkingDir(gitClient);
 
-            List<String> sparsePaths = Lists.newArrayList("uuid.txt");
+            List<String> sparsePaths = Collections.singletonList("uuid.txt");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths).execute();
 
             assertFileContent(file1, expectedContent1);
@@ -1315,7 +1313,7 @@ public class GitClientTest {
             String remote = fetchLFSTestRepo(branch);
             assertEmptyWorkingDir(gitClient);
 
-            List<String> sparsePaths = Lists.newArrayList("uuid.txt", "uuid2.txt");
+            List<String> sparsePaths = Arrays.asList("uuid.txt", "uuid2.txt");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths).execute();
 
             assertFileContent(file1, expectedContent1);
@@ -1336,7 +1334,7 @@ public class GitClientTest {
             String remote = fetchLFSTestRepo(branch);
             assertEmptyWorkingDir(gitClient);
 
-            List<String> sparsePaths = Lists.newArrayList("uuid,3.txt");
+            List<String> sparsePaths = Collections.singletonList("uuid,3.txt");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths).execute();
 
             assertFileContent(file1, expectedContent1); // file present due to workaround
@@ -1356,7 +1354,7 @@ public class GitClientTest {
             String remote = fetchLFSTestRepo(branch);
             assertEmptyWorkingDir(gitClient);
 
-            List<String> sparsePaths = Lists.newArrayList("uuid 4.txt");
+            List<String> sparsePaths = Collections.singletonList("uuid 4.txt");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths).execute();
 
             assertFileNotInWorkingDir(gitClient, file1);
@@ -1376,7 +1374,7 @@ public class GitClientTest {
             String remote = fetchLFSTestRepo(branch);
             assertEmptyWorkingDir(gitClient);
 
-            List<String> sparsePaths = Lists.newArrayList("uuid.t?t");
+            List<String> sparsePaths = Collections.singletonList("uuid.t?t");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths).execute();
 
             assertFileContent(file1, expectedContent1);
@@ -1396,7 +1394,7 @@ public class GitClientTest {
             String remote = fetchLFSTestRepo(branch);
             assertEmptyWorkingDir(gitClient);
 
-            List<String> sparsePaths = Lists.newArrayList("uuid.*");
+            List<String> sparsePaths = Collections.singletonList("uuid.*");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths).execute();
 
             assertFileContent(file1, expectedContent1);
@@ -1416,7 +1414,7 @@ public class GitClientTest {
             String remote = fetchLFSTestRepo(branch);
             assertEmptyWorkingDir(gitClient);
 
-            List<String> sparsePaths = Lists.newArrayList("/**/uuid.txt");
+            List<String> sparsePaths = Collections.singletonList("/**/uuid.txt");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths).execute();
 
             assertFileContent(file1, expectedContent1);
@@ -1436,7 +1434,7 @@ public class GitClientTest {
             String remote = fetchLFSTestRepo(branch);
             assertEmptyWorkingDir(gitClient);
 
-            List<String> sparsePaths = Lists.newArrayList("/*", "!uuid.txt");
+            List<String> sparsePaths = Arrays.asList("/*", "!uuid.txt");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths).execute();
 
             assertFileNotInWorkingDir(gitClient, file1);
@@ -1456,7 +1454,7 @@ public class GitClientTest {
             String remote = fetchLFSTestRepo(branch);
             assertEmptyWorkingDir(gitClient);
 
-            List<String> sparsePaths1 = Lists.newArrayList("uuid.txt");
+            List<String> sparsePaths1 = Collections.singletonList("uuid.txt");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths1).execute();
 
             assertFileContent(file1, expectedContent1);
@@ -1470,7 +1468,7 @@ public class GitClientTest {
             assertFileNotInWorkingDir(gitClient, lfsObjectFile4);
 
 	    if (LFS_SUPPORTS_SPARSE_CHECKOUT) {
-		List<String> sparsePaths2 = Lists.newArrayList("uuid2.txt");
+		List<String> sparsePaths2 = Collections.singletonList("uuid2.txt");
 		gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths2).execute();
 
 		assertFileNotInWorkingDir(gitClient, file1);
@@ -1503,7 +1501,7 @@ public class GitClientTest {
             assertFileInWorkingDir(gitClient, lfsObjectFile3);
             assertFileInWorkingDir(gitClient, lfsObjectFile4);
 
-            List<String> sparsePaths = Lists.newArrayList("uuid.txt");
+            List<String> sparsePaths = Collections.singletonList("uuid.txt");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths).execute();
 
             assertFileContent(file1, expectedContent1);
@@ -1523,7 +1521,7 @@ public class GitClientTest {
             String remote = fetchLFSTestRepo(branch);
             assertEmptyWorkingDir(gitClient);
 
-            List<String> sparsePaths = Lists.newArrayList("uuid.txt");
+            List<String> sparsePaths = Collections.singletonList("uuid.txt");
             gitClient.checkout().ref(remote + "/" + branch).lfsRemote(remote).sparseCheckoutPaths(sparsePaths).execute();
 
             assertFileContent(file1, expectedContent1);
@@ -1977,7 +1975,7 @@ public class GitClientTest {
         lastModifiedFile = null;
         for (File file : repoRoot.listFiles()) {
             if (file.isFile()) {
-                List<String> lines = Files.readAllLines(file.toPath(), Charset.forName("UTF-8"));
+                List<String> lines = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
                 for (String line : lines) {
                     if (line.contains(randomString)) {
                         lastModifiedFile = file;


### PR DESCRIPTION
Replacing some unnecessary usages of Guava in tests with their native Java Platform equivalents.