### PR TITLE
[JENKINS-67466] Add timeout to JGit remote operations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,6 +56,22 @@ Click the "*Add Git*" button in the "*Global Tool Configuration*" section under 
 
 image::images/enable-jgit.png[Enable JGit or JGit with Apache HTTP Client]
 
+=== JGit timeout
+
+The command line git implementation in the git client plugin provides a timeout setting for many operations like fetch and checkout.
+Operations that take more than the specified time are canceled.
+When the timeout is exceeded, the command line git process fails and the git client plugin API operation fails.
+
+The JGit implementation in the git client plugin uses a different concept of timeout.
+The JGit timeout is a network level transport timeout rather than a timeout of a higher level JGit operation.
+If the JGit network transport does not receive a response within the defined timeout, the JGit API call fails.
+The link:https://javadoc.io/static/org.eclipse.jgit/org.eclipse.jgit/5.13.0.202109080827-r/org/eclipse/jgit/transport/Transport.html#setTimeout-int-[JGit javadoc] describes the JGit API.
+
+The JGit timeout implementation prevents JGit operations from hanging indefinitely when a remote server stops responding.
+It does not stop a JGit operation if it has executed for more than a specified time.
+The JGit timeout counter is reset each time a response is received from the remote server during the JGit API call.
+The command line git timeout counter is set at the start of the command line git call and is not reset during the call.
+
 [#jgit-with-apache-http-client]
 === JGit with Apache HTTP Client
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -40,7 +40,6 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         Method m = getClass().getMethod(getName());
 
         if (m.getAnnotation(NotImplementedInCliGit.class) != null) {
-            setTimeoutVisibleInCurrentTest(false); /* No timeout if not implemented in CliGitAPIImpl */
             return; // skip this test case
         }
         try {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
@@ -18,12 +18,9 @@ public class JGitAPIImplTest extends GitAPITestCase {
         return true; // JGit 5.10 has getRemoteSymbolicReferences, prior did not
     }
 
-    /**
-     * timeout is not implemented in JGitAPIImpl.
-     */
     @Override
     protected boolean getTimeoutVisibleInCurrentTest() {
-        return false;
+        return true; // git client plugin 3.11.0 supports JGit timeout
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitApacheAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitApacheAPIImplTest.java
@@ -18,12 +18,9 @@ public class JGitApacheAPIImplTest extends GitAPITestCase {
         return true; // JGit 5.10 gets remote symbolic references, prior did not
     }
 
-    /**
-     * timeout is not implemented in JGitAPIImpl.
-     */
     @Override
     protected boolean getTimeoutVisibleInCurrentTest() {
-        return false;
+        return true; // git client plugin 3.11.0 supports JGit timeout
     }
 
     /**


### PR DESCRIPTION
## [JENKINS-67466](https://issues.jenkins.io/browse/JENKINS-67466) - Add timeout to JGit remote operations

Uses the JGit timeout implementation to prevent JGit operations from hanging indefinitely.

The JGit timeout implementation has a very different behavior than the timeout implementation for command line git.  The command line git implementation stops once the timeout has expired.  The JGit timeout implementation stops after timeout period has completed with no traffic during the timeout period.

This does not add timeout support to JGit checkout because JGit checkout does not provide a timeout API.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature
