### PR TITLE
Use noopener and https in URLs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ It can fetch, checkout, branch, list, merge, and tag repositories.
 Refer to the https://javadoc.jenkins-ci.org/plugin/git-client/[API documentation] for specific API details.
 
 The https://javadoc.jenkins-ci.org/plugin/git-client/org/jenkinsci/plugins/gitclient/GitClient.html[GitClient interface] provides the primary entry points for git access.
-It supports username / password credentials for git repository access with HTTP and HTTPS protocols (for example, `+https://github.com/jenkinsci/git-client-plugin+` or `+http://git.example.com/your-repo.git+` ).
+It supports username / password credentials for git repository access with HTTP and HTTPS protocols (for example, `+https://github.com/jenkinsci/git-client-plugin+` or `+https://git.example.com/your-repo.git+` ).
 It supports private key credentials for git repository access with SSH protocol (for example, `+git@github.com:jenkinsci/git-client-plugin.git+` or `+ssh://git@github.com/jenkinsci/git-client-plugin.git+` ).
 Credential support is provided by the https://plugins.jenkins.io/credentials[Jenkins credentials plugin].
 

--- a/pom.xml
+++ b/pom.xml
@@ -324,8 +324,8 @@
           <force>true</force>
           <failOnError>false</failOnError>
           <links>
-            <link>http://docs.oracle.com/javase/8/docs/api/</link>
-            <link>http://download.eclipse.org/jgit/site/${jgit.version}/org.eclipse.jgit/apidocs/</link>
+            <link>https://docs.oracle.com/javase/8/docs/api/</link>
+            <link>https://download.eclipse.org/jgit/site/${jgit.version}/org.eclipse.jgit/apidocs/</link>
           </links>
         </configuration>
       </plugin>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1093,7 +1093,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /**
-     * On Windows command prompt, '^' is an escape character (http://en.wikipedia.org/wiki/Escape_character#Windows_Command_Prompt)
+     * On Windows command prompt, '^' is an escape character (https://en.wikipedia.org/wiki/Escape_character#Windows_Command_Prompt)
      * This isn't a problem if 'git' we are executing is git.exe, because '^' is a special character only for the command processor,
      * but if 'git' we are executing is git.cmd (which is the case of msysgit), then the arguments we pass in here ends up getting
      * processed by the command processor, and so 'xyz^{commit}' becomes 'xyz{commit}' and fails.
@@ -2545,7 +2545,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
         }
 
-        throw new RuntimeException("ssh executable not found. The git plugin only supports official git client http://git-scm.com/download/win");
+        throw new RuntimeException("ssh executable not found. The git plugin only supports official git client https://git-scm.com/download/win");
     }
 
     private File createWindowsGitSSH(File key, String user) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -829,7 +829,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return references;
     }
 
-    /* Adapted from http://stackoverflow.com/questions/1247772/is-there-an-equivalent-of-java-util-regex-for-glob-type-patterns */
+    /* Adapted from https://stackoverflow.com/questions/1247772/is-there-an-equivalent-of-java-util-regex-for-glob-type-patterns */
     private String createRefRegexFromGlob(String glob)
     {
         StringBuilder out = new StringBuilder();
@@ -1935,7 +1935,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                                 }
                                 specs[spec] = ref.getTarget().getName();
                                 break;
-                            case 1: //for the target ref. we can't use the repository, so we try our best to determine the ref. (see http://git.661346.n2.nabble.com/JGit-Push-to-new-Amazon-S3-does-not-work-quot-funny-refname-quot-td2441026.html)
+                            case 1: //for the target ref. we can't use the repository, so we try our best to determine the ref.
                                 if (!specs[spec].startsWith("/")) {
                                     specs[spec] = "/" + specs[spec];
                                 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/jgit/PreemptiveAuthHttpClientConnection.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/jgit/PreemptiveAuthHttpClientConnection.java
@@ -5,7 +5,7 @@
  * This program and the accompanying materials are made available
  * under the terms of the Eclipse Distribution License v1.0 which
  * accompanies this distribution, is reproduced below, and is
- * available at http://www.eclipse.org/org/documents/edl-v10.php
+ * available at https://www.eclipse.org/org/documents/edl-v10.php
  *
  * All rights reserved.
  *

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -7,10 +7,10 @@
 
 The Jenkins git client plugin provides an API to execute general-purpose git operations on a local or remote repository.
 Its primary use is from the
-<a href="https://plugins.jenkins.io/git" target="_blank">git plugin</a>;
+<a href="https://plugins.jenkins.io/git" target="_blank" rel="noopener">git plugin</a>;
 as such, it is also used by the
-<a href="https://plugins.jenkins.io/gerrit-trigger" target="_blank">gerrit trigger plugin</a>,
-<a href="https://plugins.jenkins.io/git-parameter" target="_blank">git parameter plugin</a>,
+<a href="https://plugins.jenkins.io/gerrit-trigger" target="_blank" rel="noopener">gerrit trigger plugin</a>,
+<a href="https://plugins.jenkins.io/git-parameter" target="_blank" rel="noopener">git parameter plugin</a>,
 and the branch source plugins (GitHub branch source, Bitbucket branch source, Gitea, and others).
 
 <p>Plugin developers are encouraged to use
@@ -18,7 +18,7 @@ and the branch source plugins (GitHub branch source, Bitbucket branch source, Gi
 instead of the legacy IGitAPI.
 
 <p>The plugin isolates low-level git commands from the git-plugin, allowing alternate git implementations
-(like <a href="http://wiki.eclipse.org/JGit/User_Guide"  target="_blank">JGit</a>).</p>
+(like <a href="https://wiki.eclipse.org/JGit/User_Guide" target="_blank" rel="noopener">JGit</a>).</p>
 
 <p>For backwards compatibility, this plugin uses API classes from the hudson.plugins.git package.</p>
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -526,7 +526,7 @@ public class GitAPITest {
          * double struck small t as the first character of the file
          * name. The last three characters of the file name are three
          * different forms of the a-with-ring character. Refer to
-         * http://unicode.org/reports/tr15/#Detecting_Normalization_Forms
+         * https://unicode.org/reports/tr15/#Detecting_Normalization_Forms
          * for the source of those example characters.
          */
         final String fileName = "\uD835\uDD65-\u5c4f\u5e55\u622a\u56fe-\u0041\u030a-\u00c5-\u212b-fileName.xml";

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitURIRequirementsBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitURIRequirementsBuilderTest.java
@@ -153,7 +153,7 @@ public class GitURIRequirementsBuilderTest {
         assertThat(path, notNullValue());
         assertThat(path.getPath(), is("/path/to/repo.git/"));
 
-        list = GitURIRequirementsBuilder.fromUri("http://bob:bobpass@foo.bar.com:8080/path/to/repo.git/").build();
+        list = GitURIRequirementsBuilder.fromUri("https://bob:bobpass@foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
@@ -161,7 +161,7 @@ public class GitURIRequirementsBuilderTest {
         path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
-        assertThat(scheme.getScheme(), is("http"));
+        assertThat(scheme.getScheme(), is("https"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, notNullValue());
@@ -170,7 +170,7 @@ public class GitURIRequirementsBuilderTest {
         assertThat(path, notNullValue());
         assertThat(path.getPath(), is("/path/to/repo.git/"));
 
-        list = GitURIRequirementsBuilder.fromUri("http://foo.bar.com:8080/path/to/repo.git/").build();
+        list = GitURIRequirementsBuilder.fromUri("https://foo.bar.com:8080/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
@@ -178,7 +178,7 @@ public class GitURIRequirementsBuilderTest {
         path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
-        assertThat(scheme.getScheme(), is("http"));
+        assertThat(scheme.getScheme(), is("https"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, notNullValue());
@@ -187,7 +187,7 @@ public class GitURIRequirementsBuilderTest {
         assertThat(path, notNullValue());
         assertThat(path.getPath(), is("/path/to/repo.git/"));
 
-        list = GitURIRequirementsBuilder.fromUri("http://bob@foo.bar.com/path/to/repo.git/").build();
+        list = GitURIRequirementsBuilder.fromUri("https://bob@foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
@@ -195,14 +195,14 @@ public class GitURIRequirementsBuilderTest {
         path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
-        assertThat(scheme.getScheme(), is("http"));
+        assertThat(scheme.getScheme(), is("https"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());
         assertThat(path, notNullValue());
         assertThat(path.getPath(), is("/path/to/repo.git/"));
 
-        list = GitURIRequirementsBuilder.fromUri("http://foo.bar.com/path/to/repo.git/").build();
+        list = GitURIRequirementsBuilder.fromUri("https://foo.bar.com/path/to/repo.git/").build();
 
         scheme = firstOrNull(list, SchemeRequirement.class);
         hostname = firstOrNull(list, HostnameRequirement.class);
@@ -210,7 +210,7 @@ public class GitURIRequirementsBuilderTest {
         path = firstOrNull(list, PathRequirement.class);
 
         assertThat(scheme, notNullValue());
-        assertThat(scheme.getScheme(), is("http"));
+        assertThat(scheme.getScheme(), is("https"));
         assertThat(hostname, notNullValue());
         assertThat(hostname.getHostname(), is("foo.bar.com"));
         assertThat(hostnamePort, nullValue());

--- a/src/test/java/org/jenkinsci/plugins/gitclient/jgit/PreemptiveAuthHttpClientConnectionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/jgit/PreemptiveAuthHttpClientConnectionTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 public class PreemptiveAuthHttpClientConnectionTest {
 
     @Test public void goUp_noPath() throws Exception {
-        final URIish input = new URIish("http://example.com");
+        final URIish input = new URIish("https://example.com");
 
         final URIish actual = PreemptiveAuthHttpClientConnection.goUp(input);
 
@@ -20,7 +20,7 @@ public class PreemptiveAuthHttpClientConnectionTest {
     }
 
     @Test public void goUp_slash() throws Exception {
-        final URIish input = new URIish("http://example.com/");
+        final URIish input = new URIish("https://example.com/");
 
         final URIish actual = PreemptiveAuthHttpClientConnection.goUp(input);
 
@@ -28,57 +28,57 @@ public class PreemptiveAuthHttpClientConnectionTest {
     }
 
     @Test public void goUp_slashSlash() throws Exception {
-        final URIish input = new URIish("http://example.com//");
+        final URIish input = new URIish("https://example.com//");
 
         final URIish actual = PreemptiveAuthHttpClientConnection.goUp(input);
 
         assertNotNull(actual);
-        assertEquals("http://example.com", actual.toString());
+        assertEquals("https://example.com", actual.toString());
     }
 
     @Test public void goUp_one() throws Exception {
-        final URIish input = new URIish("http://example.com/one");
+        final URIish input = new URIish("https://example.com/one");
 
         final URIish actual = PreemptiveAuthHttpClientConnection.goUp(input);
 
         assertNotNull(actual);
-        assertEquals("http://example.com", actual.toString());
+        assertEquals("https://example.com", actual.toString());
     }
 
     @Test public void goUp_oneSlash() throws Exception {
-        final URIish input = new URIish("http://example.com/one/");
+        final URIish input = new URIish("https://example.com/one/");
 
         final URIish actual = PreemptiveAuthHttpClientConnection.goUp(input);
 
         assertNotNull(actual);
-        assertEquals("http://example.com", actual.toString());
+        assertEquals("https://example.com", actual.toString());
     }
 
     @Test public void goUp_oneSlashTwo() throws Exception {
-        final URIish input = new URIish("http://example.com/one/two");
+        final URIish input = new URIish("https://example.com/one/two");
 
         final URIish actual = PreemptiveAuthHttpClientConnection.goUp(input);
 
         assertNotNull(actual);
-        assertEquals("http://example.com/one", actual.toString());
+        assertEquals("https://example.com/one", actual.toString());
     }
 
     @Test public void goUp_oneSlashSlashTwoSlash() throws Exception {
-        final URIish input = new URIish("http://example.com/one//two/");
+        final URIish input = new URIish("https://example.com/one//two/");
 
         final URIish actual = PreemptiveAuthHttpClientConnection.goUp(input);
 
         assertNotNull(actual);
-        assertEquals("http://example.com/one/", actual.toString());
+        assertEquals("https://example.com/one/", actual.toString());
     }
 
     @Test public void goUp_oneSlashTwoSlash() throws Exception {
-        final URIish input = new URIish("http://example.com/one/two/");
+        final URIish input = new URIish("https://example.com/one/two/");
 
         final URIish actual = PreemptiveAuthHttpClientConnection.goUp(input);
 
         assertNotNull(actual);
-        assertEquals("http://example.com/one", actual.toString());
+        assertEquals("https://example.com/one", actual.toString());
     }
 
     private static void createNTCredentials(final String inputUserName, final String inputPassword, final String expectedDomain, final String expectedUserName, final String expectedPassword) {


### PR DESCRIPTION
## Use noopener and https

HTTP protocol should be avoidded because it is easy enough to get a Let's Encrypt certificate to secure a site.  Let's encourage users to run https on all their sites.

* Use noopener with target="blank"
* Use https in docs example
* Use https for javadoc links
* Use https in comments
* Use https in test URLs

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Docs and test
