### PR TITLE
[JENKINS-69193] GitAPITestUpdateCliGit: rely less on strict wording of messages from git CLI tool

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
@@ -48,7 +48,16 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
             w.git.submoduleUpdate().execute();
             fail("Did not throw expected submodule update exception");
         } catch (GitException e) {
-            assertThat(e.getMessage(), containsString("Command \"git submodule update modules/ntp\" returned status code 1"));
+            /* Depending on git program implementation/version, the string can be either short:
+             *    Command "git submodule update modules/ntp" returned status code 1"
+             * or detailed:
+             *    Command "git submodule update modules/ntp" executed in workdir "C:\Users\..." returned status code 1
+             * so we catch below the two common parts separately.
+             * NOTE: git codebase itself goes to great extents to forbid their
+             * own unit-testing code from relying on emitted text messages.
+             */
+            assertThat(e.getMessage(), containsString("Command \"git submodule update modules/ntp\" "));
+            assertThat(e.getMessage(), containsString(" returned status code 1"));
         }
     }
 


### PR DESCRIPTION
## [JENKINS-69193](https://issues.jenkins.io/browse/JENKINS-69193) - see #886 for details

This PR just re-applies the logical change of PR #886 into the new test case file, after the original fix got lost with merge of #824 with its mass renaming.