### PR TITLE
[JENKINS-69706] Use gson 2.8.9 to satisfy security scanners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>
     </dependency>
+    <!-- TODO: Remove when the plugin switches to JGit 6.x and Java 11 -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.9</version>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>


### PR DESCRIPTION
## [JENKINS-69706](https://issues.jenkins.io/browse/JENKINS-69706) - Use gson 2.8.9, not 2.8.8 in JGit

The gson package is not enabled for serialization in Jenkins, so the vulnerability reported as [CVE-2022-25647](https://nvd.nist.gov/vuln/detail/CVE-2022-25647) is unlikely to have any impact on the git client plugin.  However, it is easier for users running security scans if we upgrade the gson library from 2.8.8 to 2.8.9.

See the [gson 2.8.9 changelog](https://github.com/google/gson/blob/master/CHANGELOG.md#version-289) for more details.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
