### PR TITLE
Allow file:// clones of submodules in tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2321,7 +2321,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * NOT INTENDED FOR USE OUTSIDE THE PLUGIN.
      */
     @NonNull
-    private List<String> extraGitCommandArguments = new ArrayList<>();
+    private List<String> extraGitCommandArguments = Collections.<String>emptyList();
 
     /* package protected for use in tests.
      *

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2327,7 +2327,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      *
      * NOT INTENDED FOR USE OUTSIDE THE PLUGIN.
      */
-    void setExtraGitCommandArguments(@NonNull List<String> args) {
+    private void setExtraGitCommandArguments(@NonNull List<String> args) {
         extraGitCommandArguments = new ArrayList<>(args);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2685,7 +2685,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
         /* Prepend extra git command line arguments if any */
         if (!extraGitCommandArguments.isEmpty()) {
-            args = args.prepend(extraGitCommandArguments.stream().toArray(String[]::new));
+            args = args.prepend(extraGitCommandArguments.toArray(new String[0]));
         }
         String command = gitExe + " " + StringUtils.join(args.toCommandArray(), " ");
         try {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2323,7 +2323,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     @NonNull
     private List<String> extraGitCommandArguments = Collections.<String>emptyList();
 
-    /* package protected for use in tests.
+    /* Define arguments that will be inserted into every command line git
+     * call immediately after the "git" command.  Intended to be used
+     * for specific testing situations internal to the plugin.
      *
      * NOT INTENDED FOR USE OUTSIDE THE PLUGIN.
      */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2320,6 +2320,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      *
      * NOT INTENDED FOR USE OUTSIDE THE PLUGIN.
      */
+    @NonNull
     private List<String> extraGitCommandArguments = new ArrayList<>();
 
     /* package protected for use in tests.

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -14,10 +14,6 @@ public class CliGitAPIImplTest extends GitAPITestUpdateCliGit {
     @Override
     protected GitClient setupGitAPI(File ws) throws Exception {
         GitClient client = Git.with(listener, env).in(ws).using("git").getClient();
-        /* TODO does not help:
-        // https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253
-        new CliGitCommand(client).run("config", "protocol.file.allow", "always");
-        */
         return client;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -257,6 +257,8 @@ public abstract class GitAPITestUpdate {
             return FileUtils.readFileToString(file(path), "UTF-8");
         }
 
+        private CliGitAPIImpl cachedCliGitAPIImpl = null;
+
         /**
          * Returns a CGit implementation. Sometimes we need this for testing
          * JGit impl.
@@ -265,7 +267,11 @@ public abstract class GitAPITestUpdate {
             if (git instanceof CliGitAPIImpl) {
                 return (CliGitAPIImpl) git;
             }
-            return (CliGitAPIImpl) Git.with(listener, env).in(repo).using("git").getClient();
+            if (cachedCliGitAPIImpl != null) {
+                return cachedCliGitAPIImpl;
+            }
+            cachedCliGitAPIImpl = (CliGitAPIImpl) Git.with(listener, env).in(repo).using("git").getClient();
+            return cachedCliGitAPIImpl;
         }
 
         /**

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -946,7 +946,7 @@ public abstract class GitAPITestUpdate {
     @Test
     public void testSubmoduleUpdateShallow() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
-        w.cgit().allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
+        w.cgit().allowFileProtocol();
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();
         w.git.checkout().branch(defaultBranchName).ref(defaultRemoteBranchName).execute();
         w.git.submoduleInit();
@@ -965,7 +965,7 @@ public abstract class GitAPITestUpdate {
     @Test
     public void testSubmoduleUpdateShallowWithDepth() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
-        w.cgit().allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
+        w.cgit().allowFileProtocol();
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();
         w.git.checkout().branch(defaultBranchName).ref(defaultRemoteBranchName).execute();
         w.git.submoduleInit();
@@ -1927,7 +1927,7 @@ public abstract class GitAPITestUpdate {
 
         repositoryWorkingArea.commitEmpty("init");
 
-        repositoryWorkingArea.cgit().allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always
+        repositoryWorkingArea.cgit().allowFileProtocol();
         repositoryWorkingArea.cgit().add(".");
         repositoryWorkingArea.cgit().addSubmodule("file://" + submoduleDir.getAbsolutePath(), "submodule");
         repositoryWorkingArea.cgit().commit("submodule");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -951,7 +951,7 @@ public abstract class GitAPITestUpdate {
     @Test
     public void testSubmoduleUpdateShallow() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
-        allowFileProtocol(w.git);
+        allowFileProtocol(w.git); // CLI git 2.38.1 requires protocol.file.allow=always for this test
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();
         w.git.checkout().branch(defaultBranchName).ref(defaultRemoteBranchName).execute();
         w.git.submoduleInit();
@@ -970,7 +970,7 @@ public abstract class GitAPITestUpdate {
     @Test
     public void testSubmoduleUpdateShallowWithDepth() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
-        allowFileProtocol(w.git);
+        allowFileProtocol(w.git); // CLI git 2.38.1 requires protocol.file.allow=always for this test
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();
         w.git.checkout().branch(defaultBranchName).ref(defaultRemoteBranchName).execute();
         w.git.submoduleInit();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -447,23 +447,6 @@ public abstract class GitAPITestUpdate {
         }
     }
 
-    /**
-     * Allow local git clones to use the file:// protocol by setting
-     * protocol.file.allow=always on the git command line of the
-     * GitClient argument that is passed.
-     *
-     * Command line git 2.38.1 and patches to earlier versions
-     * disallow local git submodule cloning with the file:// protocol.
-     * The change resolves a security issue but that security issue is
-     * not a threat to these tests.
-     */
-    public void allowFileProtocol(GitClient client) throws Exception {
-        if (client instanceof CliGitAPIImpl) {
-            CliGitAPIImpl cliGit = (CliGitAPIImpl) client;
-            cliGit.setExtraGitCommandArguments(Arrays.asList("-c", "protocol.file.allow=always"));
-        }
-    }
-
     private void checkGetHeadRev(String remote, String branchSpec, ObjectId expectedObjectId) throws Exception {
         ObjectId actualObjectId = w.git.getHeadRev(remote, branchSpec);
         assertNotNull(String.format("Expected ObjectId is null expectedObjectId '%s', remote '%s', branchSpec '%s'.",
@@ -951,7 +934,7 @@ public abstract class GitAPITestUpdate {
     @Test
     public void testSubmoduleUpdateShallow() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
-        allowFileProtocol(w.git); // CLI git 2.38.1 requires protocol.file.allow=always for this test
+        w.cgit().allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();
         w.git.checkout().branch(defaultBranchName).ref(defaultRemoteBranchName).execute();
         w.git.submoduleInit();
@@ -970,7 +953,7 @@ public abstract class GitAPITestUpdate {
     @Test
     public void testSubmoduleUpdateShallowWithDepth() throws Exception {
         WorkingArea remote = setupRepositoryWithSubmodule();
-        allowFileProtocol(w.git); // CLI git 2.38.1 requires protocol.file.allow=always for this test
+        w.cgit().allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
         w.git.clone_().url("file://" + remote.file("dir-repository").getAbsolutePath()).repositoryName("origin").execute();
         w.git.checkout().branch(defaultBranchName).ref(defaultRemoteBranchName).execute();
         w.git.submoduleInit();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -257,6 +257,18 @@ public abstract class GitAPITestUpdate {
             return FileUtils.readFileToString(file(path), "UTF-8");
         }
 
+        /* Remember the CliGitAPIImpl for this WorkingArea so that the
+         * allowFileProtocol() changes are "sticky" for the life of
+         * the WorkingArea.
+         *
+         * Some of the submodule checkout tests use command line git
+         * to create a submodule test repository.  When running the
+         * test with JGit, the command line git configuration of the
+         * WorkingArea needs to be preserved for the life of the
+         * WorkingArea object so that command line git uses the
+         * correct arguments when creating the submodule test
+         * repository.
+         */
         private CliGitAPIImpl cachedCliGitAPIImpl = null;
 
         /**

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
@@ -113,7 +113,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         String subFile3 = submodDir + File.separator + "file3";
 
         // Add new GIT repo to w, at the default branch
-        w.cgit().allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
+        w.cgit().allowFileProtocol();
         w.git.addSubmodule(r.repoPath(), submodDir);
         w.git.submoduleInit();
         assertTrue("file1 does not exist and should be we imported the submodule.", w.exists(subFile1));
@@ -156,7 +156,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         r.git.commit("submod-commit1");
 
         // Add new GIT repo to w
-        w.cgit().allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
+        w.cgit().allowFileProtocol();
         String subModDir = "submod1-" + UUID.randomUUID();
         w.git.addSubmodule(r.repoPath(), subModDir);
         w.git.submoduleInit();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
-import org.junit.Ignore;
 
 public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
 
@@ -79,7 +78,6 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         assertFixSubmoduleUrlsThrows();
     }
 
-    @Ignore("TODO see comment in CliGitAPIImplTest.setupGitAPI")
     @Test
     public void testTrackingSubmoduleBranches() throws Exception {
         w.init(); // empty repository
@@ -115,6 +113,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         String subFile3 = submodDir + File.separator + "file3";
 
         // Add new GIT repo to w, at the default branch
+        allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
         w.git.addSubmodule(r.repoPath(), submodDir);
         w.git.submoduleInit();
         assertTrue("file1 does not exist and should be we imported the submodule.", w.exists(subFile1));
@@ -144,7 +143,6 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         assertFalse("file3 exists and should not because not on 'branch2'", w.exists(subFile3));
     }
 
-    @Ignore("TODO see comment in CliGitAPIImplTest.setupGitAPI")
     @Test
     public void testTrackingSubmodule() throws Exception {
         w.init(); // empty repository
@@ -158,6 +156,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         r.git.commit("submod-commit1");
 
         // Add new GIT repo to w
+        allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
         String subModDir = "submod1-" + UUID.randomUUID();
         w.git.addSubmodule(r.repoPath(), subModDir);
         w.git.submoduleInit();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
@@ -113,7 +113,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         String subFile3 = submodDir + File.separator + "file3";
 
         // Add new GIT repo to w, at the default branch
-        allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
+        allowFileProtocol(w.git); // CLI git 2.38.1 requires protocol.file.allow=always for this test
         w.git.addSubmodule(r.repoPath(), submodDir);
         w.git.submoduleInit();
         assertTrue("file1 does not exist and should be we imported the submodule.", w.exists(subFile1));
@@ -156,7 +156,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         r.git.commit("submod-commit1");
 
         // Add new GIT repo to w
-        allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
+        allowFileProtocol(w.git); // CLI git 2.38.1 requires protocol.file.allow=always for this test
         String subModDir = "submod1-" + UUID.randomUUID();
         w.git.addSubmodule(r.repoPath(), subModDir);
         w.git.submoduleInit();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
@@ -113,7 +113,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         String subFile3 = submodDir + File.separator + "file3";
 
         // Add new GIT repo to w, at the default branch
-        allowFileProtocol(w.git); // CLI git 2.38.1 requires protocol.file.allow=always for this test
+        w.cgit().allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
         w.git.addSubmodule(r.repoPath(), submodDir);
         w.git.submoduleInit();
         assertTrue("file1 does not exist and should be we imported the submodule.", w.exists(subFile1));
@@ -156,7 +156,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         r.git.commit("submod-commit1");
 
         // Add new GIT repo to w
-        allowFileProtocol(w.git); // CLI git 2.38.1 requires protocol.file.allow=always for this test
+        w.cgit().allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always for this test
         String subModDir = "submod1-" + UUID.randomUUID();
         w.git.addSubmodule(r.repoPath(), subModDir);
         w.git.submoduleInit();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -2123,7 +2123,7 @@ public class GitClientTest {
             expectedDirs = expectedDirsWithoutRename;
         }
         String remote = fetchUpstream(branch);
-        allowFileProtocol(gitClient); // CLI git 2.38.1 requires protocol.file.allow=always
+        allowFileProtocol(gitClient);
         if (random.nextBoolean()) {
             gitClient.checkoutBranch(branch, remote + "/" + branch);
         } else {
@@ -2258,7 +2258,7 @@ public class GitClientTest {
         String upstream = fetchUpstream(oldBranchName);
         /* Enable long paths to prevent checkout failure on default Windows workspace with MSI installer */
         enableLongPaths(gitClient);
-        allowFileProtocol(gitClient); // CLI git 2.38.1 requires protocol.file.allow=always
+        allowFileProtocol(gitClient);
         if (random.nextBoolean()) {
             gitClient.checkoutBranch(oldBranchName, upstream + "/" + oldBranchName);
         } else {
@@ -2327,7 +2327,7 @@ public class GitClientTest {
         assertTrue("Failed to create URL repo dir", urlRepoDir.mkdir());
         GitClient urlRepoClient = Git.with(TaskListener.NULL, new EnvVars()).in(urlRepoDir).using(gitImplName).getClient();
         urlRepoClient.init();
-        allowFileProtocol(urlRepoClient); // CLI git 2.38.1 requires protocol.file.allow=always
+        allowFileProtocol(urlRepoClient);
         CliGitCommand gitCmd = new CliGitCommand(urlRepoClient);
         gitCmd.run("config", "user.name", "Vojtěch GitClientTest Zweibrücken-Šafařík");
         gitCmd.run("config", "user.email", "email.from.git.client@example.com");
@@ -2349,7 +2349,7 @@ public class GitClientTest {
         gitCmd.run("config", "user.email", "email.from.git.client@example.com");
         /* Enable long paths to prevent checkout failure on default Windows workspace with MSI installer */
         enableLongPaths(repoHasSubmoduleClient);
-        allowFileProtocol(repoHasSubmoduleClient); // CLI git 2.38.1 requires protocol.file.allow=always
+        allowFileProtocol(repoHasSubmoduleClient);
         File hasSubmoduleReadme = new File(repoHasSubmodule, "readme");
         String hasSubmoduleReadmeText = "Repo has a submodule that includes .url in its directory name (" + random.nextInt() + ")";
         Files.write(Paths.get(hasSubmoduleReadme.getAbsolutePath()), hasSubmoduleReadmeText.getBytes());
@@ -2376,7 +2376,7 @@ public class GitClientTest {
         assertTrue("Failed to create clone dir", cloneDir.mkdir());
         GitClient cloneGitClient = Git.with(TaskListener.NULL, new EnvVars()).in(cloneDir).using(gitImplName).getClient();
         cloneGitClient.init();
-        allowFileProtocol(cloneGitClient); // CLI git 2.38.1 requires protocol.file.allow=always
+        allowFileProtocol(cloneGitClient);
         cloneGitClient.clone_().url(repoHasSubmodule.getAbsolutePath()).execute();
         cloneGitClient.checkoutBranch(defaultBranchName, "origin/" + defaultBranchName);
         /* Enable long paths to prevent checkout failure on default Windows workspace with MSI installer */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -1,8 +1,8 @@
-
 package org.jenkinsci.plugins.gitclient;
 
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Launcher;
 import hudson.model.TaskListener;
 import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
@@ -10,6 +10,7 @@ import hudson.plugins.git.GitObject;
 import hudson.plugins.git.IGitAPI;
 import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.FileNotFoundException;
@@ -56,10 +57,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -256,6 +257,63 @@ public class GitClientTest {
         CliGitCommand gitCmd = new CliGitCommand(gitClient);
         gitCmd.run("config", "user.name", "Vojtěch GitClientTest Zweibrücken-Šafařík");
         gitCmd.run("config", "user.email", "email.from.git.client@example.com");
+    }
+
+    private boolean fileProtocolIsAllowed = false;
+
+    /**
+     * Allow local git clones to use the file:// protocol by setting
+     * protocol.file.allow=always in the global git configuration for
+     * the current user.
+     *
+     * Command line git 2.38.1 and patches to earlier versions
+     * disallow local git submodule cloning with the file:// protocol.
+     * The change resolves a security issue but that security issue is
+     * not a threat to these tests.
+     *
+     * After the test completes, the setting is removed from the
+     * global git configuration of the current user.
+     *
+     * The setting must be applied to the global configuration of the
+     * current user or the affected tests will fail. It is unfortunate
+     * that the tests are modifying the global configuration of the
+     * current user, but it is more important that the tests be run
+     * than that we defend the git settings of git plugin developers
+     * from changes performed by the tests.
+     */
+    private void allowFileProtocol() throws Exception {
+        CliGitAPIImpl cliGitClient;
+        if (this.srcGitClient instanceof CliGitAPIImpl) {
+            cliGitClient = (CliGitAPIImpl) this.srcGitClient;
+        } else {
+            cliGitClient = (CliGitAPIImpl) Git.with(TaskListener.NULL, new EnvVars()).in(srcRepoDir).using("git").getClient();
+        }
+        cliGitClient.launchCommand("config", "--global", "protocol.file.allow", "always");
+        fileProtocolIsAllowed = true;
+    }
+
+    /**
+     * Removes the protocol.file.allow setting from the global git
+     * configuration of the current user.
+     */
+    @After
+    public void resetFileProtocol() throws Exception {
+        if (!fileProtocolIsAllowed) {
+            return;
+        }
+        fileProtocolIsAllowed = false;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int st = new Launcher.LocalLauncher(TaskListener.NULL).launch()
+                .pwd(".")
+                .cmds("git", "config", "--global", "--unset", "protocol.file.allow")
+                .stdout(out)
+                .stderr(err)
+                .join();
+        assertThat("Failed to reset protocol.file.allow."
+                + " stdout was '" + out.toString() + "'."
+                + " stderr was '" + err.toString() + "'."
+                + " error code was " + st, st, is(0));
     }
 
     private static final String COMMITTED_ONE_TEXT_FILE = "Committed one text file";
@@ -2091,7 +2149,6 @@ public class GitClientTest {
         }
     }
 
-    @Ignore("TODO flake: Missing file …/modules/firewall/LICENSE (path:7)")
     // @Issue("JENKINS-8053")  // outdated submodules not removed by checkout
     @Issue("JENKINS-37419") // Git plugin checking out non-existent submodule from different branch
     @Test
@@ -2109,6 +2166,7 @@ public class GitClientTest {
             expectedDirs = expectedDirsWithoutRename;
         }
         String remote = fetchUpstream(branch);
+        allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always
         if (random.nextBoolean()) {
             gitClient.checkoutBranch(branch, remote + "/" + branch);
         } else {
@@ -2230,7 +2288,6 @@ public class GitClientTest {
         }
     }
 
-    @Ignore("TODO see comment in CliGitAPIImplTest.setupGitAPI")
     @Issue("JENKINS-37419") // Submodules from other branches are used in checkout
     @Test
     public void testSubmodulesUsedFromOtherBranches() throws Exception {
@@ -2244,6 +2301,7 @@ public class GitClientTest {
         String upstream = fetchUpstream(oldBranchName);
         /* Enable long paths to prevent checkout failure on default Windows workspace with MSI installer */
         enableLongPaths(gitClient);
+        allowFileProtocol(); // CLI git 2.38.1 requires protocol.file.allow=always
         if (random.nextBoolean()) {
             gitClient.checkoutBranch(oldBranchName, upstream + "/" + oldBranchName);
         } else {
@@ -2303,7 +2361,6 @@ public class GitClientTest {
         assertSubmoduleStatus(gitClient, true, "firewall", "ntp", "sshkeys"); // newDirName module won't be there
     }
 
-    @Ignore("TODO see comment in CliGitAPIImplTest.setupGitAPI")
     @Issue("JENKINS-46054")
     @Test
     public void testSubmoduleUrlEndsWithDotUrl() throws Exception {
@@ -2313,6 +2370,7 @@ public class GitClientTest {
         assertTrue("Failed to create URL repo dir", urlRepoDir.mkdir());
         GitClient urlRepoClient = Git.with(TaskListener.NULL, new EnvVars()).in(urlRepoDir).using(gitImplName).getClient();
         urlRepoClient.init();
+        allowFileProtocol();
         CliGitCommand gitCmd = new CliGitCommand(urlRepoClient);
         gitCmd.run("config", "user.name", "Vojtěch GitClientTest Zweibrücken-Šafařík");
         gitCmd.run("config", "user.email", "email.from.git.client@example.com");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -260,7 +260,7 @@ public class GitClientTest {
      * Allow local git clones to use the file:// protocol by setting
      * protocol.file.allow=always on the git command line of the
      * GitClient argument that is passed.
-     *
+     * <p>
      * Command line git 2.38.1 and patches to earlier versions
      * disallow local git submodule cloning with the file:// protocol.
      * The change resolves a security issue but that security issue is


### PR DESCRIPTION
## Allow file:// clones of submodules in tests

Allow local git clones to use the file:// protocol by setting protocol.file.allow=always in the global git configuration for the current user.

Command line git 2.38.1 and patches to earlier versions disallow local git submodule cloning with the file:// protocol. The change resolves a security issue but that security issue is not a threat to these tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test improvement
