### PR TITLE
Introduce new suppressMergeCommitDiff parameter in showRevision 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1286,7 +1286,18 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     @Override
     public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput) throws GitException, InterruptedException {
+    	return showRevision(from, to, useRawOutput, false);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean supressMergeCommitDiff) throws GitException, InterruptedException {
         ArgumentListBuilder args = new ArgumentListBuilder("log", "--full-history", "--no-abbrev", "--format=raw", "-M");
+        
+        if (!supressMergeCommitDiff) {
+            args.add("-m");
+        }
+        
         if (useRawOutput) {
             args.add("--raw");
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1286,7 +1286,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     @Override
     public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput) throws GitException, InterruptedException {
-        ArgumentListBuilder args = new ArgumentListBuilder("log", "--full-history", "--no-abbrev", "--format=raw", "-M", "-m");
+        ArgumentListBuilder args = new ArgumentListBuilder("log", "--full-history", "--no-abbrev", "--format=raw", "-M");
         if (useRawOutput) {
             args.add("--raw");
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1291,10 +1291,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /** {@inheritDoc} */
     @Override
-    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean supressMergeCommitDiff) throws GitException, InterruptedException {
+    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean suppressMergeCommitDiff) throws GitException, InterruptedException {
         ArgumentListBuilder args = new ArgumentListBuilder("log", "--full-history", "--no-abbrev", "--format=raw", "-M");
         
-        if (!supressMergeCommitDiff) {
+        if (!suppressMergeCommitDiff) {
             args.add("-m");
         }
         

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -956,6 +956,29 @@ public interface GitClient {
      */
     List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput) throws GitException, InterruptedException;
 
+    /**
+     * Given a Revision, show it as if it were an entry from git whatchanged, so that it
+     * can be parsed by GitChangeLogParser.
+     *
+     * <p>
+     * If useRawOutput is true, the '--raw' option will include commit file information to be passed to the
+     * GitChangeLogParser.
+     *
+     * <p>
+     * Changes are computed on the [from..to] range. If {@code from} is null, this prints
+     * just one commit that {@code to} represents.
+     *
+     * <p>
+     * If supressMergeCommitDiff is false, for merge commit this method reports one diff per each parent. 
+     *
+     * @param from a {@link org.eclipse.jgit.lib.ObjectId} object.
+     * @param to a {@link org.eclipse.jgit.lib.ObjectId} object.
+     * @param useRawOutput a {java.lang.Boolean} object.
+     * @return The git whatchanged output, in <code>raw</code> format.
+     * @throws hudson.plugins.git.GitException if underlying git operation fails.
+     * @throws java.lang.InterruptedException if interrupted.
+     */
+    List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean supressMergeCommitDiff) throws GitException, InterruptedException;
 
     /**
      * Equivalent of "git-describe --tags".

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -969,7 +969,7 @@ public interface GitClient {
      * just one commit that {@code to} represents.
      *
      * <p>
-     * If supressMergeCommitDiff is false, for merge commit this method reports one diff per each parent. 
+     * If suppressMergeCommitDiff is false, for merge commit this method reports one diff per each parent. 
      *
      * @param from a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @param to a {@link org.eclipse.jgit.lib.ObjectId} object.
@@ -978,7 +978,7 @@ public interface GitClient {
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean supressMergeCommitDiff) throws GitException, InterruptedException;
+    List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean suppressMergeCommitDiff) throws GitException, InterruptedException;
 
     /**
      * Equivalent of "git-describe --tags".

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2119,7 +2119,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     @Override
-    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean supressMergeCommitDiff) throws GitException {
+    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean suppressMergeCommitDiff) throws GitException {
         try (Repository repo = getRepository();
              ObjectReader or = repo.newObjectReader();
              RevWalk w = new RevWalk(or)) {
@@ -2138,7 +2138,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     if (c.getParentCount()<=1 || !useRawOutput) {
                         f.format(c,null,pw,useRawOutput);
                     } else {
-                    	if( !supressMergeCommitDiff ) {
+                    	if( !suppressMergeCommitDiff ) {
 	                        // the effect of the -m option, which makes the diff produce for each parent of a merge commit
 	                        for (RevCommit p : c.getParents()) {
 	                            f.format(c,p,pw,useRawOutput);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2115,6 +2115,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     @Override
     public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput) throws GitException {
+        return showRevision(from, to, useRawOutput, false);
+    }
+
+    @Override
+    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean supressMergeCommitDiff) throws GitException {
         try (Repository repo = getRepository();
              ObjectReader or = repo.newObjectReader();
              RevWalk w = new RevWalk(or)) {
@@ -2133,10 +2138,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     if (c.getParentCount()<=1 || !useRawOutput) {
                         f.format(c,null,pw,useRawOutput);
                     } else {
-                        // the effect of the -m option, which makes the diff produce for each parent of a merge commit
-                        for (RevCommit p : c.getParents()) {
-                            f.format(c,p,pw,useRawOutput);
-                        }
+                    	if( !supressMergeCommitDiff ) {
+	                        // the effect of the -m option, which makes the diff produce for each parent of a merge commit
+	                        for (RevCommit p : c.getParents()) {
+	                            f.format(c,p,pw,useRawOutput);
+	                        }
+                    	}
                     }
 
                     r.addAll(Arrays.asList(sw.toString().split("\n")));

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -745,6 +745,11 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
     }
 
     /** {@inheritDoc} */
+    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean supressMergeCommitDiff) throws GitException, InterruptedException {
+        return proxy.showRevision(from, to, useRawOutput, supressMergeCommitDiff);
+    }
+
+    /** {@inheritDoc} */
     public boolean hasGitModules(String treeIsh) throws GitException, InterruptedException {
         return getGitAPI().hasGitModules(treeIsh);
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -745,8 +745,8 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
     }
 
     /** {@inheritDoc} */
-    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean supressMergeCommitDiff) throws GitException, InterruptedException {
-        return proxy.showRevision(from, to, useRawOutput, supressMergeCommitDiff);
+    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean suppressMergeCommitDiff) throws GitException, InterruptedException {
+        return proxy.showRevision(from, to, useRawOutput, suppressMergeCommitDiff);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
The -m flag breaks polling changes mechanism, for example: 

https://issues.jenkins.io/browse/JENKINS-20389
https://issues.jenkins.io/browse/JENKINS-23606
https://issues.jenkins.io/browse/JENKINS-36180
https://issues.jenkins.io/browse/JENKINS-65932

This pull request is the first step to fix above issues. The next step is to call showRevision in https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/GitSCM.java#L2063 with suppressMergeCommitDiff=true to suppress merge commit diff in change log.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x]  Bug fix (non-breaking change which fixes an issue)
