### PR TITLE
Require Java 11 and Jenkins 2.361.4 or newer

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -17,7 +17,7 @@ Tests help us assure that we're delivering a reliable plugin, and that we've com
 
 === Compiling and testing the plugin
 
-Compile and run the plugin automated tests on Java 8 or Java 11 with:
+Compile and run the plugin automated tests on Java 11 or Java 17 with:
 
 * `mvn clean verify`
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,13 +6,13 @@ buildPlugin(
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
+  // Opt-in to the Artifact Caching Proxy, to be removed when it will be opt-out.
   // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
   artifactCachingProxyEnabled: true,
-  // Test Java 8 with default Jenkins version, Java 11 with a recent LTS, Java 17 even more recent
+  // Test Java 11 with a recent LTS, Java 17 even more recent
   configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.375'],
-    [platform: 'linux',   jdk: '11', jenkins: '2.361.4'],
-    [platform: 'windows', jdk:  '8']
+    [platform: 'linux',   jdk: '17', jenkins: '2.380'],
+    [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
+    [platform: 'windows', jdk: '11']
   ]
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ buildPlugin(
   artifactCachingProxyEnabled: true,
   // Test Java 11 with a recent LTS, Java 17 even more recent
   configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.380'],
+    [platform: 'linux',   jdk: '17', jenkins: '2.383'],
     [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
     [platform: 'windows', jdk: '11']
   ]

--- a/README.adoc
+++ b/README.adoc
@@ -65,7 +65,7 @@ When the timeout is exceeded, the command line git process fails and the git cli
 The JGit implementation in the git client plugin uses a different concept of timeout.
 The JGit timeout is a network level transport timeout rather than a timeout of a higher level JGit operation.
 If the JGit network transport does not receive a response within the defined timeout, the JGit API call fails.
-The link:https://javadoc.io/static/org.eclipse.jgit/org.eclipse.jgit/5.13.0.202109080827-r/org/eclipse/jgit/transport/Transport.html#setTimeout-int-[JGit javadoc] describes the JGit API.
+The link:https://javadoc.io/doc/org.eclipse.jgit/org.eclipse.jgit/latest/org.eclipse.jgit/org/eclipse/jgit/transport/Transport.html#setTimeout(int)[JGit javadoc] describes the JGit API.
 
 The JGit timeout implementation prevents JGit operations from hanging indefinitely when a remote server stops responding.
 It does not stop a JGit operation if it has executed for more than a specified time.

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <jenkins.version>2.361.4</jenkins.version>
     <jgit.version>6.4.0.202211300538-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
-    <spotbugs.threshold>High</spotbugs.threshold>
+    <spotbugs.threshold>Medium</spotbugs.threshold>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <jenkins.version>2.361.4</jenkins.version>
     <jgit.version>6.4.0.202211300538-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
-    <spotbugs.threshold>Medium</spotbugs.threshold>
+    <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -350,12 +350,6 @@
           <fixTags>param,return,throws,link</fixTags>
           <author>false</author>
           <force>true</force>
-          <failOnError>false</failOnError>
-          <links>
-            <link>https://docs.oracle.com/javase/8/docs/api/</link>
-            <!-- JGit patch releases do not provide javadoc. Use javadoc from matching minor release -->
-            <link>https://download.eclipse.org/jgit/site/5.13.0.202109080827-r/org.eclipse.jgit/apidocs/</link>
-          </links>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <revision>4.0.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <jenkins.version>2.361.4</jenkins.version>
     <jgit.version>6.4.0.202211300538-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>

--- a/pom.xml
+++ b/pom.xml
@@ -355,15 +355,6 @@
     </plugins>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <profiles>
     <profile>
       <id>continuous-integration</id>

--- a/pom.xml
+++ b/pom.xml
@@ -61,20 +61,17 @@
     <revision>3.13.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.346.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <jgit.version>5.13.1.202206130422-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
-    <spotbugs.failOnError>true</spotbugs.failOnError>
-    <spotbugs.threshold>Medium</spotbugs.threshold>
+    <spotbugs.threshold>High</spotbugs.threshold>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.346.x</artifactId>
+        <artifactId>bom-2.361.x</artifactId>
         <version>1723.vcb_9fee52c9fc</version>
         <type>pom</type>
         <scope>import</scope>
@@ -86,12 +83,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>
-    </dependency>
-    <!-- TODO: Remove when the plugin switches to JGit 6.x and Java 11 -->
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.9</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <jenkins.version>2.361.4</jenkins.version>
     <jgit.version>6.4.0.202211300538-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
-    <spotbugs.threshold>Low</spotbugs.threshold>
+    <spotbugs.threshold>Medium</spotbugs.threshold>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,11 @@
   </scm>
 
   <properties>
-    <revision>3.13.1</revision>
+    <revision>4.0.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.361.4</jenkins.version>
-    <jgit.version>5.13.1.202206130422-r</jgit.version>
+    <jgit.version>6.4.0.202211300538-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>High</spotbugs.threshold>
   </properties>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -3122,9 +3122,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 }
 
                 File sparseCheckoutFile = new File(workspace, SPARSE_CHECKOUT_FILE_PATH);
+
                 try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(Files.newOutputStream(sparseCheckoutFile.toPath()), StandardCharsets.UTF_8))) {
                     for (String path : paths) {
-                        writer.println(path);
+                        writer.println(environment.expand(path));
                     }
                 } catch (IOException e) {
                     throw new GitException("Could not write sparse checkout file " + sparseCheckoutFile.getAbsolutePath(), e);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -62,6 +62,7 @@ import org.eclipse.jgit.api.MergeCommand.FastForwardMode;
 import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.ShowNoteCommand;
 import org.eclipse.jgit.api.TransportCommand;
+import org.eclipse.jgit.api.errors.CanceledException;
 import org.eclipse.jgit.api.errors.CheckoutConflictException;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.JGitInternalException;
@@ -1259,7 +1260,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             rd.reset();
             rd.addAll(DiffEntry.scan(tw));
-            List<DiffEntry> diffs = rd.compute(or, null);
+            List<DiffEntry> diffs;
+            try {
+                diffs = rd.compute(or, null);
+            } catch (CanceledException e) {
+                throw new IOException(e);
+            }
             if (useRawOutput) {
 	            for (DiffEntry diff : diffs) {
 	                pw.printf(":%06o %06o %s %s %s\t%s",

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -576,7 +576,7 @@ public class GitClientTest {
         String badDirName = "CON:";
         File badDir = new File(badDirName);
         GitClient badGitClient = Git.with(TaskListener.NULL, new EnvVars()).in(badDir).using(gitImplName).getClient();
-        Class expectedExceptionClass = gitImplName.equals("git") ? GitException.class : InvalidPathException.class;
+        Class expectedExceptionClass = gitImplName.equals("git") ? GitException.class : JGitInternalException.class;
         assertThrows(expectedExceptionClass,
                      () -> badGitClient.init_().bare(random.nextBoolean()).workspace(badDirName).execute());
     }


### PR DESCRIPTION
## Require Java 11 and Jenkins 2.361.4 or newer

- Test Java 11 and Java 17 in CI
- Do not include JGit or Java 8 links in Javadoc
- Remove site generation customization
- Require Jenkins 2.371.4 or newer
- Use JGit 6.4.0
- Update JGit javadoc link to JGit 6.4.0
- Remove Java 8 reference from contributing guide

Switch from Java 8 to Java 11 as minimum Java version.  Use JGit 6.4.0 instead of JGit 5.13.x.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

JGit project has dropped support for Java 8 with the release of JGit 6.0.  It is time to run exclusively on Java 11 or newer.

- [x] Needs #940 to be merged to the master branch before this can be merged.
- [x] JMH benchmark comparison between JGit 5.13.1 and JGit 6.4.0.  The JMH comparison shows no significant regressions in JGit 6.4.0 performance compared to JGit 5.13.1.  Measurements on large repository fetch operations showed a small improvement in JGit 6.4.0 compared to JGit 5.13.1.  No attempt was made to confirm the details of the differences, only happiness that JGit 6.4.0 seems to consistently match or exceed JGit 5.13.1 performance
- [x] https://github.com/jenkinsci/bom/pull/1619 needs to be run successfully to confirm that this pull request does not break something in the plugin bill of materials.
- [x] The fetch/clone failures on my cluster with FreeBSD agents running Java 11.0.16 were resolved by restarting the agents after installation of the pre-release that includes JGit 6.4.0
