### PR TITLE
Run JMH benchmarks only with benchmark.run=true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ work/
 .classpath
 .settings/
 
+# Java microbenchmark harness results file
+/jmh-report.json
+
 /nb-configuration.xml
 
 # Vim

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -89,4 +89,6 @@ Typical bug review tasks include:
 Git client plugin includes link:https://openjdk.java.net/projects/code-tools/jmh/[Java Microbenchmark Harness (JMH)] benchmark tests to compare the performance of command line git and JGit.
 Run the benchmarks with the command:
 
-* `mvn -P jmh-benchmark test`
+* `mvn -P jmh-benchmark -Dbenchmark.run=true test`
+
+The results can be reviewed visiually by pasting the resulting `jmh-report.json` file into the link:https://jmh.morethan.io/[online JMH visualizer].

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,22 +5,3 @@ buildPlugin(failFast: false,
                 [platform: 'linux', jdk: '11'],
                 [platform: 'windows', jdk: '8'],
             ])
-
-// Return true if benchmarks should be run
-// Benchmarks run if any of the most recent 3 commits includes the word 'benchmark'
-boolean shouldRunBenchmarks(String branchName) {
-    // Disable benchmarks on default branch for speed
-    // if (branchName.endsWith('master') || branchName.endsWith('main')) { // accept either master or main
-    //     return true;
-    // }
-    def recentCommitMessages
-    node('linux') {
-        checkout scm
-        recentCommitMessages = sh(script: 'git log -n 3', returnStdout: true)
-    }
-    return recentCommitMessages =~ /.*[Bb]enchmark.*/
-}
-
-if (shouldRunBenchmarks(env.BRANCH_NAME)) {
-    runBenchmarks('jmh-report.json')
-}

--- a/pom.xml
+++ b/pom.xml
@@ -385,6 +385,12 @@
         <configuration>
           <forkCount>0.8C</forkCount>
           <reuseForks>true</reuseForks>
+          <systemProperties>
+            <property>
+              <name>surefire.profile</name>
+              <value>${project.activeProfiles[0].id}</value>
+            </property>
+          </systemProperties>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/java/jmh/benchmark/BenchmarkRunner.java
+++ b/src/test/java/jmh/benchmark/BenchmarkRunner.java
@@ -1,21 +1,42 @@
 package jmh.benchmark;
 
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
 import jenkins.benchmark.jmh.BenchmarkFinder;
+
+
 import org.junit.Test;
+
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * A runner class which finds benchmark tests annotated with @JmhBenchmark and launches them with the selected options
  * provided by JMH
  */
 public class BenchmarkRunner {
+    /**
+     * Returns true if property benchmark.run is set.
+     * @return true if benchmarks should be run
+     */
+    private boolean shouldRunBenchmarks() throws Exception {
+        return Boolean.parseBoolean(System.getProperty("benchmark.run", "false"));
+    }
+
     @Test
     public void runJmhBenchmarks() throws Exception {
+        if (!shouldRunBenchmarks()) {
+            String msg = "{\"benchmark.run\": false, \"reason\": \"Benchmark not run because benchmark.run is false\"}";
+            Files.write(Paths.get("jmh-report.json"), msg.getBytes(StandardCharsets.UTF_8));
+            return;
+        }
         ChainedOptionsBuilder options = new OptionsBuilder()
                 .mode(Mode.AverageTime) // Performance metric is Average time (ms per operation)
                 .warmupIterations(1) // Used to warm JVM before executing benchmark tests
@@ -25,9 +46,8 @@ public class BenchmarkRunner {
                 .forks(1)   // Need to increase more forks to get more observations, increases precision.
                 .shouldFailOnError(true) // Will stop forking of JVM as soon as there is a compilation error
                 .shouldDoGC(true) // do GC between measurement iterations
-                .output("jmh-report.json");
-//                .resultFormat(ResultFormatType.JSON) // store the results in a file called jmh-report.json
-//                .result("jmh-report.json");
+                .resultFormat(ResultFormatType.JSON) // store the results in a file called jmh-report.json
+                .result("jmh-report.json");
 
         BenchmarkFinder bf = new BenchmarkFinder(getClass());
         bf.findBenchmarks(options);


### PR DESCRIPTION
## Run JMH benchmarks only with benchmark.run=true

A JMH test run without a review of the results is not very valuable.  Only run the JMH tests if the property `benchmark.run` is `true`.

Don't run JMH benchmarks unless `benchmark.run`=`true`.  There is very little value to running the Java microharness benchmarks to compare JGit and command line git unless JGit is a new version.
Now that JGit 6.0 has released and requires Java 11, the git client plugin will only be accepting bug fixes from the 5.x line.

Always write JSON to the jmh-report.json file so that it can be visualized with https://jmh.morethan.io/

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
