### PR TITLE
Adapt tests to new default branch name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 target/
 work/
 .@tmp/
+.vs/
+.vscode/
 
 .project
 .classpath

--- a/src/main/java/hudson/plugins/git/GitTool.java
+++ b/src/main/java/hudson/plugins/git/GitTool.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static hudson.init.InitMilestone.EXTENSIONS_AUGMENTED;
@@ -124,6 +125,7 @@ public class GitTool extends ToolInstallation implements NodeSpecific<GitTool>, 
         GitTool[] installations = getInstallations(descriptor);
 
         if (installations != null && installations.length > 0) {
+            LOGGER.log(Level.FINEST, "Already initialized GitTool, no need to initialize again");
             //No need to initialize if there's already something
             return;
         }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
@@ -65,7 +65,7 @@ public class FilePermissionsTest {
     public static void computeDefaultBranchName() throws Exception {
         File configDir = Files.createTempDirectory("readGitConfig").toFile();
         CliGitCommand getDefaultBranchNameCmd = new CliGitCommand(Git.with(TaskListener.NULL, new hudson.EnvVars()).in(configDir).using("git").getClient());
-        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--global", "--get", "init.defaultBranch");
+        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--get", "init.defaultBranch");
         for (String s : output) {
             String result = s.trim();
             if (result != null && !result.isEmpty()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -136,7 +136,7 @@ public class GitAPITest {
     public static void computeDefaultBranchName() throws Exception {
         File configDir = Files.createTempDirectory("readGitConfig").toFile();
         CliGitCommand getDefaultBranchNameCmd = new CliGitCommand(Git.with(TaskListener.NULL, new hudson.EnvVars()).in(configDir).using("git").getClient());
-        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--global", "--get", "init.defaultBranch");
+        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--get", "init.defaultBranch");
         for (String s : output) {
             String result = s.trim();
             if (result != null && !result.isEmpty()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -408,7 +408,7 @@ public abstract class GitAPITestCase extends TestCase {
         String defaultBranchValue = "mast" + "er"; // Intentionally split to note this will remain
         File configDir = Files.createTempDirectory("readGitConfig").toFile();
         CliGitCommand getDefaultBranchNameCmd = new CliGitCommand(Git.with(TaskListener.NULL, env).in(configDir).using("git").getClient());
-        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--global", "--get", "init.defaultBranch");
+        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--get", "init.defaultBranch");
         for (String s : output) {
             String result = s.trim();
             if (result != null && !result.isEmpty()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -91,7 +91,7 @@ public class GitClientFetchTest {
     public static void computeDefaultBranchName() throws Exception {
         File configDir = Files.createTempDirectory("readGitConfig").toFile();
         CliGitCommand getDefaultBranchNameCmd = new CliGitCommand(Git.with(TaskListener.NULL, new hudson.EnvVars()).in(configDir).using("git").getClient());
-        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--global", "--get", "init.defaultBranch");
+        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--get", "init.defaultBranch");
         for (String s : output) {
             String result = s.trim();
             if (result != null && !result.isEmpty()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -224,7 +224,7 @@ public class GitClientTest {
     public static void computeDefaultBranchName() throws Exception {
         File configDir = Files.createTempDirectory("readGitConfig").toFile();
         CliGitCommand getDefaultBranchNameCmd = new CliGitCommand(Git.with(TaskListener.NULL, new EnvVars()).in(configDir).using("git").getClient());
-        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--global", "--get", "init.defaultBranch");
+        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--get", "init.defaultBranch");
         for (String s : output) {
             String result = s.trim();
             if (result != null && !result.isEmpty()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
@@ -1,13 +1,11 @@
 package org.jenkinsci.plugins.gitclient;
 
-import hudson.Launcher;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.Tag;
 import hudson.util.StreamTaskListener;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -16,12 +14,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.errors.ConfigInvalidException;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.transport.RemoteConfig;
-import org.eclipse.jgit.transport.URIish;
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
@@ -56,7 +56,7 @@ public class LegacyCompatibleGitAPIImplTest {
     public static void computeDefaultBranchName() throws Exception {
         File configDir = Files.createTempDirectory("readGitConfig").toFile();
         CliGitCommand getDefaultBranchNameCmd = new CliGitCommand(Git.with(TaskListener.NULL, new hudson.EnvVars()).in(configDir).using("git").getClient());
-        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--global", "--get", "init.defaultBranch");
+        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--get", "init.defaultBranch");
         for (String s : output) {
             String result = s.trim();
             if (result != null && !result.isEmpty()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
@@ -97,33 +97,6 @@ public class LegacyCompatibleGitAPIImplTest {
         return f;
     }
 
-    private String cmd(boolean ignoreError, String... args) throws IOException, InterruptedException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        int st = new Launcher.LocalLauncher(listener).launch().pwd(repo).cmds(args).
-                envs(env).stdout(out).join();
-        String s = out.toString();
-        if (!ignoreError) {
-            if (s == null || s.isEmpty()) {
-                s = StringUtils.join(args, ' ');
-            }
-            assertEquals(s, 0, st); /* Reports full output of failing commands */
-
-        }
-        return s;
-    }
-
-    private String log() throws IOException, InterruptedException {
-        return cmd(false, "git", "log", "-n", "3");
-    }
-
-    private String log(ObjectId rev) throws IOException, InterruptedException {
-        return cmd(false, "git", "log", "-n", "3", rev.name());
-    }
-
-    private String contentOf(File file) throws IOException {
-        return FileUtils.readFileToString(file, "UTF-8");
-    }
-
     @Test
     @Deprecated
     public void testCloneRemoteConfig() throws URISyntaxException, InterruptedException, IOException, ConfigInvalidException {
@@ -139,7 +112,6 @@ public class LegacyCompatibleGitAPIImplTest {
                 + "fetch = +refs/heads/*:refs/remotes/" + remoteName + "/*\n";
         config.fromText(configText);
         RemoteConfig remoteConfig = new RemoteConfig(config, remoteName);
-        List<URIish> list = remoteConfig.getURIs();
         git.clone(remoteConfig);
         File[] files = git.workspace.listFiles();
         assertEquals(files.length + "files in " + Arrays.toString(files), 1, files.length);
@@ -172,14 +144,14 @@ public class LegacyCompatibleGitAPIImplTest {
     @Test
     @Deprecated
     public void testShowRevisionThrowsGitException() throws Exception {
-        File trackedFile = commitTrackedFile();
+        commitTrackedFile();
         assertThrows(GitException.class, () -> git.showRevision(new Revision(gitClientCommit)));
     }
 
     @Test
     @Deprecated
     public void testShowRevisionTrackedFile() throws Exception {
-        File trackedFile = commitTrackedFile();
+        commitTrackedFile();
         ObjectId head = git.getHeadRev(repo.getPath(), defaultBranchName);
         List<String> revisions = git.showRevision(new Revision(head));
         assertEquals("commit " + head.name(), revisions.get(0));
@@ -195,7 +167,7 @@ public class LegacyCompatibleGitAPIImplTest {
     @Test
     @Deprecated
     public void testGetTagsOnCommit_non_empty() throws Exception {
-        File trackedFile = commitTrackedFile();
+        commitTrackedFile();
         List<Tag> result = git.getTagsOnCommit(taggedCommit.name());
         assertTrue("Tag list not empty: " + result, result.isEmpty());
     }
@@ -212,7 +184,7 @@ public class LegacyCompatibleGitAPIImplTest {
     @Deprecated
     public void testGetTagsOnCommit() throws Exception {
         LegacyCompatibleGitAPIImpl myGit = (LegacyCompatibleGitAPIImpl) Git.with(listener, env).in(repo).using(gitImpl).getClient();
-        File trackedFile = commitTrackedFile();
+        commitTrackedFile();
         final String uniqueTagName = "testGetTagsOnCommit-" + UUID.randomUUID();
         final String tagMessage = "Tagged with " + uniqueTagName;
         myGit.tag(uniqueTagName, tagMessage);
@@ -240,7 +212,7 @@ public class LegacyCompatibleGitAPIImplTest {
 
     @Test
     public void testLsTreeOneCommit() throws Exception {
-        File trackedFile = commitTrackedFile();
+        commitTrackedFile();
         List<IndexEntry> lsTree = git.lsTree("HEAD");
         assertEquals("lsTree wrong size - " + lsTree, 1, lsTree.size());
         assertEquals("tracked-file", lsTree.get(0).getFile());

--- a/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
@@ -67,7 +67,7 @@ public class MergeCommandTest {
     public static void computeDefaultBranchName() throws Exception {
         File configDir = java.nio.file.Files.createTempDirectory("readGitConfig").toFile();
         CliGitCommand getDefaultBranchNameCmd = new CliGitCommand(Git.with(TaskListener.NULL, new hudson.EnvVars()).in(configDir).using("git").getClient());
-        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--global", "--get", "init.defaultBranch");
+        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--get", "init.defaultBranch");
         for (String s : output) {
             String result = s.trim();
             if (result != null && !result.isEmpty()) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
@@ -180,7 +180,7 @@ public class MergeCommandTest {
     }
 
     @Parameterized.Parameters(name = "{0}")
-    public static Collection gitImplementations() {
+    public static Collection<Object[]> gitImplementations() {
         List<Object[]> args = new ArrayList<>();
         String[] implementations = new String[]{"git", "jgit"};
         for (String implementation : implementations) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushSimpleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushSimpleTest.java
@@ -34,7 +34,7 @@ public class PushSimpleTest extends PushTest {
     }
 
     @Parameterized.Parameters(name = "{0} with {1}")
-    public static Collection pushParameters() {
+    public static Collection<Object[]> pushParameters() {
         List<Object[]> parameters = new ArrayList<>();
         Object[] gitParameter = {"git", "master", "master", null};
         parameters.add(gitParameter);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
@@ -109,7 +109,7 @@ public class PushTest {
     }
 
     @Parameterized.Parameters(name = "{0} with {1} refspec {2}")
-    public static Collection pushParameters() {
+    public static Collection<Object[]> pushParameters() {
         List<Object[]> parameters = new ArrayList<>();
         final String[] implementations = {"git", "jgit"};
         final String[] goodRefSpecs = {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
@@ -17,7 +17,6 @@ import hudson.util.StreamTaskListener;
 import org.apache.commons.io.FileUtils;
 
 import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.URIish;
 
 import org.junit.After;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
@@ -153,7 +153,6 @@ public class PushTest {
     public void createWorkingRepository() throws IOException, InterruptedException {
         hudson.EnvVars env = new hudson.EnvVars();
         TaskListener listener = StreamTaskListener.fromStderr();
-        List<RefSpec> refSpecs = new ArrayList<>();
         workingRepo = temporaryFolder.newFolder();
         workingGitClient = Git.with(listener, env).in(workingRepo).using(gitImpl).getClient();
         workingGitClient.clone_()

--- a/src/test/java/org/jenkinsci/plugins/gitclient/RemoteGitImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/RemoteGitImplTest.java
@@ -98,7 +98,6 @@ public class RemoteGitImplTest {
     public void testSetCredentials() {
         CredentialsScope scope = CredentialsScope.GLOBAL;
         String password = "password";
-        String url = "https://github.com/jenkinsci/git-client-plugin";
         String username = "user";
         String id = "username-" + username + "-password-" + password + "-" + random.nextInt();
         StandardUsernameCredentials credentials = new UsernamePasswordCredentialsImpl(scope, username, password, id, "Credential description");
@@ -109,7 +108,6 @@ public class RemoteGitImplTest {
     public void testAddDefaultCredentials() {
         CredentialsScope scope = CredentialsScope.GLOBAL;
         String password = "password";
-        String url = "https://github.com/jenkinsci/git-client-plugin";
         String username = "user";
         String id = "username-" + username + "-password-" + password + "-" + random.nextInt();
         StandardCredentials credentials = new UsernamePasswordCredentialsImpl(scope, username, password, id, "Credential description");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/SubmodulePatternStringTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/SubmodulePatternStringTest.java
@@ -36,7 +36,7 @@ public class SubmodulePatternStringTest {
      * Tests file, ssh (both forms), git, and https.
      */
     @Parameterized.Parameters(name = "{0}-{1}")
-    public static Collection repoAndRemote() {
+    public static Collection<Object[]> repoAndRemote() {
         List<Object[]> arguments = new ArrayList<>();
         String[] repoUrls = {
             "file://gitroot/thirdparty.url.repo",

--- a/src/test/java/org/jenkinsci/plugins/gitclient/WarnTempDirValueTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/WarnTempDirValueTest.java
@@ -73,7 +73,7 @@ public class WarnTempDirValueTest {
     }
 
     @Parameterized.Parameters(name = "{0}")
-    public static Collection envVarsToCheck() {
+    public static Collection<Object[]> envVarsToCheck() {
         List<Object[]> envVarNames = new ArrayList<>();
         Object[] tmp = {"TMP"};
         envVarNames.add(tmp);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/trilead/CredentialsProviderImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/trilead/CredentialsProviderImplTest.java
@@ -95,7 +95,6 @@ public class CredentialsProviderImplTest {
 
     @Test
     public void testSupportsDisallowed() {
-        Secret secret = Secret.fromString(SECRET_VALUE);
         listener = StreamTaskListener.fromStdout();
         StandardUsernameCredentials badCred = new MyUsernameCredentialsImpl(USER_NAME);
         CredentialsProviderImpl badProvider = new CredentialsProviderImpl(listener, badCred);


### PR DESCRIPTION
## [JENKINS-67362](https://issues.jenkins.io/browse/JENKINS-67362)- Test with init.defaultBranch value

* [JENKINS-67362](https://issues.jenkins.io/browse/JENKINS-67362) Test with init.defaultBranch value
* Ignore VSCode working files
* Log GitTool redundant initialization
* Use spotless to remove unused imports
* Remove unused variables in tests
* Return a typed collection in test

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test improvement
