### PR TITLE
Add verifier package description for javadoc

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/package-info.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * SSH host key verifier classes for git client API.
+ * @since 3.11.1
+ */
+package org.jenkinsci.plugins.gitclient.verifier;


### PR DESCRIPTION
## Add javadoc package description for verifier

Describe org.jenkinsci.plugins.gitclient.verifier in the javadoc so that it matches the javadoc of the other packages.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Documentation
