### PR TITLE
Test a wider range of Jenkins versions in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 buildPlugin(failFast: false,
             configurations: [
-                [platform: 'linux',    jdk: 17, jenkins: '2.346.1'],
-                [platform: 'maven-11', jdk: 11],
+                [platform: 'linux',    jdk: 17, jenkins: '2.361.1'],
+                [platform: 'maven-11', jdk: 11, jenkins: '2.346.3'],
                 [platform: 'windows',  jdk:  8],
             ])

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -946,15 +946,17 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 /* See JENKINS-45228 */
                 /* Git merge requires authentication in LFS merges, plugin does not authenticate the git merge command */
-                String defaultRemote = null;
+                String repoUrl = null;
                 try {
-                    defaultRemote = getDefaultRemote();
+                    String defaultRemote = getDefaultRemote();
+                    if (defaultRemote != null && !defaultRemote.isEmpty()) {
+                        repoUrl = getRemoteUrl(defaultRemote);
+                    }
                 } catch (GitException e) {
-                    /* Nothing to do, just keeping defaultRemote = null */
+                    /* Nothing to do, just keeping repoUrl = null */
                 }
 
-                if (defaultRemote != null && !defaultRemote.isEmpty()) {
-                    String repoUrl = getRemoteUrl(defaultRemote);
+                if (repoUrl != null) {
                     StandardCredentials cred = credentials.get(repoUrl);
                     if (cred == null) cred = defaultCredentials;
                     launchCommandWithCredentials(args, workspace, cred, repoUrl);


### PR DESCRIPTION
## Test wider range of Jenkins versions in CI

* Java 17 with the most recent LTS - 2.361.1
* Java 11 with the previous LTS - 2.346.3
* Java 8 with the default provided by jenkins.version - 2.332.4

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- ~~I have referenced the Jira issue related to my changes in one or more commit messages~~
- ~~I have added tests that verify my changes~~
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- ~~I have interactively tested my changes~~

## Types of changes

- [x] Test
