### PR TITLE
Simplify test assertions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -203,11 +203,6 @@ public class CredentialsTest {
         return new UsernamePasswordCredentialsImpl(scope, id, "desc: " + id, username, password);
     }
 
-    private static boolean isCredentialsSupported() throws IOException, InterruptedException {
-        CliGitAPIImpl cli = (CliGitAPIImpl) Git.with(null, new hudson.EnvVars()).in(CURR_DIR).using("git").getClient();
-        return cli.isAtLeastVersion(1, 7, 9, 0);
-    }
-
     private boolean isShallowCloneSupported(String implementation, GitClient gitClient) {
         if (!implementation.equals("git")) {
             return false;
@@ -219,7 +214,7 @@ public class CredentialsTest {
     @Parameterized.Parameters(name = "Impl:{0} User:{2} Pass:{3} Embed:{9} Phrase:{5} URL:{1}")
     public static Collection gitRepoUrls() throws IOException, InterruptedException, ParseException {
         List<Object[]> repos = new ArrayList<>();
-        String[] implementations = isCredentialsSupported() ? new String[]{"git", "jgit", "jgitapache"} : new String[]{"jgit", "jgitapache"};
+        String[] implementations = new String[]{"git", "jgit", "jgitapache"};
         for (String implementation : implementations) {
             /* Add upstream repository as authentication test with private
              * key of current user.  Try to test at least one

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -1283,8 +1283,8 @@ public class GitAPITest {
         Exception exception = assertThrows(GitException.class, () -> {
             testGitClient.rebase().setUpstream(defaultBranchName).execute();
         });
-        assertThat(exception.getMessage(), anyOf(containsString("Failed to rebase main"),
-                                                 containsString("Could not rebase main")));
+        assertThat(exception.getMessage(), anyOf(containsString("Failed to rebase " + defaultBranchName),
+                                                 containsString("Could not rebase " + defaultBranchName)));
         assertEquals("HEAD not reset to the feature branch.", testGitClient.revParse("HEAD").name(), testGitClient.revParse("feature1").name());
         Status status = new org.eclipse.jgit.api.Git(new FileRepository(new File(testGitDir, ".git"))).status().call();
         assertTrue("Workspace is not clean", status.isClean());

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -601,7 +601,7 @@ public class GitAPITest {
         workspace.tag("tag1", true); /* Tag already exists, move from commit1 to commit2 */
         assertTrue("tag1 wasn't created", testGitClient.tagExists("tag1"));
         assertEquals("tag1 points to wrong commit", commit2, testGitClient.revParse("tag1"));
-        if (testGitClient instanceof CliGitAPIImpl && workspace.cgit().isAtLeastVersion(1,8,0,0)) {
+        if (testGitClient instanceof CliGitAPIImpl) {
             // Modern CLI git should throw exception pushing a change to existing tag
             Exception exception = assertThrows(GitException.class, () -> {
                 testGitClient.push().ref(defaultBranchName).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).execute();
@@ -611,8 +611,8 @@ public class GitAPITest {
             testGitClient.push().ref(defaultBranchName).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).execute();
         }
 
-        if (testGitClient instanceof CliGitAPIImpl && workspace.cgit().isAtLeastVersion(1, 8, 0, 0)) {
-            /* CliGit before 1.8 does not throw exception updating existing tag - ugh */
+        if (testGitClient instanceof CliGitAPIImpl) {
+            /* CliGit throws exception updating existing tag */
             Exception exception = assertThrows(GitException.class, () -> {
                 testGitClient.push().ref(defaultBranchName).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).force(false).execute();
             });

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -659,7 +659,7 @@ public abstract class GitAPITestUpdate {
 
         /* git.clean() does not remove submodule remnants in CliGitAPIImpl, does in JGitAPIImpl */
         w.git.clean();
-        if (w.git instanceof CliGitAPIImpl && w.cgit().isAtLeastVersion(1, 7, 9, 0)) {
+        if (w.git instanceof CliGitAPIImpl) {
             assertDirExists(ntpDir);
             assertDirExists(firewallDir);
             assertDirExists(sshkeysDir);
@@ -1033,12 +1033,6 @@ public abstract class GitAPITestUpdate {
         w.igit().merge("branch1");
         assertTrue("file1 does not exist after merge", w.exists("file1"));
 
-        /* Git 1.7.1 does not understand the --orphan argument to checkout.
-         * Stop the test here on older git versions
-         */
-        if (!w.cgit().isAtLeastVersion(1, 7, 9, 0)) {
-            return;
-        }
         w.launchCommand("git", "checkout", "--orphan", "newroot"); // Create an independent root
         w.commitEmpty("init-on-newroot");
         final ObjectId newRootCommit = w.head();
@@ -1873,19 +1867,8 @@ public abstract class GitAPITestUpdate {
         String mergeMessage = "Merge message to be tested.";
         w.git.merge().setMessage(mergeMessage).setGitPluginFastForwardMode(MergeCommand.GitPluginFastForwardMode.NO_FF).setRevisionToMerge(w.git.getHeadRev(w.repoPath(), "branch-1")).execute();
 
-        /* JGit, and git 1.7.1 handle merge commits in changelog
-         * differently than git 1.7.9 and later.  See JENKINS-40023.
-         */
-        int maxlimit;
-        if (w.git instanceof CliGitAPIImpl) {
-            if (!w.cgit().isAtLeastVersion(1, 7, 9, 0)) {
-                return;
-                /* git 1.7.1 is too old, changelog is too different */
-            }
-            maxlimit = 1;
-        } else {
-            maxlimit = 2;
-        }
+        /* JGit handles merge commits in changelog differently than CLI git.  See JENKINS-40023. */
+        int maxlimit = w.git instanceof CliGitAPIImpl ? 1 : 2;
 
         StringWriter writer = new StringWriter();
         w.git.changelog().max(maxlimit).to(writer).execute();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
@@ -71,11 +71,6 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
 
     @Test
     public void testTrackingSubmoduleBranches() throws Exception {
-        if (!((CliGitAPIImpl) w.git).isAtLeastVersion(1, 8, 2, 0)) {
-            setTimeoutVisibleInCurrentTest(false);
-            System.err.println("git must be at least 1.8.2 to do tracking submodules.");
-            return;
-        }
         w.init(); // empty repository
 
         // create a new GIT repo.
@@ -140,10 +135,6 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
 
     @Test
     public void testTrackingSubmodule() throws Exception {
-        if (!((CliGitAPIImpl) w.git).isAtLeastVersion(1, 8, 2, 0)) {
-            System.err.println("git must be at least 1.8.2 to do tracking submodules.");
-            return;
-        }
         w.init(); // empty repository
 
         // create a new GIT repo.
@@ -192,12 +183,6 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
 
     @Test
     public void testSparseCheckout() throws Exception {
-        /* Sparse checkout was added in git 1.7.0, but the checkout -f syntax
-         * required by the plugin implementation does not work in git 1.7.1.
-         */
-        if (!w.cgit().isAtLeastVersion(1, 7, 9, 0)) {
-            return;
-        }
         // Create a repo for cloning purpose
         w.init();
         w.commitEmpty("init");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -168,7 +168,7 @@ public class GitClientCloneTest {
         assertBranchesExist(testGitClient.getBranches(), "master");
         assertAlternatesFileNotFound();
         /* JGit does not support shallow clone */
-        boolean hasShallowCloneSupport = testGitClient instanceof CliGitAPIImpl && workspace.cgit().isAtLeastVersion(1, 5, 0, 0);
+        boolean hasShallowCloneSupport = testGitClient instanceof CliGitAPIImpl;
         assertThat("isShallow?", workspace.cgit().isShallowRepository(), is(hasShallowCloneSupport));
         String shallow = ".git" + File.separator + "shallow";
         if (hasShallowCloneSupport) {
@@ -186,7 +186,7 @@ public class GitClientCloneTest {
         assertBranchesExist(testGitClient.getBranches(), "master");
         assertAlternatesFileNotFound();
         /* JGit does not support shallow clone */
-        boolean hasShallowCloneSupport = testGitClient instanceof CliGitAPIImpl && workspace.cgit().isAtLeastVersion(1, 5, 0, 0);
+        boolean hasShallowCloneSupport = testGitClient instanceof CliGitAPIImpl;
         assertThat("isShallow?", workspace.cgit().isShallowRepository(), is(hasShallowCloneSupport));
         String shallow = ".git" + File.separator + "shallow";
         if (hasShallowCloneSupport) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -443,14 +443,7 @@ public class GitClientFetchTest {
         newAreaWorkspace.getGitClient().fetch_().from(new URIish(bareWorkspace.getGitFileDir().toString()), refSpecs).prune(true).execute();
         remoteBranches = newAreaWorkspace.getGitClient().getRemoteBranches();
 
-        /* Git older than 1.7.9 (like 1.7.1 on Red Hat 6) does not prune branch1, don't fail the test
-         * on that old git version.
-         */
-        if (newAreaWorkspace.getGitClient() instanceof CliGitAPIImpl && !workspace.cgit().isAtLeastVersion(1, 7, 9, 0)) {
-            assertThat(getBranchNames(remoteBranches), containsInAnyOrder("origin/" + defaultBranchName, "origin/branch1", "origin/branch2", "origin/HEAD"));
-        } else {
-            assertThat(getBranchNames(remoteBranches), containsInAnyOrder("origin/" + defaultBranchName, "origin/branch2", "origin/HEAD"));
-        }
+        assertThat(getBranchNames(remoteBranches), containsInAnyOrder("origin/" + defaultBranchName, "origin/branch2", "origin/HEAD"));
     }
 
     @Test
@@ -475,7 +468,7 @@ public class GitClientFetchTest {
         assertBranchesExist(testGitClient.getRemoteBranches(), "origin/" + DEFAULT_MIRROR_BRANCH_NAME);
         assertAlternatesFileExists(testGitDir);
         /* JGit does not support shallow fetch */
-        boolean hasShallowFetchSupport = testGitClient instanceof CliGitAPIImpl && workspace.cgit().isAtLeastVersion(1, 5, 0, 0);
+        boolean hasShallowFetchSupport = testGitClient instanceof CliGitAPIImpl;
         assertThat("isShallow?", workspace.cgit().isShallowRepository(), is(hasShallowFetchSupport));
         String shallow = ".git" + File.separator + "shallow";
         assertThat("shallow file existence: " + shallow, new File(testGitDir, shallow).exists(), is(hasShallowFetchSupport));
@@ -489,7 +482,7 @@ public class GitClientFetchTest {
         assertBranchesExist(testGitClient.getRemoteBranches(), "origin/" + DEFAULT_MIRROR_BRANCH_NAME);
         assertAlternatesFileExists(testGitDir);
         /* JGit does not support shallow fetch */
-        boolean hasShallowFetchSupport = testGitClient instanceof CliGitAPIImpl && workspace.cgit().isAtLeastVersion(1, 5, 0, 0);
+        boolean hasShallowFetchSupport = testGitClient instanceof CliGitAPIImpl;
         assertThat("isShallow?", workspace.cgit().isShallowRepository(), is(hasShallowFetchSupport));
         String shallow = ".git" + File.separator + "shallow";
         assertThat("shallow file existence: " + shallow, new File(testGitDir, shallow).exists(), is(hasShallowFetchSupport));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -127,11 +127,11 @@ public class GitClientTest {
         } else {
             cliGitClient = (CliGitAPIImpl) Git.with(TaskListener.NULL, new EnvVars()).in(srcRepoDir).using("git").getClient();
         }
-        CLI_GIT_REPORTS_DETACHED_SHA1 = cliGitClient.isAtLeastVersion(1, 8, 0, 0);
+        CLI_GIT_REPORTS_DETACHED_SHA1 = true; // Included in CLI git 1.8.0 and later
         CLI_GIT_SUPPORTS_SUBMODULE_DEINIT = cliGitClient.isAtLeastVersion(1, 9, 0, 0);
         CLI_GIT_SUPPORTS_SUBMODULE_RENAME = cliGitClient.isAtLeastVersion(1, 9, 0, 0);
         CLI_GIT_SUPPORTS_SYMREF = cliGitClient.isAtLeastVersion(2, 8, 0, 0);
-        CLI_GIT_SUPPORTS_REV_LIST_NO_WALK = cliGitClient.isAtLeastVersion(1, 5, 3, 0);
+        CLI_GIT_SUPPORTS_REV_LIST_NO_WALK = true; // Included in CLI git 1.8.0 and later
 
         boolean gitLFSExists;
         boolean gitSparseCheckoutWithLFS;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifierTest.java
@@ -16,8 +16,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -37,20 +37,17 @@ public class AcceptFirstConnectionVerifierTest {
     }
 
     @Test
-    public void testVerifyServerHostKeyWhenFirstConnection() {
+    public void testVerifyServerHostKeyWhenFirstConnection() throws Exception {
         File file = new File(testFolder.getRoot() + "path/to/file");
         AcceptFirstConnectionVerifier acceptFirstConnectionVerifier = spy(new AcceptFirstConnectionVerifier());
         when(acceptFirstConnectionVerifier.getKnownHostsFile()).thenReturn(file);
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            assertTrue(file.exists());
-            assertThat(Files.readAllLines(file.toPath()), hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
-        } catch (IOException e) {
-            fail("Should not fail because first connection and create a file");
-        }
+        // Should not fail because first connection and create a file
+        jGitConnection.connect(verifier);
+        assertThat(file, is(anExistingFile()));
+        assertThat(Files.readAllLines(file.toPath()), hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
     }
 
     @Test
@@ -63,12 +60,10 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(hostKeyEntry)));
-        } catch (IOException e) {
-            fail("Should connect and do not add new line because keys are equal");
-        }
+        // Should connect and do not add new line because keys are equal
+        jGitConnection.connect(verifier);
+        assertThat(mockedKnownHosts, is(anExistingFile()));
+        assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(hostKeyEntry)));
     }
 
     @Test
@@ -80,12 +75,10 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(hostKeyEntry)));
-        } catch (IOException e) {
-            fail("Should connect and do not add new line because keys are equal");
-        }
+        // Should connect and do not add new line because keys are equal
+        jGitConnection.connect(verifier);
+        assertThat(mockedKnownHosts, is(anExistingFile()));
+        assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(hostKeyEntry)));
     }
 
     @Test
@@ -99,12 +92,10 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(fileContent)));
-        } catch (IOException e) {
-            fail("Should connect and do not add new line because keys are equal");
-        }
+        // Should connect and do not add new line because keys are equal
+        jGitConnection.connect(verifier);
+        assertThat(mockedKnownHosts, is(anExistingFile()));
+        assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(fileContent)));
     }
 
     @Test
@@ -118,12 +109,10 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
+        Exception exception = assertThrows(IOException.class, () -> {
             jGitConnection.connect(verifier);
-            fail("Should fail because hostkey is broken for 'github.com:22'");
-        } catch (IOException e) {
-            assertThat(e.getMessage(), is("There was a problem while connecting to github.com:22"));
-        }
+        });
+        assertThat(exception.getMessage(), containsString("There was a problem while connecting to github.com:22"));
     }
 
     @Test
@@ -138,14 +127,11 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            List<String> actual = Files.readAllLines(fakeKnownHosts.toPath());
-            assertThat(actual, hasItem(bitbucketFileContent));
-            assertThat(actual, hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
-        } catch (IOException e) {
-            fail("Should connect and add new line because a new key");
-        }
+        // Should connect and add new line because a new key
+        jGitConnection.connect(verifier);
+        List<String> actual = Files.readAllLines(fakeKnownHosts.toPath());
+        assertThat(actual, hasItem(bitbucketFileContent));
+        assertThat(actual, hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
     }
 
     @Test
@@ -159,14 +145,10 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            List<String> actual = Files.readAllLines(mockedKnownHosts.toPath());
-            assertThat(actual, hasItem(fileContent));
-            assertThat(actual, hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
-        } catch (IOException e) {
-            fail("Should connect and add new line because a new key");
-        }
+        // Should connect and add new line because a new key
+        jGitConnection.connect(verifier);
+        List<String> actual = Files.readAllLines(mockedKnownHosts.toPath());
+        assertThat(actual, hasItem(fileContent));
+        assertThat(actual, hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
@@ -15,7 +15,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
@@ -8,13 +8,13 @@ import org.jenkinsci.plugins.gitclient.trilead.JGitConnection;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -29,13 +29,9 @@ public class KnownHostsFileVerifierTest {
     @Rule
     public TemporaryFolder testFolder = TemporaryFolder.builder().assureDeletion().build();
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     private File fakeKnownHosts;
 
     private final KnownHostsTestUtil knownHostsTestUtil = new KnownHostsTestUtil(testFolder);
-
 
     @Before
     public void assignVerifiers() throws IOException {
@@ -51,8 +47,11 @@ public class KnownHostsFileVerifierTest {
         JGitConnection jGitConnection = new JGitConnection("bitbucket.org", 22);
 
         // Should throw exception because hostkey for 'bitbucket.org:22' is not in known_hosts file
-        expectedException.expectMessage("There was a problem while connecting to bitbucket.org:22");
-        jGitConnection.connect(verifier);
+        Exception exception = assertThrows(IOException.class, () -> {
+            jGitConnection.connect(verifier);
+        });
+        assertThat(exception.getMessage(), is("There was a problem while connecting to bitbucket.org:22"));
+
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
@@ -8,6 +8,7 @@ import org.jenkinsci.plugins.gitclient.trilead.JGitConnection;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -29,6 +30,9 @@ public class KnownHostsFileVerifierTest {
     @Rule
     public TemporaryFolder testFolder = TemporaryFolder.builder().assureDeletion().build();
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
     private File fakeKnownHosts;
 
     private final KnownHostsTestUtil knownHostsTestUtil = new KnownHostsTestUtil(testFolder);
@@ -47,26 +51,19 @@ public class KnownHostsFileVerifierTest {
         AbstractJGitHostKeyVerifier verifier = knownHostsFileVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("bitbucket.org", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            fail("Should fail because hostkey for 'bitbucket.org:22' is not in known_hosts file");
-        } catch (IOException e) {
-            assertThat(e.getMessage(), is("There was a problem while connecting to bitbucket.org:22"));
-        }
+        // Should throw exception because hostkey for 'bitbucket.org:22' is not in known_hosts file
+        expectedException.expectMessage("There was a problem while connecting to bitbucket.org:22");
+        jGitConnection.connect(verifier);
     }
 
     @Test
-    public void connectWhenHostKeyProvidedThenShouldNotFail() {
+    public void connectWhenHostKeyProvidedThenShouldNotFail() throws IOException {
         KnownHostsFileVerifier knownHostsFileVerifier = spy(new KnownHostsFileVerifier());
         when(knownHostsFileVerifier.getKnownHostsFile()).thenReturn(fakeKnownHosts);
         AbstractJGitHostKeyVerifier verifier = knownHostsFileVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
-
-        try {
-            jGitConnection.connect(verifier);
-        } catch (IOException e) {
-            fail("Should not fail because hostkey for 'github.com:22' is in known_hosts");
-        }
+        // Should not fail because hostkey for 'github.com:22' is in known_hosts
+        jGitConnection.connect(verifier);
     }
 
     @Test
@@ -77,12 +74,8 @@ public class KnownHostsFileVerifierTest {
         when(knownHostsFileVerifier.getKnownHostsFile()).thenReturn(fakeKnownHosts);
         AbstractJGitHostKeyVerifier verifier = knownHostsFileVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
-
-        try {
-            jGitConnection.connect(verifier);
-        } catch (IOException e) {
-            fail("Should not fail because hostkey for 'github.com:22' is in known_hosts with algorithm 'ecdsa-sha2-nistp256'");
-        }
+        // Should not fail because hostkey for 'github.com:22' is in known_hosts with algorithm 'ecdsa-sha2-nistp256
+        jGitConnection.connect(verifier);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifierTest.java
@@ -1,9 +1,8 @@
 package org.jenkinsci.plugins.gitclient.verifier;
 
-import hudson.Functions;
 import hudson.model.TaskListener;
+import java.io.File;
 import org.jenkinsci.plugins.gitclient.trilead.JGitConnection;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,8 +16,9 @@ import java.nio.file.Path;
 import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ManuallyProvidedKeyVerifierTest {
@@ -40,24 +40,20 @@ public class ManuallyProvidedKeyVerifierTest {
         verifier = new ManuallyProvidedKeyVerifier(hostKey).forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("bitbucket.org", 22);
 
-        try {
+        // Should fail because hostkey for 'bitbucket.org:22' is not manually provided
+        Exception exception = assertThrows(IOException.class, () -> {
             jGitConnection.connect(verifier);
-            fail("Should fail because hostkey for 'bitbucket.org:22' is not manually provided");
-        } catch (IOException e) {
-            assertThat(e.getMessage(), is("There was a problem while connecting to bitbucket.org:22"));
-        }
+        });
+        assertThat(exception.getMessage(), containsString("There was a problem while connecting to bitbucket.org:22"));
     }
 
     @Test
-    public void connectWhenHostKeyProvidedThenShouldNotFail() {
-        AbstractJGitHostKeyVerifier verifier = new ManuallyProvidedKeyVerifier(hostKey).forJGit(TaskListener.NULL);
+    public void connectWhenHostKeyProvidedThenShouldNotFail() throws Exception {
+        verifier = new ManuallyProvidedKeyVerifier(hostKey).forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-        } catch (IOException e) {
-            fail("Should not fail because hostkey for 'github.com:22' was provided");
-        }
+        //Should not fail because hostkey for 'github.com:22' was provided
+        jGitConnection.connect(verifier);
     }
 
     @Test
@@ -65,66 +61,57 @@ public class ManuallyProvidedKeyVerifierTest {
         verifier = new ManuallyProvidedKeyVerifier("github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9OOOO").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
+        Exception exception = assertThrows(IOException.class, () -> {
             jGitConnection.connect(verifier);
-            fail("Should fail because hostkey for 'github.com' is wrong");
-        } catch (IOException e) {
-            assertThat(e.getMessage(), is("There was a problem while connecting to github.com:22"));
-        }
+        });
+        assertThat(exception.getMessage(), containsString("There was a problem while connecting to github.com:22"));
     }
 
     @Test
-    public void connectWhenHostKeyProvidedWithPortThenShouldNotFail() {
-        AbstractJGitHostKeyVerifier verifier = new ManuallyProvidedKeyVerifier("github.com:22 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl").forJGit(TaskListener.NULL);
+    public void connectWhenHostKeyProvidedWithPortThenShouldNotFail() throws Exception {
+        verifier = new ManuallyProvidedKeyVerifier("github.com:22 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-        } catch (IOException e) {
-            fail("Should not fail because hostkey for 'github.com:22' was provided, but fails with: " + e.getMessage());
-        }
+        //Should not fail because hostkey for 'github.com:22' was provided
+        jGitConnection.connect(verifier);
     }
 
     @Test
-    public void connectWhenProvidedHostnameWithPortHashedShouldNotFail() {
+    public void connectWhenProvidedHostnameWithPortHashedShouldNotFail() throws Exception {
         // |1|L95XQhkJWMDrDLdtkT1oH7hj2ec=|A2ocjuIDw2x+SOhTnRU3IGjqai0= is github.com:22
-        AbstractJGitHostKeyVerifier verifier = new ManuallyProvidedKeyVerifier("|1|L95XQhkJWMDrDLdtkT1oH7hj2ec=|A2ocjuIDw2x+SOhTnRU3IGjqai0= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=").forJGit(TaskListener.NULL);
+        verifier = new ManuallyProvidedKeyVerifier("|1|L95XQhkJWMDrDLdtkT1oH7hj2ec=|A2ocjuIDw2x+SOhTnRU3IGjqai0= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-        } catch (IOException e) {
-            fail("Should not fail because hostkey for 'github.com:22' was provided, but fails with: " + e.getMessage());
-        }
+        //Should not fail because hostkey for 'github.com:22' was provided
+        jGitConnection.connect(verifier);
     }
 
     @Test
-    public void connectWhenProvidedHostnameWithoutPortHashedShouldNotFail() {
+    public void connectWhenProvidedHostnameWithoutPortHashedShouldNotFail() throws Exception {
         // |1|Sps9q6AJcYKtFor8T+uOUSdidVc=|liZf9T3FN9jJG2NPwUXK9b/YB+g= is github.com
-        AbstractJGitHostKeyVerifier verifier = new ManuallyProvidedKeyVerifier("|1|Sps9q6AJcYKtFor8T+uOUSdidVc=|liZf9T3FN9jJG2NPwUXK9b/YB+g= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=").forJGit(TaskListener.NULL);
+        verifier = new ManuallyProvidedKeyVerifier("|1|Sps9q6AJcYKtFor8T+uOUSdidVc=|liZf9T3FN9jJG2NPwUXK9b/YB+g= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-        } catch (IOException e) {
-            fail("Should not fail because hostkey for 'github.com' was provided, but fails with: " + e.getMessage());
-        }
+        // Should not fail because hostkey for 'github.com' was provided
+        jGitConnection.connect(verifier);
     }
+
     @Test
     public void connectWhenHostKeyProvidedThenShouldFail() {
         verifier = new ManuallyProvidedKeyVerifier("github.com:33 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
+        Exception exception = assertThrows(IOException.class, () -> {
             jGitConnection.connect(verifier);
-            fail("Should fail because hostkey for 'github.com:33' was provided instead of 'github.com:22'");
-        } catch (IOException e) {
-            assertThat(e.getMessage(), is("There was a problem while connecting to github.com:22"));
-        }
+        });
+        assertThat(exception.getMessage(), containsString("There was a problem while connecting to github.com:22"));
     }
+
     @Test
     public void testGetVerifyHostKeyOption() throws IOException {
-        Assume.assumeFalse("test can not run on windows", Functions.isWindows());
+        if (isWindows()) {
+            return; // Skip test without generating a Maven surefire warning
+        }
         Path tempFile = testFolder.newFile().toPath();
         String actual = new ManuallyProvidedKeyVerifier(hostKey).forCliGit(TaskListener.NULL).getVerifyHostKeyOption(tempFile);
         assertThat(actual, is("-o StrictHostKeyChecking=yes  -o UserKnownHostsFile=\\\"\"\"" + tempFile.toAbsolutePath() + "\\\"\"\""));
@@ -133,11 +120,16 @@ public class ManuallyProvidedKeyVerifierTest {
 
     @Test
     public void testGetVerifyHostKeyOptionOnWindows() throws IOException {
-        Assume.assumeTrue("test should run on windows", Functions.isWindows());
+        if (!isWindows()) {
+            return; // Skip test without generating a Maven surefire warning
+        }
         Path tempFile = testFolder.newFile().toPath();
         String actual = new ManuallyProvidedKeyVerifier(hostKey).forCliGit(TaskListener.NULL).getVerifyHostKeyOption(tempFile);
         assertThat(actual, is("-o StrictHostKeyChecking=yes  -o UserKnownHostsFile=" + tempFile.toAbsolutePath() + ""));
         assertThat(Files.readAllLines(tempFile), is(Collections.singletonList(hostKey)));
     }
 
+    private boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Paths;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
 
 public class NoHostKeyVerifierTest {
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
@@ -22,13 +22,10 @@ public class NoHostKeyVerifierTest {
     }
 
     @Test
-    public void testVerifyServerHostKey() {
+    public void testVerifyServerHostKey() throws IOException {
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
-        try {
-            jGitConnection.connect(verifier.forJGit(TaskListener.NULL));
-        } catch (IOException e) {
-            fail("Should not fail because verifyServerHostKey always true");
-        }
+        // Should not fail because verifyServerHostKey always true
+        jGitConnection.connect(verifier.forJGit(TaskListener.NULL));
     }
 
     @Test


### PR DESCRIPTION
## Simplify test assertions

Tests included safeguards for conditions that are no longer supported, like running the tests on CentOS 6 or other operating systems that are no longer supported by the operating system provider.  No need to have the additional conditionals for conditions that are not changing.

- Show more information if test fails
- Remove unused imports
- Simplify assertions
- Use assertThrows instead of try / catch
- Credentials are always supported with the supported CLI git versions
- Do not test for CLI git versions older than 1.8.3

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Tests
