### PR TITLE
Improve detection of LFS sparse checkout limits

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -133,10 +133,13 @@ public class GitClientTest {
         CLI_GIT_SUPPORTS_REV_LIST_NO_WALK = cliGitClient.isAtLeastVersion(1, 5, 3, 0);
 
         boolean gitLFSExists;
+        boolean gitSparseCheckoutWithLFS;
         try {
             // If git-lfs is installed then the version string should look like this:
             // git-lfs/1.5.6 (GitHub; linux amd64; go 1.7.4)
-            gitLFSExists = cliGitClient.launchCommand("lfs", "version").startsWith("git-lfs");
+            String lfsVersionOutput = cliGitClient.launchCommand("lfs", "version");
+            gitLFSExists = lfsVersionOutput.startsWith("git-lfs");
+            gitSparseCheckoutWithLFS = lfsVersionOutput.matches("git-lfs/[3-9][.].*|git-lfs/2[.]1[0-9].*|git-lfs/2[.][89].*");
             // Avoid test failures on ci.jenkins.io agents by calling `git lfs install`
             // Intentionally ignores the return value, assumes that failure will throw an exception
             // and disable the git LFS tests
@@ -144,6 +147,7 @@ public class GitClientTest {
         } catch (GitException exception) {
             // This is expected when git-lfs is not installed.
             gitLFSExists = false;
+            gitSparseCheckoutWithLFS = false;
         }
         CLI_GIT_HAS_GIT_LFS = gitLFSExists;
 
@@ -156,7 +160,7 @@ public class GitClientTest {
             gitLFSConfigured = false;
         }
         CLI_GIT_HAS_GIT_LFS_CONFIGURED = gitLFSConfigured;
-        LFS_SUPPORTS_SPARSE_CHECKOUT = CLI_GIT_HAS_GIT_LFS_CONFIGURED && cliGitClient.isAtLeastVersion(2, 0, 0, 0);
+        LFS_SUPPORTS_SPARSE_CHECKOUT = CLI_GIT_HAS_GIT_LFS_CONFIGURED && gitSparseCheckoutWithLFS && cliGitClient.isAtLeastVersion(2, 0, 0, 0);
     }
 
     @Parameterized.Parameters(name = "{0}")

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -137,7 +137,7 @@ public class GitClientTest {
         try {
             // If git-lfs is installed then the version string should look like this:
             // git-lfs/1.5.6 (GitHub; linux amd64; go 1.7.4)
-            String lfsVersionOutput = cliGitClient.launchCommand("lfs", "version");
+            String lfsVersionOutput = cliGitClient.launchCommand("lfs", "version").trim();
             gitLFSExists = lfsVersionOutput.startsWith("git-lfs");
             gitSparseCheckoutWithLFS = lfsVersionOutput.matches("git-lfs/[3-9][.].*|git-lfs/2[.]1[0-9].*|git-lfs/2[.][89].*");
             // Avoid test failures on ci.jenkins.io agents by calling `git lfs install`


### PR DESCRIPTION

## Better detect Git LFS support for sparse checkout in tests

Git LFS definitely does not support sparse checkout with git lfs 2.3.4.  Known to support sparse checkout with 2.13 and with 3.0.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Test
