### PR TITLE
[JENKINS-69149] Use Java for accept-new in StrictHostKeyChecking 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2041,10 +2041,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 passphrase = createPassphraseFile(sshUser);
                 knownHostsTemp = createTempFile("known_hosts","");
                 if (launcher.isUnix()) {
-                    ssh =  createUnixGitSSH(key, userName, knownHostsTemp);
+                    ssh =  createUnixGitSSH(key, userName, knownHostsTemp, url);
                     askpass =  createUnixSshAskpass(sshUser, passphrase);
                 } else {
-                    ssh = createWindowsGitSSH(key, userName, knownHostsTemp);
+                    ssh = createWindowsGitSSH(key, userName, knownHostsTemp, url);
                     askpass =  createWindowsSshAskpass(sshUser, passphrase);
                 }
 
@@ -2554,7 +2554,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         throw new RuntimeException("ssh executable not found. The git plugin only supports official git client https://git-scm.com/download/win");
     }
 
-    private Path createWindowsGitSSH(Path key, String user, Path knownHosts) throws IOException {
+    private Path createWindowsGitSSH(Path key, String user, Path knownHosts, URIish url) throws IOException {
         Path ssh = createTempFile("ssh", ".bat");
 
         File sshexe = getSSHExecutable();
@@ -2562,14 +2562,14 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         try (BufferedWriter w = Files.newBufferedWriter(ssh, Charset.forName(encoding))) {
             w.write("@echo off");
             w.newLine();
-            w.write("\"" + sshexe.getAbsolutePath() + "\" -i \"" + key.toAbsolutePath() +"\" -l \"" + user + "\" " + getHostKeyFactory().forCliGit(listener).getVerifyHostKeyOption(knownHosts) + " %* ");
+            w.write("\"" + sshexe.getAbsolutePath() + "\" -i \"" + key.toAbsolutePath() +"\" -l \"" + user + "\" " + getHostKeyFactory().forCliGit(listener).getVerifyHostKeyOption(knownHosts, url) + " %* ");
             w.newLine();
         }
         ssh.toFile().setExecutable(true, true);
         return ssh;
     }
 
-    private Path createUnixGitSSH(Path key, String user, Path knownHosts) throws IOException {
+    private Path createUnixGitSSH(Path key, String user, Path knownHosts, URIish url) throws IOException {
         Path ssh = createTempFile("ssh", ".sh");
         Path ssh_copy = Paths.get(ssh.toString() + "-copy");
         boolean isCopied = false;
@@ -2585,7 +2585,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             w.newLine();
             w.write("fi");
             w.newLine();
-            w.write("ssh -i \"" + key.toAbsolutePath() + "\" -l \"" + user + "\" " + getHostKeyFactory().forCliGit(listener).getVerifyHostKeyOption(knownHosts) + " \"$@\"");
+            w.write("ssh -i \"" + key.toAbsolutePath() + "\" -l \"" + user + "\" " + getHostKeyFactory().forCliGit(listener).getVerifyHostKeyOption(knownHosts, url) + " \"$@\"");
             w.newLine();
         }
         ssh.toFile().setExecutable(true, true);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/AbstractCliGitHostKeyVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/AbstractCliGitHostKeyVerifier.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.gitclient.verifier;
 
+import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 
 import java.io.IOException;
@@ -10,9 +11,10 @@ public interface AbstractCliGitHostKeyVerifier extends SerializableOnlyOverRemot
     /**
      * Specifies Git command-line options that control the logic of this verifier.
      * @param tempKnownHosts a temporary file that has already been created and may be used.
+     * @param url a server url
      * @return the command-line options
      * @throws IOException on input or output error
      */
-    String getVerifyHostKeyOption(Path tempKnownHosts) throws IOException;
+    String getVerifyHostKeyOption(Path tempKnownHosts, URIish url) throws IOException;
 
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/HostNameHashVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/HostNameHashVerifier.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2007-2008 Trilead AG (http://www.trilead.com)
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+a.) Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+b.) Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+c.) Neither the name of Trilead nor the names of its contributors may
+    be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+Trilead SSH-2 for Java includes code that was written by Dr. Christian Plattner
+during his PhD at ETH Zurich. The license states the following:
+
+Copyright (c) 2005 - 2006 Swiss Federal Institute of Technology (ETH Zurich),
+  Department of Computer Science (http://www.inf.ethz.ch),
+  Christian Plattner. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+a.) Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+b.) Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+c.) Neither the name of ETH Zurich nor the names of its contributors may
+    be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+The Java implementations of the AES, Blowfish and 3DES ciphers have been
+taken (and slightly modified) from the cryptography package released by
+"The Legion Of The Bouncy Castle".
+
+Their license states the following:
+
+Copyright (c) 2000 - 2004 The Legion Of The Bouncy Castle
+(http://www.bouncycastle.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.gitclient.verifier;
+
+import com.trilead.ssh2.crypto.Base64;
+import com.trilead.ssh2.crypto.digest.MessageMac;
+import com.trilead.ssh2.crypto.digest.SHA1;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+public class HostNameHashVerifier {
+
+    private HostNameHashVerifier() {
+        // to hide the implicit public constructor
+    }
+
+    public static boolean checkHashed(String entry, String hostname)
+    {
+        if (!entry.startsWith("|1|"))
+            return false;
+
+        int delim_idx = entry.indexOf('|', 3);
+
+        if (delim_idx == -1)
+            return false;
+
+        String salt_base64 = entry.substring(3, delim_idx);
+        String hash_base64 = entry.substring(delim_idx + 1);
+
+        byte[] salt = null;
+        byte[] hash = null;
+
+        try
+        {
+            salt = Base64.decode(salt_base64.toCharArray());
+            hash = Base64.decode(hash_base64.toCharArray());
+        }
+        catch (IOException e)
+        {
+            return false;
+        }
+
+        SHA1 sha1 = new SHA1();
+
+        if (salt.length != sha1.getDigestLength())
+            return false;
+
+        byte[] dig = hmacSha1Hash(salt, hostname);
+
+        for (int i = 0; i < dig.length; i++)
+            if (dig[i] != hash[i])
+                return false;
+
+        return true;
+    }
+
+    private static byte[] hmacSha1Hash(byte[] salt, String hostname)
+    {
+
+        if (salt.length != 20) {
+            throw new IllegalArgumentException("Salt has wrong length (" + salt.length + ")");
+        }
+
+        MessageMac messageMac = new MessageMac("hmac-sha1", salt);
+
+        try {
+            byte[] message = hostname.getBytes("ISO-8859-1");
+            messageMac.update(message, 0, message.length);
+        } catch (UnsupportedEncodingException ignore) {
+            /* Actually, ISO-8859-1 is supported by all correct
+             * Java implementations. But... you never know. */
+            byte[] message = hostname.getBytes(Charset.defaultCharset());
+            messageMac.update(message, 0, message.length);
+        }
+
+        byte[] dig = new byte[20];
+
+        messageMac.getMac(dig, 0);
+
+        return dig;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifier.java
@@ -15,7 +15,7 @@ public class KnownHostsFileVerifier extends HostKeyVerifierFactory {
 
     @Override
     public AbstractCliGitHostKeyVerifier forCliGit(TaskListener listener) {
-        return tempKnownHosts -> {
+        return (tempKnownHosts, url) -> {
             listener.getLogger().println("Verifying host key using known hosts file");
             return "-o StrictHostKeyChecking=yes";
         };

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifier.java
@@ -24,7 +24,7 @@ public class ManuallyProvidedKeyVerifier extends HostKeyVerifierFactory {
 
     @Override
     public AbstractCliGitHostKeyVerifier forCliGit(TaskListener listener) {
-        return tempKnownHosts -> {
+        return (tempKnownHosts, url) -> {
             Files.write(tempKnownHosts, (approvedHostKeys + System.lineSeparator()).getBytes(StandardCharsets.UTF_8));
             listener.getLogger().println("Verifying host key using manually-configured host key entries");
             String userKnownHostsFileFlag;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifier.java
@@ -8,7 +8,7 @@ public class NoHostKeyVerifier extends HostKeyVerifierFactory {
 
     @Override
     public AbstractCliGitHostKeyVerifier forCliGit(TaskListener listener) {
-        return tempKnownHosts -> "-o StrictHostKeyChecking=no";
+        return (tempKnownHosts, url) -> "-o StrictHostKeyChecking=no";
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 
 import hudson.model.TaskListener;
+import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.plugins.gitclient.trilead.JGitConnection;
 import org.junit.Before;
 import org.junit.Rule;
@@ -88,7 +89,7 @@ public class KnownHostsFileVerifierTest {
     @Test
     public void testVerifyHostKeyOptionWithDefaultFile() throws Exception {
         KnownHostsFileVerifier verifier = new KnownHostsFileVerifier();
-        assertThat(verifier.forCliGit(TaskListener.NULL).getVerifyHostKeyOption(null), is("-o StrictHostKeyChecking=yes"));
+        assertThat(verifier.forCliGit(TaskListener.NULL).getVerifyHostKeyOption(null, new URIish()), is("-o StrictHostKeyChecking=yes"));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifierTest.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.gitclient.verifier;
 
 import hudson.Functions;
 import hudson.model.TaskListener;
+import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.plugins.gitclient.trilead.JGitConnection;
 import org.junit.Assume;
 import org.junit.Before;
@@ -126,7 +127,7 @@ public class ManuallyProvidedKeyVerifierTest {
     public void testGetVerifyHostKeyOption() throws IOException {
         Assume.assumeFalse("test can not run on windows", Functions.isWindows());
         Path tempFile = testFolder.newFile().toPath();
-        String actual = new ManuallyProvidedKeyVerifier(hostKey).forCliGit(TaskListener.NULL).getVerifyHostKeyOption(tempFile);
+        String actual = new ManuallyProvidedKeyVerifier(hostKey).forCliGit(TaskListener.NULL).getVerifyHostKeyOption(tempFile, new URIish());
         assertThat(actual, is("-o StrictHostKeyChecking=yes  -o UserKnownHostsFile=\\\"\"\"" + tempFile.toAbsolutePath() + "\\\"\"\""));
         assertThat(Files.readAllLines(tempFile), is(Collections.singletonList(hostKey)));
     }
@@ -135,7 +136,7 @@ public class ManuallyProvidedKeyVerifierTest {
     public void testGetVerifyHostKeyOptionOnWindows() throws IOException {
         Assume.assumeTrue("test should run on windows", Functions.isWindows());
         Path tempFile = testFolder.newFile().toPath();
-        String actual = new ManuallyProvidedKeyVerifier(hostKey).forCliGit(TaskListener.NULL).getVerifyHostKeyOption(tempFile);
+        String actual = new ManuallyProvidedKeyVerifier(hostKey).forCliGit(TaskListener.NULL).getVerifyHostKeyOption(tempFile, new URIish());
         assertThat(actual, is("-o StrictHostKeyChecking=yes  -o UserKnownHostsFile=" + tempFile.toAbsolutePath() + ""));
         assertThat(Files.readAllLines(tempFile), is(Collections.singletonList(hostKey)));
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.gitclient.verifier;
 
 import hudson.model.TaskListener;
+import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.plugins.gitclient.trilead.JGitConnection;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +34,6 @@ public class NoHostKeyVerifierTest {
 
     @Test
     public void testVerifyHostKeyOption() throws IOException {
-        assertThat(verifier.forCliGit(TaskListener.NULL).getVerifyHostKeyOption(Paths.get("")), is("-o StrictHostKeyChecking=no"));
+        assertThat(verifier.forCliGit(TaskListener.NULL).getVerifyHostKeyOption(Paths.get(""), new URIish()), is("-o StrictHostKeyChecking=no"));
     }
 }


### PR DESCRIPTION
## [JENKINS-69149](https://issues.jenkins.io/browse/JENKINS-69149) Use Java for accept-new in StrictHostKeyChecking

As `accept-new` is not supported in several environments this PR implement it's logic manually.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
