### PR TITLE
[JENKINS-69193] GitAPITestCase: rely less on strict wording of messages from git CLI tool

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1225,7 +1225,16 @@ public abstract class GitAPITestCase extends TestCase {
             w.git.submoduleUpdate().execute();
             fail("Did not throw expected submodule update exception");
         } catch (GitException e) {
-            assertThat(e.getMessage(), containsString("Command \"git submodule update modules/ntp\" returned status code 1"));
+            /* Depending on git program implementation/version, the string can be either short:
+             *    Command "git submodule update modules/ntp" returned status code 1"
+             * or detailed:
+             *    Command "git submodule update modules/ntp" executed in workdir "C:\Users\..." returned status code 1
+             * so we catch below the two common parts separately.
+             * NOTE: git codebase itself goes to great extents to forbid their
+             * own unit-testing code from relying on emitted text messages.
+             */
+            assertThat(e.getMessage(), containsString("Command \"git submodule update modules/ntp\" "));
+            assertThat(e.getMessage(), containsString(" returned status code 1"));
         }
     }
 


### PR DESCRIPTION
## [JENKINS-69193](https://issues.jenkins.io/browse/JENKINS-69193) - GitAPITestCase: rely less on strict wording of messages from git CLI tool

As detailed in the Jenkins ticket, during work on another PR I found in local tests that `test_submodule_update_with_error()` failed because `git` CLI tool returned a more detailed STDOUT message wording than expected by the plugin unit test. This commit quickly fixes the situation, to match both wordings involved.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary -- comment in changed test code
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes -- not applicable, a test case was fixed

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
