### PR TITLE
Use 'Report an Issue' redirect for better bug reports

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -93,7 +93,7 @@ It is best to disable Windows Credentials Manager when installing Git on Jenkins
 [#bug-reports]
 == Bug Reports
 
-Report issues and enhancements with the https://issues.jenkins.io[Jenkins issue tracker].
+Report issues and enhancements with the link:https://www.jenkins.io/participate/report-issue/redirect/#17423[Jenkins issue tracker].
 Please use the link:https://www.jenkins.io/participate/report-issue/["How to Report an Issue"] guidelines when reporting issues.
 
 [#contributing-to-the-plugin]


### PR DESCRIPTION
## Use a better 'Report an Issue' link in the docs

Same link is used by https://plugins.jenkins.io.  Encourage submitters to correctly classify their bug reports and to use the correct path to report security issues.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Documentation
