### PR TITLE
Use expected test class names

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPICliGitNotIntializedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPICliGitNotIntializedTest.java
@@ -36,12 +36,11 @@ import java.util.logging.Logger;
  */
 
 @RunWith(Parameterized.class)
-public class GitAPITestCliGitNotIntialized {
+public class GitAPICliGitNotIntializedTest {
     @Rule
     public GitClientSampleRepoRule repo = new GitClientSampleRepoRule();
 
     private int logCount = 0;
-    private final Random random = new Random();
     private static final String LOGGING_STARTED = "Logging started";
     private LogHandler handler = null;
     private TaskListener listener;
@@ -51,9 +50,8 @@ public class GitAPITestCliGitNotIntialized {
 
     private GitClient testGitClient;
     private File testGitDir;
-    private CliGitCommand cliGitCommand;
 
-    public GitAPITestCliGitNotIntialized(final String gitImplName) {
+    public GitAPICliGitNotIntializedTest(final String gitImplName) {
         this.gitImplName = gitImplName;
     }
 
@@ -98,7 +96,6 @@ public class GitAPITestCliGitNotIntialized {
 
         testGitClient = workspace.getGitClient();
         testGitDir = workspace.getGitFileDir();
-        cliGitCommand = workspace.getCliGitCommand();
     }
 
     @After

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPIForCliGitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPIForCliGitTest.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
  */
 
 @RunWith(Parameterized.class)
-public class GitAPITestForCliGit {
+public class GitAPIForCliGitTest {
 
     @Rule
     public GitClientSampleRepoRule repo = new GitClientSampleRepoRule();
@@ -41,7 +41,6 @@ public class GitAPITestForCliGit {
     public GitClientSampleRepoRule secondRepo = new GitClientSampleRepoRule();
 
     private int logCount = 0;
-    private final Random random = new Random();
     private static final String LOGGING_STARTED = "Logging started";
     private LogHandler handler = null;
     private TaskListener listener;
@@ -51,9 +50,13 @@ public class GitAPITestForCliGit {
 
     private GitClient testGitClient;
     private File testGitDir;
-    private CliGitCommand cliGitCommand;
 
-    public GitAPITestForCliGit(final String gitImplName) {
+    /**
+     * Tests that need the default branch name can use this variable.
+     */
+    private static String defaultBranchName = "mast" + "er"; // Intentionally split string
+
+    public GitAPIForCliGitTest(final String gitImplName) {
         this.gitImplName = gitImplName;
     }
 
@@ -83,6 +86,26 @@ public class GitAPITestForCliGit {
         Util.deleteRecursive(tempDir);
     }
 
+    /**
+     * Determine the global default branch name.
+     * Command line git is moving towards more inclusive naming.
+     * Git 2.32.0 honors the configuration variable `init.defaultBranch` and uses it for the name of the initial branch.
+     * This method reads the global configuration and uses it to set the value of `defaultBranchName`.
+     */
+    @BeforeClass
+    public static void computeDefaultBranchName() throws Exception {
+        File configDir = Files.createTempDirectory("readGitConfig").toFile();
+        CliGitCommand getDefaultBranchNameCmd = new CliGitCommand(Git.with(TaskListener.NULL, new hudson.EnvVars()).in(configDir).using("git").getClient());
+        String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--get", "init.defaultBranch");
+        for (String s : output) {
+            String result = s.trim();
+            if (result != null && !result.isEmpty()) {
+                defaultBranchName = result;
+            }
+        }
+        assertTrue("Failed to delete temporary readGitConfig directory", configDir.delete());
+    }
+
     @Before
     public void setUpRepositories() throws Exception {
         Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);
@@ -98,7 +121,6 @@ public class GitAPITestForCliGit {
 
         testGitClient = workspace.getGitClient();
         testGitDir = workspace.getGitFileDir();
-        cliGitCommand = workspace.getCliGitCommand();
         initializeWorkspace(workspace);
     }
 
@@ -135,7 +157,7 @@ public class GitAPITestForCliGit {
         remote.launchCommand("git", "checkout", "-b", "other");
 
         workspace.launchCommand("git", "remote", "add", "origin", remote.getGitFileDir().getAbsolutePath());
-        workspace.launchCommand("git", "pull", "--depth=1", "origin", "master");
+        workspace.launchCommand("git", "pull", "--depth=1", "origin", defaultBranchName);
 
         workspace.touch(testGitDir, "file2", "");
         testGitClient.add("file2");
@@ -143,9 +165,9 @@ public class GitAPITestForCliGit {
         ObjectId sha1 = workspace.head();
 
         try {
-            testGitClient.push("origin", "master");
+            testGitClient.push("origin", defaultBranchName);
             assertTrue("git < 1.9.0 can push from shallow repository", workspace.cgit().isAtLeastVersion(1, 9, 0, 0));
-            String remoteSha1 = remote.launchCommand("git", "rev-parse", "master").substring(0, 40);
+            String remoteSha1 = remote.launchCommand("git", "rev-parse", defaultBranchName).substring(0, 40);
             assertEquals(sha1.name(), remoteSha1);
         } catch (GitException ge) {
             // expected for git cli < 1.9.0

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPIJGitNotInitializedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPIJGitNotInitializedTest.java
@@ -30,7 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @RunWith(Parameterized.class)
-public class GitAPITestJGitNotInitialized {
+public class GitAPIJGitNotInitializedTest {
 
     @Rule
     public GitClientSampleRepoRule repo = new GitClientSampleRepoRule();
@@ -45,7 +45,7 @@ public class GitAPITestJGitNotInitialized {
 
     private GitClient testGitClient;
 
-    public GitAPITestJGitNotInitialized(final String gitImplName) {
+    public GitAPIJGitNotInitializedTest(final String gitImplName) {
         this.gitImplName = gitImplName;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPINotIntializedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPINotIntializedTest.java
@@ -37,13 +37,12 @@ import java.util.logging.Logger;
  */
 
 @RunWith(Parameterized.class)
-public class GitAPITestNotIntialized {
+public class GitAPINotIntializedTest {
 
     @Rule
     public GitClientSampleRepoRule repo = new GitClientSampleRepoRule();
 
     private int logCount = 0;
-    private final Random random = new Random();
     private static final String LOGGING_STARTED = "Logging started";
     private LogHandler handler = null;
     private TaskListener listener;
@@ -55,7 +54,7 @@ public class GitAPITestNotIntialized {
     private File testGitDir;
     private CliGitCommand cliGitCommand;
 
-    public GitAPITestNotIntialized(final String gitImplName) { this.gitImplName = gitImplName; }
+    public GitAPINotIntializedTest(final String gitImplName) { this.gitImplName = gitImplName; }
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection gitObjects() {


### PR DESCRIPTION
## Use expected test class names

The JUnit 4 transition renamed these test classes and the maven surefire plugin was not running the tests because they did use the expected class name pattern.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Tests
