### PR TITLE
Fix JMH environment test setup

### DIFF
--- a/src/test/java/jmh/benchmark/FolderForBenchmark.java
+++ b/src/test/java/jmh/benchmark/FolderForBenchmark.java
@@ -1,5 +1,7 @@
 package jmh.benchmark;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
 import org.junit.Rule;
 
 import java.io.File;
@@ -111,8 +113,13 @@ public class FolderForBenchmark {
         return createTemporaryFolderIn(getRoot());
     }
 
-    private File createTemporaryFolderIn(File parentFolder) throws IOException {
-        File createdFolder = Files.createTempDirectory(parentFolder.toPath(), "junit").toFile();
+    private File createTemporaryFolderIn(@CheckForNull File parentFolder) throws IOException {
+        File createdFolder;
+        if (parentFolder == null) {
+            createdFolder = Files.createTempDirectory("junit").toFile();
+        } else {
+            createdFolder = Files.createTempDirectory(parentFolder.toPath(), "junit").toFile();
+        }
         return createdFolder;
     }
 


### PR DESCRIPTION
## Fix JMH environment test setup

Introduced in 107bbe0b4a574d94de7171078aabfdba1cdd86eb when I missed that the folder argument could be null.  When the folder argument is null, the previous method uses the system temporary directory. This change does the same.

JMH tests will be used to compare JGit 5.13.1 and JGit 6.4.0.  This change will allow the JGit 5.13.1 baseline tests to be performed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix in test setup code
