### PR TITLE
Explicitly specify Objenesis version rather than consuming it from plugin parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,7 @@
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
+      <version>3.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Preparing for https://github.com/jenkinsci/plugin-pom/pull/634 in which I plan to remove the managed dependency on Objenesis from the plugin parent POM. I do not think it makes sense to manage this dependency in the plugin parent POM, since unlike the other test dependencies managed there (e.g., Hamcrest, JUnit, and Mockito) it is not very common for plugins to consume this dependency directly. Better for the few that do to manage the version on their own.