### PR TITLE
Remove git protocol from GitHub URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>${scmTag}</tag>

--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -45,7 +45,7 @@ public interface IGitAPI extends GitClient {
      * Set remote repository name and URL.
      *
      * @param name name for the remote repository, for examnple, "origin"
-     * @param url URL for the remote repository, for example git://github.com/jenkinsci/git-client-plugin.git
+     * @param url URL for the remote repository, for example https://github.com/jenkinsci/git-client-plugin.git
      * @param GIT_DIR directory containing git repository
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
@@ -240,9 +240,7 @@ public class GitClientSecurityTest {
 
     private static final String[] VALID_REMOTES = {
         "https://github.com/jenkinsci/platformlabeler-plugin.git",
-        "git://github.com/jenkinsci/platformlabeler-plugin.git",
         "https://github.com/jenkinsci/archetypes.git",
-        "git://github.com/jenkinsci/archetypes.git",
         "https://github.com/jenkinsci/archetypes.git",
         "https://git.assembla.com/git-plugin.3.git",
         "https://markewaite@bitbucket.org/markewaite/jenkins-pipeline-utils.git",

--- a/src/test/java/org/jenkinsci/plugins/gitclient/trilead/CredentialsProviderImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/trilead/CredentialsProviderImplTest.java
@@ -23,7 +23,7 @@ public class CredentialsProviderImplTest {
     private final String SECRET_VALUE = "secret-credentials-provider-impl-test";
 
     public CredentialsProviderImplTest() throws URISyntaxException {
-        uri = new URIish("git://github.com/jenkinsci/git-client-plugin.git");
+        uri = new URIish("git://example.com/someone/somewhere.git");
     }
 
     @Before

--- a/src/test/java/org/jenkinsci/plugins/gitclient/trilead/SmartCredentialsProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/trilead/SmartCredentialsProviderTest.java
@@ -32,7 +32,7 @@ public class SmartCredentialsProviderTest {
     private final String SPECIAL_STRING_TYPE_PROMPT = "Password: ";
 
     public SmartCredentialsProviderTest() throws URISyntaxException {
-        gitURI = new URIish("git://github.com/jenkinsci/git-client-plugin.git");
+        gitURI = new URIish("git://example.com/someone/somewhere.git");
     }
 
     @Before


### PR DESCRIPTION
## Replace Git protocol URLs to GitHub with https

Git is deprecating the git protocol per their [blog post](https://github.blog/2021-09-01-improving-git-protocol-security-github/).

* Replace git://github.com with https://github.com in Javadoc
* Replace git://github.com with https://github.com in tests

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test and docs
