### PR TITLE
Bump jgit.version from 5.13.0 to 5.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <jenkins.version>2.289.1</jenkins.version>
-    <jgit.version>5.13.0.202109080827-r</jgit.version>
+    <jgit.version>5.13.1.202206130422-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>Medium</spotbugs.threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,8 @@
           <failOnError>false</failOnError>
           <links>
             <link>https://docs.oracle.com/javase/8/docs/api/</link>
-            <link>https://download.eclipse.org/jgit/site/${jgit.version}/org.eclipse.jgit/apidocs/</link>
+	    <!-- JGit patch releases do not provide javadoc. Use javadoc from matching minor release -->
+            <link>https://download.eclipse.org/jgit/site/5.13.0.202109080827-r/org.eclipse.jgit/apidocs/</link>
           </links>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Bump jgit.version from 5.13.0 to 5.13.1

* Updates org.eclipse.jgit from 5.13.0.202109080827-r to 5.13.1.202206130422-r
* Updates org.eclipse.jgit.http.server from 5.13.0.202109080827-r to 5.13.1.202206130422-r
* Updates org.eclipse.jgit.http.apache from 5.13.0.202109080827-r to 5.13.1.202206130422-r
* Updates org.eclipse.jgit.lfs from 5.13.0.202109080827-r to 5.13.1.202206130422-r
* Updates org.eclipse.jgit.ssh.jsch from 5.13.0.202109080827-r to 5.13.1.202206130422-r

# Release notes from [JGit 5.13.1](https://projects.eclipse.org/projects/technology.jgit/releases/5.13.1)

## Improvements

* [579907](https://eclip.se/579907) AmazonS3: Add support for AWS API signature version 4

## Bug Fixes

* Fix connection leak for smart http connections
* [579445](https://eclip.se/579445) Remove stray files (probes or lock files) created by background threads
* [578511](https://eclip.se/578511) Stop initCause throwing in readAdvertisedRefs
* [577937](https://eclip.se/577937) UploadPack v2 protocol: Stop negotiation for orphan refs
* [577983](https://eclip.se/577983) Use FileSnapshot without using configs for FileBasedConfig
* [577227](https://eclip.se/577227) TreeRevFilter: fix wrong stop when the given path disappears
* [577492](https://eclip.se/577492) FS: debug logging only if system config file cannot be found
* [576604](https://eclip.se/576604) Set JSch global config values only if not set already
* [577358](https://eclip.se/577358) Better git system config finding
* Fix missing peel-part in lsRefsV2 for loose annotated tags
* Fix RevWalk.getMergedInto() ignores annotated tags
* [576250](https://eclip.se/576250) reftable: drop code for truncated reads
* reftable: pass on invalid object ID in conversion
* Fix running benchmarks from bazel

## Performance Improvements

* FileSnapshot: Lazy load file store attributes cache
* Optimize RevWalk.getMergedInto()

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update

## Further comments

Patch release from the JGit project.  JGit 6.0, 6.1, and 6.2 require Java 11, so are not usable in the git client plugin.
