### PR TITLE
Prevent unused Java import statements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,32 @@
   </pluginRepositories>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.17.7</version>
+          <configuration>
+            <!-- define a language-specific format -->
+            <java>
+              <!-- no need to specify files, inferred automatically -->
+              <endWithNewline></endWithNewline>
+              <removeUnusedImports></removeUnusedImports>
+            </java>
+          </configuration>
+          <executions>
+            <execution>
+              <!-- Runs in verify phase by default -->
+              <goals>
+                <!-- Can be disabled using -Dspotless.check.skip -->
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/hudson/plugins/git/GitTool.java
+++ b/src/main/java/hudson/plugins/git/GitTool.java
@@ -207,4 +207,3 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
         return File.pathSeparatorChar==';';
     }
 }
-

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSampleRepoRule.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSampleRepoRule.java
@@ -119,4 +119,3 @@ public final class GitClientSampleRepoRule extends AbstractSampleDVCSRepoRule {
                 (gitMajor == neededMajor && gitMinor == neededMinor  && gitPatch >= neededPatch);
     }
 }
-


### PR DESCRIPTION
## Prevent unused Java import statements

Also remove trailing blank lines at end of file

Systematically prevent the addition of unused imports.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
