### PR TITLE
Remove unused assertions and assert methods

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCliGitNotIntialized.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCliGitNotIntialized.java
@@ -44,26 +44,12 @@ public class GitAPITestCliGitNotIntialized {
     @Rule
     public GitClientSampleRepoRule repo = new GitClientSampleRepoRule();
 
-    @Rule
-    public GitClientSampleRepoRule secondRepo = new GitClientSampleRepoRule();
-
-    @Rule
-    public GitClientSampleRepoRule thirdRepo = new GitClientSampleRepoRule();
-
     private int logCount = 0;
     private final Random random = new Random();
     private static final String LOGGING_STARTED = "Logging started";
     private LogHandler handler = null;
     private TaskListener listener;
     private final String gitImplName;
-
-    private String revParseBranchName = null;
-
-    private int checkoutTimeout = -1;
-    private int cloneTimeout = -1;
-    private int fetchTimeout = -1;
-    private int submoduleUpdateTimeout = -1;
-
 
     WorkspaceWithRepo workspace;
 
@@ -89,13 +75,13 @@ public class GitAPITestCliGitNotIntialized {
     @BeforeClass
     public static void loadLocalMirror() throws Exception {
         /* Prime the local mirror cache before other tests run */
-        /* Allow 2-5 second delay before priming the cache */
+        /* Allow 2-6 second delay before priming the cache */
         /* Allow other tests a better chance to prime the cache */
-        /* 2-5 second delay is small compared to execution time of this test */
+        /* 2-6 second delay is small compared to execution time of this test */
         Random random = new Random();
-        Thread.sleep((2 + random.nextInt(4)) * 1000L); // Wait 2-5 seconds before priming the cache
+        Thread.sleep(2000L + random.nextInt(4000)); // Wait 2-6 seconds before priming the cache
         TaskListener mirrorListener = StreamTaskListener.fromStdout();
-        File tempDir = Files.createTempDirectory("PrimeGITAPITest").toFile();
+        File tempDir = Files.createTempDirectory("PrimeGitAPITestCliGitNotInitialized").toFile();
         WorkspaceWithRepo cache = new WorkspaceWithRepo(tempDir, "git", mirrorListener);
         cache.localMirror();
         Util.deleteRecursive(tempDir);
@@ -103,12 +89,6 @@ public class GitAPITestCliGitNotIntialized {
 
     @Before
     public void setUpRepositories() throws Exception {
-        revParseBranchName = null;
-        checkoutTimeout = -1;
-        cloneTimeout = -1;
-        fetchTimeout = -1;
-        submoduleUpdateTimeout = -1;
-
         Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);
         handler = new LogHandler();
         handler.setLevel(Level.ALL);
@@ -130,80 +110,9 @@ public class GitAPITestCliGitNotIntialized {
         try {
             String messages = StringUtils.join(handler.getMessages(), ";");
             assertTrue("Logging not started: " + messages, handler.containsMessageSubstring(LOGGING_STARTED));
-            assertCheckoutTimeout();
-            assertCloneTimeout();
-            assertFetchTimeout();
-            assertSubmoduleUpdateTimeout();
-            assertRevParseCalls(revParseBranchName);
         } finally {
             handler.close();
         }
-    }
-
-    private void assertCheckoutTimeout() {
-        if (checkoutTimeout > 0) {
-            assertSubstringTimeout("git checkout", checkoutTimeout);
-        }
-    }
-
-    private void assertCloneTimeout() {
-        if (cloneTimeout > 0) {
-            // clone_() uses "git fetch" internally, not "git clone"
-            assertSubstringTimeout("git fetch", cloneTimeout);
-        }
-    }
-
-    private void assertFetchTimeout() {
-        if (fetchTimeout > 0) {
-            assertSubstringTimeout("git fetch", fetchTimeout);
-        }
-    }
-
-    private void assertSubmoduleUpdateTimeout() {
-        if (submoduleUpdateTimeout > 0) {
-            assertSubstringTimeout("git submodule update", submoduleUpdateTimeout);
-        }
-    }
-
-    private void assertSubstringTimeout(final String substring, int expectedTimeout) {
-        if (!(testGitClient instanceof CliGitAPIImpl)) { // Timeout only implemented in CliGitAPIImpl
-            return;
-        }
-        List<String> messages = handler.getMessages();
-        List<String> substringMessages = new ArrayList<>();
-        List<String> substringTimeoutMessages = new ArrayList<>();
-        final String messageRegEx = ".*\\b" + substring + "\\b.*"; // the expected substring
-        final String timeoutRegEx = messageRegEx
-                + " [#] timeout=" + expectedTimeout + "\\b.*"; // # timeout=<value>
-        for (String message : messages) {
-            if (message.matches(messageRegEx)) {
-                substringMessages.add(message);
-            }
-            if (message.matches(timeoutRegEx)) {
-                substringTimeoutMessages.add(message);
-            }
-        }
-        assertThat(messages, is(not(empty())));
-        assertThat(substringMessages, is(not(empty())));
-        assertThat(substringTimeoutMessages, is(not(empty())));
-        assertEquals(substringMessages, substringTimeoutMessages);
-    }
-
-    /* JENKINS-33258 detected many calls to git rev-parse. This checks
-     * those calls are not being made. The createRevParseBranch call
-     * creates a branch whose name is unknown to the tests. This
-     * checks that the branch name is not mentioned in a call to
-     * git rev-parse.
-     */
-    private void assertRevParseCalls(String branchName) {
-        if (revParseBranchName == null) {
-            return;
-        }
-        String messages = StringUtils.join(handler.getMessages(), ";");
-        // Linux uses rev-parse without quotes
-        assertFalse("git rev-parse called: " + messages, handler.containsMessageSubstring("rev-parse " + branchName));
-        // Windows quotes the rev-parse argument
-        assertFalse("git rev-parse called: " + messages, handler.containsMessageSubstring("rev-parse \"" + branchName));
     }
 
     /* Submodule checkout in JGit does not support renamed submodules.

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestForCliGit.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestForCliGit.java
@@ -44,23 +44,12 @@ public class GitAPITestForCliGit {
     @Rule
     public GitClientSampleRepoRule secondRepo = new GitClientSampleRepoRule();
 
-    @Rule
-    public GitClientSampleRepoRule thirdRepo = new GitClientSampleRepoRule();
-
     private int logCount = 0;
     private final Random random = new Random();
     private static final String LOGGING_STARTED = "Logging started";
     private LogHandler handler = null;
     private TaskListener listener;
     private final String gitImplName;
-
-    private String revParseBranchName = null;
-
-    private int checkoutTimeout = -1;
-    private int cloneTimeout = -1;
-    private int fetchTimeout = -1;
-    private int submoduleUpdateTimeout = -1;
-
 
     WorkspaceWithRepo workspace;
 
@@ -86,13 +75,13 @@ public class GitAPITestForCliGit {
     @BeforeClass
     public static void loadLocalMirror() throws Exception {
         /* Prime the local mirror cache before other tests run */
-        /* Allow 2-5 second delay before priming the cache */
+        /* Allow 2-6 second delay before priming the cache */
         /* Allow other tests a better chance to prime the cache */
-        /* 2-5 second delay is small compared to execution time of this test */
+        /* 2-6 second delay is small compared to execution time of this test */
         Random random = new Random();
-        Thread.sleep((2 + random.nextInt(4)) * 1000L); // Wait 2-5 seconds before priming the cache
+        Thread.sleep(2000L + random.nextInt(4000)); // Wait 2-6 seconds before priming the cache
         TaskListener mirrorListener = StreamTaskListener.fromStdout();
-        File tempDir = Files.createTempDirectory("PrimeGITAPITest").toFile();
+        File tempDir = Files.createTempDirectory("PrimeGitAPITestForCliGit").toFile();
         WorkspaceWithRepo cache = new WorkspaceWithRepo(tempDir, "git", mirrorListener);
         cache.localMirror();
         Util.deleteRecursive(tempDir);
@@ -100,12 +89,6 @@ public class GitAPITestForCliGit {
 
     @Before
     public void setUpRepositories() throws Exception {
-        revParseBranchName = null;
-        checkoutTimeout = -1;
-        cloneTimeout = -1;
-        fetchTimeout = -1;
-        submoduleUpdateTimeout = -1;
-
         Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);
         handler = new LogHandler();
         handler.setLevel(Level.ALL);
@@ -140,80 +123,9 @@ public class GitAPITestForCliGit {
         try {
             String messages = StringUtils.join(handler.getMessages(), ";");
             assertTrue("Logging not started: " + messages, handler.containsMessageSubstring(LOGGING_STARTED));
-            assertCheckoutTimeout();
-            assertCloneTimeout();
-            assertFetchTimeout();
-            assertSubmoduleUpdateTimeout();
-            assertRevParseCalls(revParseBranchName);
         } finally {
             handler.close();
         }
-    }
-
-    private void assertCheckoutTimeout() {
-        if (checkoutTimeout > 0) {
-            assertSubstringTimeout("git checkout", checkoutTimeout);
-        }
-    }
-
-    private void assertCloneTimeout() {
-        if (cloneTimeout > 0) {
-            // clone_() uses "git fetch" internally, not "git clone"
-            assertSubstringTimeout("git fetch", cloneTimeout);
-        }
-    }
-
-    private void assertFetchTimeout() {
-        if (fetchTimeout > 0) {
-            assertSubstringTimeout("git fetch", fetchTimeout);
-        }
-    }
-
-    private void assertSubmoduleUpdateTimeout() {
-        if (submoduleUpdateTimeout > 0) {
-            assertSubstringTimeout("git submodule update", submoduleUpdateTimeout);
-        }
-    }
-
-    private void assertSubstringTimeout(final String substring, int expectedTimeout) {
-        if (!(testGitClient instanceof CliGitAPIImpl)) { // Timeout only implemented in CliGitAPIImpl
-            return;
-        }
-        List<String> messages = handler.getMessages();
-        List<String> substringMessages = new ArrayList<>();
-        List<String> substringTimeoutMessages = new ArrayList<>();
-        final String messageRegEx = ".*\\b" + substring + "\\b.*"; // the expected substring
-        final String timeoutRegEx = messageRegEx
-                + " [#] timeout=" + expectedTimeout + "\\b.*"; // # timeout=<value>
-        for (String message : messages) {
-            if (message.matches(messageRegEx)) {
-                substringMessages.add(message);
-            }
-            if (message.matches(timeoutRegEx)) {
-                substringTimeoutMessages.add(message);
-            }
-        }
-        assertThat(messages, is(not(empty())));
-        assertThat(substringMessages, is(not(empty())));
-        assertThat(substringTimeoutMessages, is(not(empty())));
-        assertEquals(substringMessages, substringTimeoutMessages);
-    }
-
-    /* JENKINS-33258 detected many calls to git rev-parse. This checks
-     * those calls are not being made. The createRevParseBranch call
-     * creates a branch whose name is unknown to the tests. This
-     * checks that the branch name is not mentioned in a call to
-     * git rev-parse.
-     */
-    private void assertRevParseCalls(String branchName) {
-        if (revParseBranchName == null) {
-            return;
-        }
-        String messages = StringUtils.join(handler.getMessages(), ";");
-        // Linux uses rev-parse without quotes
-        assertFalse("git rev-parse called: " + messages, handler.containsMessageSubstring("rev-parse " + branchName));
-        // Windows quotes the rev-parse argument
-        assertFalse("git rev-parse called: " + messages, handler.containsMessageSubstring("rev-parse \"" + branchName));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestJGitNotInitialized.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestJGitNotInitialized.java
@@ -70,7 +70,7 @@ public class GitAPITestJGitNotInitialized {
         Random random = new Random();
         Thread.sleep(2000L + random.nextInt(3000)); // Wait 2-5 seconds before priming the cache
         TaskListener mirrorListener = StreamTaskListener.fromStdout();
-        File tempDir = Files.createTempDirectory("PrimeGITAPITest").toFile();
+        File tempDir = Files.createTempDirectory("PrimeGitAPITestJGitNotInitialized").toFile();
         WorkspaceWithRepo cache = new WorkspaceWithRepo(tempDir, "git", mirrorListener);
         cache.localMirror();
         Util.deleteRecursive(tempDir);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestNotIntialized.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestNotIntialized.java
@@ -42,26 +42,12 @@ public class GitAPITestNotIntialized {
     @Rule
     public GitClientSampleRepoRule repo = new GitClientSampleRepoRule();
 
-    @Rule
-    public GitClientSampleRepoRule secondRepo = new GitClientSampleRepoRule();
-
-    @Rule
-    public GitClientSampleRepoRule thirdRepo = new GitClientSampleRepoRule();
-
     private int logCount = 0;
     private final Random random = new Random();
     private static final String LOGGING_STARTED = "Logging started";
     private LogHandler handler = null;
     private TaskListener listener;
     private final String gitImplName;
-
-    private String revParseBranchName = null;
-
-    private int checkoutTimeout = -1;
-    private int cloneTimeout = -1;
-    private int fetchTimeout = -1;
-    private int submoduleUpdateTimeout = -1;
-
 
     WorkspaceWithRepo workspace;
 
@@ -85,13 +71,13 @@ public class GitAPITestNotIntialized {
     @BeforeClass
     public static void loadLocalMirror() throws Exception {
         /* Prime the local mirror cache before other tests run */
-        /* Allow 2-5 second delay before priming the cache */
+        /* Allow 2-6 second delay before priming the cache */
         /* Allow other tests a better chance to prime the cache */
-        /* 2-5 second delay is small compared to execution time of this test */
+        /* 2-6 second delay is small compared to execution time of this test */
         Random random = new Random();
-        Thread.sleep((2 + random.nextInt(4)) * 1000L); // Wait 2-5 seconds before priming the cache
+        Thread.sleep(2000L + random.nextInt(4000)); // Wait 2-6 seconds before priming the cache
         TaskListener mirrorListener = StreamTaskListener.fromStdout();
-        File tempDir = Files.createTempDirectory("PrimeGITAPITest").toFile();
+        File tempDir = Files.createTempDirectory("PrimeGitAPITestNotInitialized").toFile();
         WorkspaceWithRepo cache = new WorkspaceWithRepo(tempDir, "git", mirrorListener);
         cache.localMirror();
         Util.deleteRecursive(tempDir);
@@ -99,12 +85,6 @@ public class GitAPITestNotIntialized {
 
     @Before
     public void setUpRepositories() throws Exception {
-        revParseBranchName = null;
-        checkoutTimeout = -1;
-        cloneTimeout = -1;
-        fetchTimeout = -1;
-        submoduleUpdateTimeout = -1;
-
         Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);
         handler = new LogHandler();
         handler.setLevel(Level.ALL);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCliCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCliCloneTest.java
@@ -204,10 +204,8 @@ public class GitClientCliCloneTest {
     }
 
     /* JENKINS-33258 detected many calls to git rev-parse. This checks
-     * those calls are not being made. The createRevParseBranch call
-     * creates a branch whose name is unknown to the tests. This
-     * checks that the branch name is not mentioned in a call to
-     * git rev-parse.
+     * those calls that unexpectedBranchName is not referenced in the
+     * log.
      */
     private void assertRevParseNotCalled(GitClient gitClient, String unexpectedBranchName) {
         assertLoggedMessage(gitClient, "git rev-parse ", unexpectedBranchName, false);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -76,13 +76,13 @@ public class GitClientCloneTest {
     @BeforeClass
     public static void loadLocalMirror() throws Exception {
         /* Prime the local mirror cache before other tests run */
-        /* Allow 3-7 second delay before priming the cache */
+        /* Allow 3-8 second delay before priming the cache */
         /* Allow other tests a better chance to prime the cache */
-        /* 3-7 second delay is small compared to execution time of this test */
+        /* 3-8 second delay is small compared to execution time of this test */
         Random random = new Random();
-        Thread.sleep((3 + random.nextInt(5)) * 1000L); // Wait 3-7 seconds before priming the cache
+        Thread.sleep(3000L + random.nextInt(5000)); // Wait 3-8 seconds before priming the cache
         TaskListener mirrorListener = StreamTaskListener.fromStdout();
-        File tempDir = Files.createTempDirectory("PrimeCloneTest").toFile();
+        File tempDir = Files.createTempDirectory("PrimeGitClientCloneTest").toFile();
         WorkspaceWithRepo cache = new WorkspaceWithRepo(tempDir, "git", mirrorListener);
         cache.localMirror();
         Util.deleteRecursive(tempDir);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -104,13 +104,13 @@ public class GitClientFetchTest {
     @BeforeClass
     public static void loadLocalMirror() throws Exception {
         /* Prime the local mirror cache before other tests run */
-        /* Allow 2-5 second delay before priming the cache */
+        /* Allow 2-6 second delay before priming the cache */
         /* Allow other tests a better chance to prime the cache */
-        /* 2-5 second delay is small compared to execution time of this test */
+        /* 2-6 second delay is small compared to execution time of this test */
         Random random = new Random();
-        Thread.sleep((2 + random.nextInt(4)) * 1000L); // Wait 2-5 seconds before priming the cache
+        Thread.sleep(2000L + random.nextInt(4000)); // Wait 2-6 seconds before priming the cache
         TaskListener mirrorListener = StreamTaskListener.fromStdout();
-        File tempDir = Files.createTempDirectory("PrimeFetchTest").toFile();
+        File tempDir = Files.createTempDirectory("PrimeGitClientFetchTest").toFile();
         WorkspaceWithRepo cache = new WorkspaceWithRepo(tempDir, "git", mirrorListener);
         cache.localMirror();
         Util.deleteRecursive(tempDir);


### PR DESCRIPTION
## Remove unused assertions

Earlier splits of tests from one large file into smaller files did not consider that the tests in the smaller files did not need all the infrastructure that had been included when all the tests were in a single, larger file.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test improvements
