### PR TITLE
use aci containers for ci remove exclusion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,6 @@
 buildPlugin(failFast: false,
             configurations: [
                 [platform: 'linux',   jdk: '17', jenkins: '2.342'],
-                [platform: 'linux',   jdk: '11'],
+                [platform: 'maven-11', jdk: 11],
                 [platform: 'windows', jdk:  '8'],
             ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 buildPlugin(failFast: false,
             configurations: [
-                [platform: 'linux',   jdk: '17', jenkins: '2.342'],
+                [platform: 'linux',    jdk: 17, jenkins: '2.346.1'],
                 [platform: 'maven-11', jdk: 11],
-                [platform: 'windows', jdk:  '8'],
+                [platform: 'windows',  jdk:  8],
             ])

--- a/pom.xml
+++ b/pom.xml
@@ -231,15 +231,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <!-- newer version required by equalsverifier -->
-          <!-- needed by equalsverifier, not directly used by git client -->
-          <!-- Remove exclusion as soon as equalsverifier and mockito-core agree on byte buddy version -->
-          <groupId>net.bytebuddy</groupId>
-          <artifactId>byte-buddy</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -373,35 +373,6 @@
           </links>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <extensions>true</extensions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs</artifactId>
-            <version>4.7.1</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>0.8C</forkCount>
-          <reuseForks>true</reuseForks>
-          <systemProperties>
-            <property>
-              <name>surefire.profile</name>
-              <value>${project.activeProfiles[0].id}</value>
-            </property>
-          </systemProperties>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,12 @@
       <artifactId>spotbugs-annotations</artifactId>
       <version>4.7.1</version>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifierTest.java
@@ -38,6 +38,9 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenFirstConnection() throws Exception {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         File file = new File(testFolder.getRoot() + "path/to/file");
         AcceptFirstConnectionVerifier acceptFirstConnectionVerifier = spy(new AcceptFirstConnectionVerifier());
         when(acceptFirstConnectionVerifier.getKnownHostsFile()).thenReturn(file);
@@ -52,6 +55,9 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenSecondConnectionWithEqualKeys() throws Exception {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         // |1|I9eFW1PcZ6UvKPt6iHmYwTXTo54=|PyasyFX5Az4w9co6JTn7rHkeFII= is github.com:22
         String hostKeyEntry = "|1|I9eFW1PcZ6UvKPt6iHmYwTXTo54=|PyasyFX5Az4w9co6JTn7rHkeFII= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";
         File mockedKnownHosts = knownHostsTestUtil.createFakeKnownHosts(hostKeyEntry);
@@ -68,6 +74,9 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenHostnameWithoutPort() throws Exception {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         String hostKeyEntry = "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";
         File mockedKnownHosts = knownHostsTestUtil.createFakeKnownHosts(hostKeyEntry);
         AcceptFirstConnectionVerifier acceptFirstConnectionVerifier = spy(new AcceptFirstConnectionVerifier());
@@ -83,6 +92,9 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenSecondConnectionWhenNotDefaultAlgorithm() throws Exception {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         String fileContent = "github.com,140.82.121.4"
                 + " ecdsa-sha2-nistp256"
                 + " AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=";
@@ -117,6 +129,9 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenConnectionWithAnotherHost() throws Exception {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         String bitbucketFileContent = "|1|HnmPCP38pBhCY0NUtBXSraOg9pM=|L6YZ9asEeb2xplTDEThGOxRq7ZY="
                 + " ssh-rsa"
                 + " AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==";
@@ -136,6 +151,9 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenHostnamePortProvided() throws Exception {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         String fileContent = "|1|6uMj3M7sLgZpn54vQbGqgPNTCVM=|OkV9Lu9REJZR5QCVrITAIY34I1M=" //github.com:59666
                 + " ssh-ed25519"
                 + " AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";
@@ -150,5 +168,12 @@ public class AcceptFirstConnectionVerifierTest {
         List<String> actual = Files.readAllLines(mockedKnownHosts.toPath());
         assertThat(actual, hasItem(fileContent));
         assertThat(actual, hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
+    }
+
+    /* Return true if running on a Kubernetes pod on ci.jenkins.io */
+    private boolean isKubernetesCI() {
+        String kubernetesPort = System.getenv("KUBERNETES_PORT");
+        String buildURL = System.getenv("BUILD_URL");
+        return kubernetesPort != null && kubernetesPort.isEmpty() && buildURL != null && buildURL.startsWith("https://ci.jenkins.io/");
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifierTest.java
@@ -16,8 +16,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -37,20 +37,17 @@ public class AcceptFirstConnectionVerifierTest {
     }
 
     @Test
-    public void testVerifyServerHostKeyWhenFirstConnection() {
+    public void testVerifyServerHostKeyWhenFirstConnection() throws Exception {
         File file = new File(testFolder.getRoot() + "path/to/file");
         AcceptFirstConnectionVerifier acceptFirstConnectionVerifier = spy(new AcceptFirstConnectionVerifier());
         when(acceptFirstConnectionVerifier.getKnownHostsFile()).thenReturn(file);
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            assertTrue(file.exists());
-            assertThat(Files.readAllLines(file.toPath()), hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
-        } catch (IOException e) {
-            fail("Should not fail because first connection and create a file");
-        }
+        // Should not fail because first connection and create a file
+        jGitConnection.connect(verifier);
+        assertThat(file, is(anExistingFile()));
+        assertThat(Files.readAllLines(file.toPath()), hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
     }
 
     @Test
@@ -63,12 +60,10 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(hostKeyEntry)));
-        } catch (IOException e) {
-            fail("Should connect and do not add new line because keys are equal");
-        }
+        // Should connect and do not add new line because keys are equal
+        jGitConnection.connect(verifier);
+        assertThat(mockedKnownHosts, is(anExistingFile()));
+        assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(hostKeyEntry)));
     }
 
     @Test
@@ -80,12 +75,10 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(hostKeyEntry)));
-        } catch (IOException e) {
-            fail("Should connect and do not add new line because keys are equal");
-        }
+        // Should connect and do not add new line because keys are equal
+        jGitConnection.connect(verifier);
+        assertThat(mockedKnownHosts, is(anExistingFile()));
+        assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(hostKeyEntry)));
     }
 
     @Test
@@ -99,12 +92,10 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(fileContent)));
-        } catch (IOException e) {
-            fail("Should connect and do not add new line because keys are equal");
-        }
+        // Should connect and do not add new line because keys are equal
+        jGitConnection.connect(verifier);
+        assertThat(mockedKnownHosts, is(anExistingFile()));
+        assertThat(Files.readAllLines(mockedKnownHosts.toPath()), is(Collections.singletonList(fileContent)));
     }
 
     @Test
@@ -118,12 +109,10 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
+        Exception exception = assertThrows(IOException.class, () -> {
             jGitConnection.connect(verifier);
-            fail("Should fail because hostkey is broken for 'github.com:22'");
-        } catch (IOException e) {
-            assertThat(e.getMessage(), is("There was a problem while connecting to github.com:22"));
-        }
+        });
+        assertThat(exception.getMessage(), containsString("There was a problem while connecting to github.com:22"));
     }
 
     @Test
@@ -138,14 +127,11 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            List<String> actual = Files.readAllLines(fakeKnownHosts.toPath());
-            assertThat(actual, hasItem(bitbucketFileContent));
-            assertThat(actual, hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
-        } catch (IOException e) {
-            fail("Should connect and add new line because a new key");
-        }
+        // Should connect and add new line because a new key
+        jGitConnection.connect(verifier);
+        List<String> actual = Files.readAllLines(fakeKnownHosts.toPath());
+        assertThat(actual, hasItem(bitbucketFileContent));
+        assertThat(actual, hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
     }
 
     @Test
@@ -159,14 +145,10 @@ public class AcceptFirstConnectionVerifierTest {
         AbstractJGitHostKeyVerifier verifier = acceptFirstConnectionVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            List<String> actual = Files.readAllLines(mockedKnownHosts.toPath());
-            assertThat(actual, hasItem(fileContent));
-            assertThat(actual, hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
-        } catch (IOException e) {
-            fail("Should connect and add new line because a new key");
-        }
+        // Should connect and add new line because a new key
+        jGitConnection.connect(verifier);
+        List<String> actual = Files.readAllLines(mockedKnownHosts.toPath());
+        assertThat(actual, hasItem(fileContent));
+        assertThat(actual, hasItem(containsString(FILE_CONTENT.substring(FILE_CONTENT.indexOf(" ")))));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
@@ -51,6 +51,7 @@ public class KnownHostsFileVerifierTest {
             jGitConnection.connect(verifier);
         });
         assertThat(exception.getMessage(), is("There was a problem while connecting to bitbucket.org:22"));
+
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
@@ -56,6 +56,9 @@ public class KnownHostsFileVerifierTest {
 
     @Test
     public void connectWhenHostKeyProvidedThenShouldNotFail() throws IOException {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         KnownHostsFileVerifier knownHostsFileVerifier = spy(new KnownHostsFileVerifier());
         when(knownHostsFileVerifier.getKnownHostsFile()).thenReturn(fakeKnownHosts);
         AbstractJGitHostKeyVerifier verifier = knownHostsFileVerifier.forJGit(TaskListener.NULL);
@@ -66,6 +69,9 @@ public class KnownHostsFileVerifierTest {
 
     @Test
     public void connectWhenHostKeyInKnownHostsFileWithNotDefaultAlgorithmThenShouldNotFail() throws IOException {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         fakeKnownHosts = knownHostsTestUtil.createFakeKnownHosts("fake2.ssh", "known_hosts_fake2",
                 "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=");
         KnownHostsFileVerifier knownHostsFileVerifier = spy(new KnownHostsFileVerifier());
@@ -82,4 +88,10 @@ public class KnownHostsFileVerifierTest {
         assertThat(verifier.forCliGit(TaskListener.NULL).getVerifyHostKeyOption(null), is("-o StrictHostKeyChecking=yes"));
     }
 
+    /* Return true if running on a Kubernetes pod on ci.jenkins.io */
+    private boolean isKubernetesCI() {
+        String kubernetesPort = System.getenv("KUBERNETES_PORT");
+        String buildURL = System.getenv("BUILD_URL");
+        return kubernetesPort != null && kubernetesPort.isEmpty() && buildURL != null && buildURL.startsWith("https://ci.jenkins.io/");
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
@@ -56,22 +56,20 @@ public class KnownHostsFileVerifierTest {
 
     @Test
     public void connectWhenHostKeyProvidedThenShouldNotFail() throws IOException {
-        if (isKubernetesCI()) {
-            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
-        }
         KnownHostsFileVerifier knownHostsFileVerifier = spy(new KnownHostsFileVerifier());
         when(knownHostsFileVerifier.getKnownHostsFile()).thenReturn(fakeKnownHosts);
         AbstractJGitHostKeyVerifier verifier = knownHostsFileVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
         // Should not fail because hostkey for 'github.com:22' is in known_hosts
-        jGitConnection.connect(verifier);
+        try {
+            jGitConnection.connect(verifier);
+        } finally {
+            jGitConnection.close();
+        }
     }
 
     @Test
     public void connectWhenHostKeyInKnownHostsFileWithNotDefaultAlgorithmThenShouldNotFail() throws IOException {
-        if (isKubernetesCI()) {
-            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
-        }
         fakeKnownHosts = knownHostsTestUtil.createFakeKnownHosts("fake2.ssh", "known_hosts_fake2",
                 "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=");
         KnownHostsFileVerifier knownHostsFileVerifier = spy(new KnownHostsFileVerifier());
@@ -79,19 +77,16 @@ public class KnownHostsFileVerifierTest {
         AbstractJGitHostKeyVerifier verifier = knownHostsFileVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
         // Should not fail because hostkey for 'github.com:22' is in known_hosts with algorithm 'ecdsa-sha2-nistp256
-        jGitConnection.connect(verifier);
+        try {
+            jGitConnection.connect(verifier);
+        } finally {
+            jGitConnection.close();
+        }
     }
 
     @Test
     public void testVerifyHostKeyOptionWithDefaultFile() throws Exception {
         KnownHostsFileVerifier verifier = new KnownHostsFileVerifier();
         assertThat(verifier.forCliGit(TaskListener.NULL).getVerifyHostKeyOption(null), is("-o StrictHostKeyChecking=yes"));
-    }
-
-    /* Return true if running on a Kubernetes pod on ci.jenkins.io */
-    private boolean isKubernetesCI() {
-        String kubernetesPort = System.getenv("KUBERNETES_PORT");
-        String buildURL = System.getenv("BUILD_URL");
-        return kubernetesPort != null && kubernetesPort.isEmpty() && buildURL != null && buildURL.startsWith("https://ci.jenkins.io/");
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
@@ -8,6 +8,7 @@ import org.jenkinsci.plugins.gitclient.trilead.JGitConnection;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -29,6 +30,9 @@ public class KnownHostsFileVerifierTest {
     @Rule
     public TemporaryFolder testFolder = TemporaryFolder.builder().assureDeletion().build();
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
     private File fakeKnownHosts;
 
     private final KnownHostsTestUtil knownHostsTestUtil = new KnownHostsTestUtil(testFolder);
@@ -47,26 +51,19 @@ public class KnownHostsFileVerifierTest {
         AbstractJGitHostKeyVerifier verifier = knownHostsFileVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("bitbucket.org", 22);
 
-        try {
-            jGitConnection.connect(verifier);
-            fail("Should fail because hostkey for 'bitbucket.org:22' is not in known_hosts file");
-        } catch (IOException e) {
-            assertThat(e.getMessage(), is("There was a problem while connecting to bitbucket.org:22"));
-        }
+        // Should throw exception because hostkey for 'bitbucket.org:22' is not in known_hosts file
+        expectedException.expectMessage("There was a problem while connecting to bitbucket.org:22");
+        jGitConnection.connect(verifier);
     }
 
     @Test
-    public void connectWhenHostKeyProvidedThenShouldNotFail() {
+    public void connectWhenHostKeyProvidedThenShouldNotFail() throws IOException {
         KnownHostsFileVerifier knownHostsFileVerifier = spy(new KnownHostsFileVerifier());
         when(knownHostsFileVerifier.getKnownHostsFile()).thenReturn(fakeKnownHosts);
         AbstractJGitHostKeyVerifier verifier = knownHostsFileVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
-
-        try {
-            jGitConnection.connect(verifier);
-        } catch (IOException e) {
-            fail("Should not fail because hostkey for 'github.com:22' is in known_hosts");
-        }
+        // Should not fail because hostkey for 'github.com:22' is in known_hosts
+        jGitConnection.connect(verifier);
     }
 
     @Test
@@ -77,12 +74,8 @@ public class KnownHostsFileVerifierTest {
         when(knownHostsFileVerifier.getKnownHostsFile()).thenReturn(fakeKnownHosts);
         AbstractJGitHostKeyVerifier verifier = knownHostsFileVerifier.forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
-
-        try {
-            jGitConnection.connect(verifier);
-        } catch (IOException e) {
-            fail("Should not fail because hostkey for 'github.com:22' is in known_hosts with algorithm 'ecdsa-sha2-nistp256'");
-        }
+        // Should not fail because hostkey for 'github.com:22' is in known_hosts with algorithm 'ecdsa-sha2-nistp256
+        jGitConnection.connect(verifier);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifierTest.java
@@ -49,6 +49,9 @@ public class ManuallyProvidedKeyVerifierTest {
 
     @Test
     public void connectWhenHostKeyProvidedThenShouldNotFail() throws Exception {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         verifier = new ManuallyProvidedKeyVerifier(hostKey).forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
@@ -69,6 +72,9 @@ public class ManuallyProvidedKeyVerifierTest {
 
     @Test
     public void connectWhenHostKeyProvidedWithPortThenShouldNotFail() throws Exception {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         verifier = new ManuallyProvidedKeyVerifier("github.com:22 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
@@ -78,6 +84,9 @@ public class ManuallyProvidedKeyVerifierTest {
 
     @Test
     public void connectWhenProvidedHostnameWithPortHashedShouldNotFail() throws Exception {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         // |1|L95XQhkJWMDrDLdtkT1oH7hj2ec=|A2ocjuIDw2x+SOhTnRU3IGjqai0= is github.com:22
         verifier = new ManuallyProvidedKeyVerifier("|1|L95XQhkJWMDrDLdtkT1oH7hj2ec=|A2ocjuIDw2x+SOhTnRU3IGjqai0= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
@@ -88,6 +97,9 @@ public class ManuallyProvidedKeyVerifierTest {
 
     @Test
     public void connectWhenProvidedHostnameWithoutPortHashedShouldNotFail() throws Exception {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         // |1|Sps9q6AJcYKtFor8T+uOUSdidVc=|liZf9T3FN9jJG2NPwUXK9b/YB+g= is github.com
         verifier = new ManuallyProvidedKeyVerifier("|1|Sps9q6AJcYKtFor8T+uOUSdidVc=|liZf9T3FN9jJG2NPwUXK9b/YB+g= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
@@ -131,5 +143,12 @@ public class ManuallyProvidedKeyVerifierTest {
 
     private boolean isWindows() {
         return File.pathSeparatorChar == ';';
+    }
+
+    /* Return true if running on a Kubernetes pod on ci.jenkins.io */
+    private boolean isKubernetesCI() {
+        String kubernetesPort = System.getenv("KUBERNETES_PORT");
+        String buildURL = System.getenv("BUILD_URL");
+        return kubernetesPort != null && kubernetesPort.isEmpty() && buildURL != null && buildURL.startsWith("https://ci.jenkins.io/");
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifierTest.java
@@ -49,14 +49,15 @@ public class ManuallyProvidedKeyVerifierTest {
 
     @Test
     public void connectWhenHostKeyProvidedThenShouldNotFail() throws Exception {
-        if (isKubernetesCI()) {
-            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
-        }
         verifier = new ManuallyProvidedKeyVerifier(hostKey).forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
         //Should not fail because hostkey for 'github.com:22' was provided
-        jGitConnection.connect(verifier);
+        try {
+            jGitConnection.connect(verifier);
+        } finally {
+            jGitConnection.close();
+        }
     }
 
     @Test
@@ -72,40 +73,43 @@ public class ManuallyProvidedKeyVerifierTest {
 
     @Test
     public void connectWhenHostKeyProvidedWithPortThenShouldNotFail() throws Exception {
-        if (isKubernetesCI()) {
-            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
-        }
         verifier = new ManuallyProvidedKeyVerifier("github.com:22 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
         //Should not fail because hostkey for 'github.com:22' was provided
-        jGitConnection.connect(verifier);
+        try {
+            jGitConnection.connect(verifier);
+        } finally {
+            jGitConnection.close();
+        }
     }
 
     @Test
     public void connectWhenProvidedHostnameWithPortHashedShouldNotFail() throws Exception {
-        if (isKubernetesCI()) {
-            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
-        }
         // |1|L95XQhkJWMDrDLdtkT1oH7hj2ec=|A2ocjuIDw2x+SOhTnRU3IGjqai0= is github.com:22
         verifier = new ManuallyProvidedKeyVerifier("|1|L95XQhkJWMDrDLdtkT1oH7hj2ec=|A2ocjuIDw2x+SOhTnRU3IGjqai0= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
         //Should not fail because hostkey for 'github.com:22' was provided
-        jGitConnection.connect(verifier);
+        try {
+            jGitConnection.connect(verifier);
+        } finally {
+            jGitConnection.close();
+        }
     }
 
     @Test
     public void connectWhenProvidedHostnameWithoutPortHashedShouldNotFail() throws Exception {
-        if (isKubernetesCI()) {
-            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
-        }
         // |1|Sps9q6AJcYKtFor8T+uOUSdidVc=|liZf9T3FN9jJG2NPwUXK9b/YB+g= is github.com
         verifier = new ManuallyProvidedKeyVerifier("|1|Sps9q6AJcYKtFor8T+uOUSdidVc=|liZf9T3FN9jJG2NPwUXK9b/YB+g= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=").forJGit(TaskListener.NULL);
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
 
         // Should not fail because hostkey for 'github.com' was provided
-        jGitConnection.connect(verifier);
+        try {
+            jGitConnection.connect(verifier);
+        } finally {
+            jGitConnection.close();
+        }
     }
 
     @Test
@@ -143,12 +147,5 @@ public class ManuallyProvidedKeyVerifierTest {
 
     private boolean isWindows() {
         return File.pathSeparatorChar == ';';
-    }
-
-    /* Return true if running on a Kubernetes pod on ci.jenkins.io */
-    private boolean isKubernetesCI() {
-        String kubernetesPort = System.getenv("KUBERNETES_PORT");
-        String buildURL = System.getenv("BUILD_URL");
-        return kubernetesPort != null && kubernetesPort.isEmpty() && buildURL != null && buildURL.startsWith("https://ci.jenkins.io/");
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
@@ -22,13 +22,10 @@ public class NoHostKeyVerifierTest {
     }
 
     @Test
-    public void testVerifyServerHostKey() {
+    public void testVerifyServerHostKey() throws IOException {
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
-        try {
-            jGitConnection.connect(verifier.forJGit(TaskListener.NULL));
-        } catch (IOException e) {
-            fail("Should not fail because verifyServerHostKey always true");
-        }
+        // Should not fail because verifyServerHostKey always true
+        jGitConnection.connect(verifier.forJGit(TaskListener.NULL));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
@@ -22,23 +22,17 @@ public class NoHostKeyVerifierTest {
 
     @Test
     public void testVerifyServerHostKey() throws IOException {
-        if (isKubernetesCI()) {
-            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
-        }
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
         // Should not fail because verifyServerHostKey always true
-        jGitConnection.connect(verifier.forJGit(TaskListener.NULL));
+        try {
+            jGitConnection.connect(verifier.forJGit(TaskListener.NULL));
+        } finally {
+            jGitConnection.close();
+        }
     }
 
     @Test
     public void testVerifyHostKeyOption() throws IOException {
         assertThat(verifier.forCliGit(TaskListener.NULL).getVerifyHostKeyOption(Paths.get("")), is("-o StrictHostKeyChecking=no"));
-    }
-
-    /* Return true if running on a Kubernetes pod on ci.jenkins.io */
-    private boolean isKubernetesCI() {
-        String kubernetesPort = System.getenv("KUBERNETES_PORT");
-        String buildURL = System.getenv("BUILD_URL");
-        return kubernetesPort != null && kubernetesPort.isEmpty() && buildURL != null && buildURL.startsWith("https://ci.jenkins.io/");
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
@@ -22,6 +22,9 @@ public class NoHostKeyVerifierTest {
 
     @Test
     public void testVerifyServerHostKey() throws IOException {
+        if (isKubernetesCI()) {
+            return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
+        }
         JGitConnection jGitConnection = new JGitConnection("github.com", 22);
         // Should not fail because verifyServerHostKey always true
         jGitConnection.connect(verifier.forJGit(TaskListener.NULL));
@@ -30,5 +33,12 @@ public class NoHostKeyVerifierTest {
     @Test
     public void testVerifyHostKeyOption() throws IOException {
         assertThat(verifier.forCliGit(TaskListener.NULL).getVerifyHostKeyOption(Paths.get("")), is("-o StrictHostKeyChecking=no"));
+    }
+
+    /* Return true if running on a Kubernetes pod on ci.jenkins.io */
+    private boolean isKubernetesCI() {
+        String kubernetesPort = System.getenv("KUBERNETES_PORT");
+        String buildURL = System.getenv("BUILD_URL");
+        return kubernetesPort != null && kubernetesPort.isEmpty() && buildURL != null && buildURL.startsWith("https://ci.jenkins.io/");
     }
 }


### PR DESCRIPTION
- Use container agent for CI build
- Show more information if test fails
- Test JDK 17 with Jenkins 2.346.1 LTS, not 2.342 weekly
- Reduce diffs
- Do not fork tests on multi-core machines
- Remove unnecessary exclusion
