### PR TITLE
Revert submodule test changes

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1201,8 +1201,8 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.checkout().ref("sub_origin/tests/getSubmodules").branch("tests/getSubmodules").execute();
         List<IndexEntry> r = w.git.getSubmodules("HEAD");
         assertEquals(
-                "[IndexEntry[mode=160000,type=commit,file=modules/firewall,object=3e50abc89dfe13675e66a7791bcc912c6014db3b], " +
-                 "IndexEntry[mode=160000,type=commit,file=modules/ntp,object=d9e287a055322f2985f63c6a77df89f617c823f9], " +
+                "[IndexEntry[mode=160000,type=commit,file=modules/firewall,object=978c8b223b33e203a5c766ecf79704a5ea9b35c8], " +
+                 "IndexEntry[mode=160000,type=commit,file=modules/ntp,object=b62fabbc2bb37908c44ded233e0f4bf479e45609], " +
                  "IndexEntry[mode=160000,type=commit,file=modules/sshkeys,object=689c45ed57f0829735f9a2b16760c14236fe21d9]]",
                 r.toString()
         );

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -709,7 +709,7 @@ public abstract class GitAPITestCase extends TestCase {
         String subRefName = "origin/" + subBranch;
         String ntpDirName = "modules/ntp";
         String contributingFileName = "modules/ntp/CONTRIBUTING.md";
-        String contributingFileContent = "Contributing to Puppet modules";
+        String contributingFileContent = "Puppet Labs modules on the Puppet Forge are open projects";
 
         File modulesDir = new File(w.repo, "modules");
         assertDirNotFound(modulesDir);
@@ -875,7 +875,7 @@ public abstract class GitAPITestCase extends TestCase {
          * since checkout of a branch does not currently use the "-f"
          * option.
          */
-        assertEquals(ObjectId.fromString("915a6bf1c66c6905a6aa68a12c06afe3607cb0eb"), w.git.revParse(subRefName));
+        assertEquals(ObjectId.fromString("a6dd186704985fdb0c60e60f5c6ea7ea35e082e5"), w.git.revParse(subRefName));
         // w.git.checkout().ref(subRefName).branch(subBranch).execute();
         w.git.checkout().ref(subRefName).execute();
         assertDirExists(modulesDir);
@@ -1024,7 +1024,7 @@ public abstract class GitAPITestCase extends TestCase {
 
         final File ntpDir = new File(modulesDir, "ntp");
         final File ntpContributingFile = new File(ntpDir, "CONTRIBUTING.md");
-        final String ntpContributingContent = "Contributing to Puppet modules";
+        final String ntpContributingContent = "Puppet Labs modules on the Puppet Forge are open projects";
         assertFileExists(ntpContributingFile);
         assertFileContains(ntpContributingFile, ntpContributingContent); /* Check substring in file */
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCliGitNotIntialized.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCliGitNotIntialized.java
@@ -271,7 +271,7 @@ public class GitAPITestCliGitNotIntialized {
 
         final File ntpDir = new File(modulesDir, "ntp");
         final File ntpContributingFile = new File(ntpDir, "CONTRIBUTING.md");
-        final String ntpContributingContent = "Contributing to Puppet modules";
+        final String ntpContributingContent = "Puppet Labs modules on the Puppet Forge are open projects";
         assertFileExists(ntpContributingFile);
         assertFileContains(ntpContributingFile, ntpContributingContent); /* Check substring in file */
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestNotIntialized.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestNotIntialized.java
@@ -255,7 +255,7 @@ public class GitAPITestNotIntialized {
 
         final File ntpDir = new File(modulesDir, "ntp");
         final File ntpContributingFile = new File(ntpDir, "CONTRIBUTING.md");
-        final String ntpContributingContent = "Contributing to Puppet modules";
+        final String ntpContributingContent = "Puppet Labs modules on the Puppet Forge are open projects";
         assertFileExists(ntpContributingFile);
         assertFileContains(ntpContributingFile, ntpContributingContent); /* Check substring in file */
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -2371,8 +2371,8 @@ public class GitClientTest {
         String upstream = checkoutAndAssertHasGitModules(branchName, true);
         List<IndexEntry> submodules = gitClient.getSubmodules(branchName);
         IndexEntry[] expectedSubmodules = {
-            new IndexEntry("160000", "commit", "3e50abc89dfe13675e66a7791bcc912c6014db3b", "modules/firewall"),
-            new IndexEntry("160000", "commit", "d9e287a055322f2985f63c6a77df89f617c823f9", "modules/ntp"),
+            new IndexEntry("160000", "commit", "978c8b223b33e203a5c766ecf79704a5ea9b35c8", "modules/firewall"),
+            new IndexEntry("160000", "commit", "b62fabbc2bb37908c44ded233e0f4bf479e45609", "modules/ntp"),
             new IndexEntry("160000", "commit", "689c45ed57f0829735f9a2b16760c14236fe21d9", "modules/sshkeys")
         };
         assertThat(submodules, hasItems(expectedSubmodules));


### PR DESCRIPTION
## Revert submodule test updates

Plugin compatibility tester is an important part of the Jenkins plugin BOM evaluation process.  The change in the `tests/getSubmodules` branch breaks the submodule related tests on released plugin versions.  That disrupts the plugin compatibility tester.

Return to the prior settings that were in the `tests/getSubmodules` branch rather than disrupt PCT.

This reverts commit e208678d925f5bf13432f5ab963345ce782cf308 and 3ede44e2771a256a21ca2f239985f8619981c1fb.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Tests
