### PR TITLE
[JENKINS-69159] Replace jsch with Apache Mina ssh in JGit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,14 +100,6 @@
       <artifactId>mina-sshd-api-core</artifactId>
     </dependency>
     <dependency>
-      <!-- Use mina api sftp plugin rather than JGit transitive dependency inclusion of Apache Mina sshd sftp -->
-      <!-- This must be listed before its consumers -->
-      <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
-      <artifactId>mina-sshd-api-sftp</artifactId>
-      <!-- Not included in the plugin bom yet -->
-      <version>2.9.2-50.va_0e1f42659a_a</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>
     </dependency>
@@ -150,6 +142,21 @@
       <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
       <version>${jgit.version}</version>
       <exclusions>
+        <exclusion>
+          <!-- Prevent inclusion of transitive dependency, OSGi not needed by git client plugin -->
+          <groupId>org.apache.sshd</groupId>
+          <artifactId>sshd-osgi</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Prevent inclusion of transitive dependency, sftp not needed by git client plugin -->
+          <groupId>org.apache.sshd</groupId>
+          <artifactId>sshd-sftp</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Prevent inclusion of transitive dependency -->
+          <groupId>net.i2p.crypto</groupId>
+          <artifactId>eddsa</artifactId>
+        </exclusion>
         <exclusion>
           <!-- provided by jenkins-core -->
           <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
   </scm>
 
   <properties>
-    <revision>4.0.1</revision>
+    <revision>4.1.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
@@ -82,6 +82,32 @@
 
   <dependencies>
     <dependency>
+      <!-- Use httpclient plugin rather than JGit transitive dependency inclusion of Apache httpclient -->
+      <!-- This must be listed before its consumers -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+    </dependency>
+    <dependency>
+      <!-- Use mina api common plugin rather than JGit transitive dependency inclusion of Apache Mina sshd common -->
+      <!-- This must be listed before its consumers -->
+      <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+      <artifactId>mina-sshd-api-common</artifactId>
+    </dependency>
+    <dependency>
+      <!-- Use mina api core plugin rather than JGit transitive dependency inclusion of Apache Mina sshd core -->
+      <!-- This must be listed before its consumers -->
+      <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+      <artifactId>mina-sshd-api-core</artifactId>
+    </dependency>
+    <dependency>
+      <!-- Use mina api sftp plugin rather than JGit transitive dependency inclusion of Apache Mina sshd sftp -->
+      <!-- This must be listed before its consumers -->
+      <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
+      <artifactId>mina-sshd-api-sftp</artifactId>
+      <!-- Not included in the plugin bom yet -->
+      <version>2.9.2-50.va_0e1f42659a_a</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>
     </dependency>
@@ -90,16 +116,6 @@
       <artifactId>org.eclipse.jgit</artifactId>
       <version>${jgit.version}</version>
       <exclusions>
-        <exclusion>
-          <!-- Provided by apache-httpcomponents-client-4-api -->
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- Provided by Jenkins core -->
-          <groupId>com.jcraft</groupId>
-          <artifactId>jzlib</artifactId>
-        </exclusion>
         <exclusion>
           <!-- Provided by Jenkins core -->
           <groupId>org.slf4j</groupId>
@@ -115,18 +131,6 @@
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit.http.server</artifactId>
       <version>${jgit.version}</version>
-      <exclusions>
-        <exclusion>
-          <!-- Provided by apache-httpcomponents-client-4-api -->
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- Provided by Jenkins core -->
-          <groupId>com.jcraft</groupId>
-          <artifactId>jzlib</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <!-- Include jgit's Apache HTTP client so that we can avoid
@@ -134,57 +138,18 @@
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit.http.apache</artifactId>
       <version>${jgit.version}</version>
-      <exclusions>
-        <exclusion>
-          <!-- Provided by apache-httpcomponents-client-4-api -->
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- Provided by apache-httpcomponents-client-4-api -->
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpcore</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- Provided by Jenkins core -->
-          <groupId>com.jcraft</groupId>
-          <artifactId>jzlib</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <!-- Include jgit's LFS module for eventual large file support -->
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit.lfs</artifactId>
       <version>${jgit.version}</version>
-      <exclusions>
-        <exclusion>
-          <!-- Provided by apache-httpcomponents-client-4-api -->
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- Provided by Jenkins core -->
-          <groupId>com.jcraft</groupId>
-          <artifactId>jzlib</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
-      <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+      <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
       <version>${jgit.version}</version>
       <exclusions>
-        <exclusion>
-          <!-- provided by jenkins-core -->
-          <groupId>com.jcraft</groupId>
-          <artifactId>jzlib</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- Provided by jsch plugin -->
-          <groupId>com.jcraft</groupId>
-          <artifactId>jsch</artifactId>
-        </exclusion>
         <exclusion>
           <!-- provided by jenkins-core -->
           <groupId>org.slf4j</groupId>
@@ -249,14 +214,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jsch</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>


### PR DESCRIPTION
## [JENKINS-69159](https://issues.jenkins.io/browse/JENKINS-69159) Replace jsch with Apache Mina ssh in JGit

A [2020 blog post from a jsch consumer](https://www.matez.de/index.php/2020/06/22/the-future-of-jsch-without-ssh-rsa/) notes that the maintainers of the jsch library are not responding to requests.  The jsch library was last released in November 2018.

The JGit project provides the [org.eclipse.jgit.ssh.apache library](https://git.eclipse.org/r/plugins/gitiles/jgit/jgit/+/master/org.eclipse.jgit.ssh.apache/) in addition to the [org.eclipse.jgit.ssh.jsch library](https://git.eclipse.org/r/plugins/gitiles/jgit/jgit/+/master/org.eclipse.jgit.ssh.jsch/).  The org.eclipse.jgit.ssh.apache library appears to be a complete replacement for git client plugin use cases.  The JGIt project has declared [their jsch library is deprecated](https://git.eclipse.org/r/plugins/gitiles/jgit/jgit/+/master/org.eclipse.jgit.ssh.jsch/) and may be removed at any time.  Jenkins has Apache Mina API plugins already available.

A [GitHub query](https://github.com/search?q=org%3Ajenkinsci+org.eclipse.jgit.ssh.jsch&type=code) shows only the git client plugin uses org.eclipse.jgit.ssh.jsch.  Replacement looks safe because there are no known consumers of `org.eclipse.jgit.ssh.jsch`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes - **required before merge**

## Types of changes

- [x] New feature

## Further comments

Would like review from @jtnord in case I've made some mistake in dependency declarations or other usage of the Apache Mina API plugins.
