### PR TITLE
Always test with container agents in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,18 @@
-#!groovy
+#!/usr/bin/env groovy
 
-buildPlugin(failFast: false,
-            configurations: [
-                [platform: 'linux',    jdk: 17, jenkins: '2.361.1'],
-                [platform: 'maven-11', jdk: 11, jenkins: '2.346.3'],
-                [platform: 'windows',  jdk:  8],
-            ])
+/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPlugin(
+  // Container agents start faster and are easier to administer
+  useContainerAgent: true,
+  // Show failures on all configurations
+  failFast: false,
+  // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
+  // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
+  artifactCachingProxyEnabled: true,
+  // Test Java 8 with default Jenkins version, Java 11 with a recent LTS, Java 17 even more recent
+  configurations: [
+    [platform: 'linux',   jdk: '17', jenkins: '2.375'],
+    [platform: 'linux',   jdk: '11', jenkins: '2.361.4'],
+    [platform: 'windows', jdk:  '8']
+  ]
+)


### PR DESCRIPTION
## Always test with containers in CI

Containers start faster and are easier to manage.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
