### PR TITLE
[JENKINS-69149] Older SSH implementations don't support accept-new

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -112,6 +112,11 @@ Git Client plugin provides various options to verify the SSH keys presented by G
 By default, Git Client plugin uses "Accept first connection" strategy, which automatically adds keys for hosts that have not been seen before to `known_hosts`, and does not allow connections to previously-seen hosts with modified keys.
 Configure the host key verification strategy from "Manage Jenkins" >> "Configure Global Security" >> "Git Host Key Verification Configuration".
 
+Note: Some very old SSH implementations (Red Hat Enterprise Linux 7, CentOS 7, Debian 9) may not accept the command line argument used to accept first connection.
+The "Git Host Key Verification Configuration" for those systems cannot use the "Accept first connection" strategy.
+Choose a different host key verification strategy if those old SSH implementations must be supported on your Jenkins agents.
+Alternately, configure the git client plugin to use JGit instead of command line git.
+
 image::images/ssh-host-key-verification.png[Configure Ssh host key verification]
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -114,8 +114,8 @@ Configure the host key verification strategy from "Manage Jenkins" >> "Configure
 
 [NOTE]
 ====
-Some very old SSH implementations (Red Hat Enterprise Linux 7, CentOS 7, Debian 9) may not accept the command line argument used to accept first connection.
-The "Git Host Key Verification Configuration" for those systems cannot use the "Accept first connection" strategy.
+Some very old SSH implementations (Red Hat Enterprise Linux 7, CentOS 7, Debian 9) do not support the ssh command line argument used to accept first connection.
+The "Git Host Key Verification Configuration" for those systems cannot use the "Accept first connection" strategy with command line git.
 Choose a different host key verification strategy if those old SSH implementations must be supported on your Jenkins agents.
 Alternately, configure the git client plugin to use JGit instead of command line git.
 ====

--- a/README.adoc
+++ b/README.adoc
@@ -112,10 +112,13 @@ Git Client plugin provides various options to verify the SSH keys presented by G
 By default, Git Client plugin uses "Accept first connection" strategy, which automatically adds keys for hosts that have not been seen before to `known_hosts`, and does not allow connections to previously-seen hosts with modified keys.
 Configure the host key verification strategy from "Manage Jenkins" >> "Configure Global Security" >> "Git Host Key Verification Configuration".
 
-Note: Some very old SSH implementations (Red Hat Enterprise Linux 7, CentOS 7, Debian 9) may not accept the command line argument used to accept first connection.
+[NOTE]
+====
+Some very old SSH implementations (Red Hat Enterprise Linux 7, CentOS 7, Debian 9) may not accept the command line argument used to accept first connection.
 The "Git Host Key Verification Configuration" for those systems cannot use the "Accept first connection" strategy.
 Choose a different host key verification strategy if those old SSH implementations must be supported on your Jenkins agents.
 Alternately, configure the git client plugin to use JGit instead of command line git.
+====
 
 image::images/ssh-host-key-verification.png[Configure Ssh host key verification]
 

--- a/README.adoc
+++ b/README.adoc
@@ -112,6 +112,8 @@ Git Client plugin provides various options to verify the SSH keys presented by G
 By default, Git Client plugin uses "Accept first connection" strategy, which automatically adds keys for hosts that have not been seen before to `known_hosts`, and does not allow connections to previously-seen hosts with modified keys.
 Configure the host key verification strategy from "Manage Jenkins" >> "Configure Global Security" >> "Git Host Key Verification Configuration".
 
+image::images/ssh-host-key-verification.png[Configure Ssh host key verification]
+
 [NOTE]
 ====
 Some very old SSH implementations (Red Hat Enterprise Linux 7, CentOS 7, Debian 9) do not support the ssh command line argument used to accept first connection.
@@ -119,9 +121,6 @@ The "Git Host Key Verification Configuration" for those systems cannot use the "
 Choose a different host key verification strategy if those old SSH implementations must be supported on your Jenkins agents.
 Alternately, configure the git client plugin to use JGit instead of command line git.
 ====
-
-image::images/ssh-host-key-verification.png[Configure Ssh host key verification]
-
 
 [#bug-reports]
 == Bug Reports

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/AbstractCliGitHostKeyVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/AbstractCliGitHostKeyVerifier.java
@@ -11,7 +11,7 @@ public interface AbstractCliGitHostKeyVerifier extends SerializableOnlyOverRemot
      * Specifies Git command-line options that control the logic of this verifier.
      * @param tempKnownHosts a temporary file that has already been created and may be used.
      * @return the command-line options
-     * @throws IOException
+     * @throws IOException on input or output error
      */
     String getVerifyHostKeyOption(Path tempKnownHosts) throws IOException;
 


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-69149

https://github.com/jenkinsci/git-client-plugin/commit/88f52c6c9b18bca4ad210e3b9910a49433583fd9#commitcomment-79586978
