### PR TITLE
Allow tests from shallow clone repos

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -347,6 +347,11 @@ public abstract class GitAPITestUpdate {
         w = new WorkingArea();
     }
 
+    private boolean isShallow() {
+        File shallowMarker = new File(".git", "shallow");
+        return shallowMarker.isFile();
+    }
+
     /**
      * Populate the local mirror of the git client plugin repository. Returns
      * path to the local mirror directory.
@@ -372,7 +377,13 @@ public abstract class GitAPITestUpdate {
                      * the final destination directory.
                      */
                     Path tempClonePath = Files.createTempDirectory(targetDir.toPath(), "clone-");
-                    w.launchCommand("git", "clone", "--reference", f.getCanonicalPath(), "--mirror", "https://github.com/jenkinsci/git-client-plugin", tempClonePath.toFile().getAbsolutePath());
+                    String repoUrl = "https://github.com/jenkinsci/git-client-plugin.git";
+                    String destination = tempClonePath.toFile().getAbsolutePath();
+                    if (isShallow()) {
+                        w.launchCommand("git", "clone", "--mirror", repoUrl, destination);
+                    } else {
+                        w.launchCommand("git", "clone", "--reference", f.getCanonicalPath(), "--mirror", repoUrl, destination);
+                    }
                     if (!clone.exists()) { // Still a race condition, but a narrow race handled by Files.move()
                         renameAndDeleteDir(tempClonePath, cloneDirName);
                     } else {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/WorkspaceWithRepo.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/WorkspaceWithRepo.java
@@ -67,6 +67,13 @@ public class WorkspaceWithRepo {
         }
     }
 
+
+    private boolean isShallow() {
+        File shallowMarker = new File(".git", "shallow");
+        return shallowMarker.isFile();
+    }
+
+
     /**
      * Populate the local mirror of the git client plugin repository.
      * Returns path to the local mirror directory.
@@ -92,7 +99,12 @@ public class WorkspaceWithRepo {
                      * the final destination directory.
                      */
                     Path tempClonePath = Files.createTempDirectory(targetDir.toPath(), "clone-");
-                    cliGitCommand.run("clone", "--reference", f.getCanonicalPath(), "--mirror", repoURL, tempClonePath.toFile().getAbsolutePath());
+                    String destination = tempClonePath.toFile().getAbsolutePath();
+                    if (isShallow()) {
+                        cliGitCommand.run("clone", "--mirror", repoURL, destination);
+                    } else {
+                        cliGitCommand.run("clone", "--reference", f.getCanonicalPath(), "--mirror", repoURL, destination);
+                    }
                     if (!clone.exists()) { // Still a race condition, but a narrow race handled by Files.move()
                         renameAndDeleteDir(tempClonePath, cloneDirName);
                     } else {


### PR DESCRIPTION
## Allow tests from shallow cloned repositories

Do not attempt to use the local repository as a reference repository when the local repository is a shallow clone.  A shallow clone repository has no content to offer as a reference.  Fixes 64 test failures when the test repository is a shallow clone.

https://github.com/jenkinsci/bom/pull/1613 describes the experiment to run the plugin compatibility tests with shallow clones.

https://github.com/jenkinsci/git-plugin/pull/1365 implemented a similar change in the git plugin so that shallow cloned repositories will not fail the tests in that plugin.

Will make a few tests in a shallow repository a little slower because they will require a full clone of the git client plugin repository rather than reusing the existing clone in the test workspace.  Doubtful that the performance difference will be detectable within the general variability of CI test jobs.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
