### PR TITLE
Improve test performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,13 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>0.8C</forkCount>
+          <reuseForks>true</reuseForks>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -703,6 +703,10 @@ public abstract class GitAPITestCase extends TestCase {
      * @throws Exception on test failure
      */
     public void test_submodule_checkout_and_clean_transitions() throws Exception {
+        if (isWindows() || random.nextBoolean()) {
+            /* Skip slow, low value test on Windows, run 50% of time on non-Windows */
+            return;
+        }
         w = clone(localMirror());
         assertSubmoduleDirs(w.repo, false, false);
 
@@ -1166,6 +1170,10 @@ public abstract class GitAPITestCase extends TestCase {
      */
     @Issue("JENKINS-8122")
     public void test_submodule_tags_not_fetched_into_parent() throws Exception {
+        if (isWindows() || random.nextBoolean()) {
+            /* Skip slow, low value test on Windows, run 50% of time on non-Windows */
+            return;
+        }
         w.git.clone_().url(localMirror()).repositoryName("origin").execute();
         checkoutTimeout = 1 + random.nextInt(60 * 24);
         w.git.checkout().ref("origin/" + DEFAULT_MIRROR_BRANCH_NAME).branch(DEFAULT_MIRROR_BRANCH_NAME).timeout(checkoutTimeout).execute();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -1254,7 +1254,8 @@ public class GitClientTest {
     @Issue("JENKINS-43427") // Git LFS sparse checkout support
     @Test
     public void testSparseCheckoutWithCliGitLFS() throws Exception {
-        if (!gitImplName.equals("git") || !CLI_GIT_HAS_GIT_LFS) {
+        if (!gitImplName.equals("git") || !CLI_GIT_HAS_GIT_LFS || isWindows()) {
+            /* Slow test that does not tell us much more on Windows than Linux */
             return;
         }
 
@@ -1900,7 +1901,8 @@ public class GitClientTest {
     @Test
     public void testSubmoduleUpdateRecursiveRenameModule() throws Exception {
         // JGit implementation doesn't handle renamed submodules
-        if (!gitImplName.equals("git") || !CLI_GIT_SUPPORTS_SUBMODULE_RENAME) {
+        if (!gitImplName.equals("git") || !CLI_GIT_SUPPORTS_SUBMODULE_RENAME || isWindows()) {
+            /* Slow test that does not tell us much more on Windows than Linux */
             return;
         }
         String branch = "tests/getSubmodules";
@@ -1922,7 +1924,8 @@ public class GitClientTest {
     @Test
     public void testSubmoduleRenameModuleUpdateRecursive() throws Exception {
         // JGit implementation doesn't handle renamed submodules
-        if (!gitImplName.equals("git") || !CLI_GIT_SUPPORTS_SUBMODULE_RENAME) {
+        if (!gitImplName.equals("git") || !CLI_GIT_SUPPORTS_SUBMODULE_RENAME || isWindows()) {
+            /* Slow test that does not tell us much more on Windows than Linux */
             return;
         }
         String branch = "tests/getSubmodules";
@@ -2086,7 +2089,8 @@ public class GitClientTest {
     @Issue("JENKINS-37419") // Git plugin checking out non-existent submodule from different branch
     @Test
     public void testOutdatedSubmodulesNotRemoved() throws Exception {
-        if (!CLI_GIT_SUPPORTS_SUBMODULE_DEINIT) {
+        if (!CLI_GIT_SUPPORTS_SUBMODULE_DEINIT || isWindows()) {
+            /* Slow test that does not tell us much more on Windows than Linux */
             return;
         }
         String branch = "tests/getSubmodules";
@@ -2224,7 +2228,8 @@ public class GitClientTest {
     public void testSubmodulesUsedFromOtherBranches() throws Exception {
         /* Submodules not fully supported with JGit */
         // JGit implementation doesn't handle renamed submodules
-        if (!gitImplName.equals("git")) {
+        if (!gitImplName.equals("git") || isWindows()) {
+            /* Slow test that does not tell us much more on Windows than Linux */
             return;
         }
         String oldBranchName = "tests/getSubmodules";

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -1,3 +1,4 @@
+
 package org.jenkinsci.plugins.gitclient;
 
 import hudson.EnvVars;
@@ -235,7 +236,11 @@ public class GitClientTest {
 
     @AfterClass
     public static void removeMirrorAndSrcRepos() throws Exception {
-        FileUtils.deleteDirectory(mirrorParent);
+        try {
+            FileUtils.deleteDirectory(mirrorParent);
+        } catch (IOException ioe) {
+            System.out.println("Ignored cleanup failure on " + mirrorParent);
+        }
     }
 
     @Before


### PR DESCRIPTION
## Improve test performance

Recent changes in the parent pom have increased test repeatability but have slowed test execution.  Increase test execution speed by skipping several slow tests on Windows and by running tests in parallel on multiple Java processes.

* Fork for tests, reuse forks
* Test less on Windows for better speed
* Ignore cleanup failure in GitClienTest

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test
