### PR TITLE
Revert equalsverifier 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,12 +232,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-      <exclusions> <!-- Temporary exclusion pending mockito-core update in plugin bom-->
-        <exclusion>
-          <groupId>net.bytebuddy</groupId>
-          <artifactId>byte-buddy</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.9</version>
+      <version>3.8.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Revert equalsverifier 3.9 until pom is available

- Revert "Exclude byte-buddy from mockito-core"
- Revert "Bump equalsverifier from 3.8.3 to 3.9"

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
