### PR TITLE
Increase test coverage

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -621,7 +621,7 @@ public class GitAPITest {
             testGitClient.push().ref(defaultBranchName).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).force(false).execute();
         }
 
-        testGitClient.push().ref(defaultBranchName).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).force(true).execute();
+        testGitClient.push().ref(defaultBranchName).to(new URIish(bare.getGitFileDir().getAbsolutePath())).tags(true).force().execute();
 
         /* Add tag to working repo without pushing it to the bare
          * repo, tests the default behavior when tags() is not added

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -186,7 +186,7 @@ public class GitClientCloneTest {
 
     @Test
     public void test_clone_shared() throws IOException, InterruptedException {
-        testGitClient.clone_().url(workspace.localMirror()).repositoryName("origin").shared(true).execute();
+        testGitClient.clone_().url(workspace.localMirror()).repositoryName("origin").shared(true).tags(true).execute();
         testGitClient.checkout().ref("origin/master").branch("master").execute();
         check_remote_url(workspace, testGitClient, "origin");
         assertBranchesExist(testGitClient.getBranches(), "master");
@@ -196,7 +196,7 @@ public class GitClientCloneTest {
 
     @Test
     public void test_clone_null_branch() throws IOException, InterruptedException {
-        testGitClient.clone_().url(workspace.localMirror()).repositoryName("origin").shared().execute();
+        testGitClient.clone_().url(workspace.localMirror()).repositoryName("origin").shared().tags(false).execute();
         testGitClient.checkout().ref("origin/master").branch(null).execute();
         check_remote_url(workspace, testGitClient, "origin");
         assertAlternateFilePointsToLocalMirror();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -196,7 +196,7 @@ public class GitClientCloneTest {
 
     @Test
     public void test_clone_null_branch() throws IOException, InterruptedException {
-        testGitClient.clone_().url(workspace.localMirror()).repositoryName("origin").shared(true).execute();
+        testGitClient.clone_().url(workspace.localMirror()).repositoryName("origin").shared().execute();
         testGitClient.checkout().ref("origin/master").branch(null).execute();
         check_remote_url(workspace, testGitClient, "origin");
         assertAlternateFilePointsToLocalMirror();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -472,16 +472,25 @@ public class GitClientFetchTest {
         assertThat("shallow file existence: " + shallow, new File(testGitDir, shallow).exists(), is(true));
     }
 
-    @Test
-    public void test_fetch_shallow_depth() throws Exception {
+    private void fetch_shallow_depth(Integer fetchDepth) throws Exception {
         testGitClient.setRemoteUrl("origin", workspace.localMirror());
-        testGitClient.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).shallow(true).depth(2).execute();
+        testGitClient.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).shallow(true).depth(fetchDepth).execute();
         check_remote_url(workspace, workspace.getGitClient(), "origin");
         assertBranchesExist(testGitClient.getRemoteBranches(), "origin/" + DEFAULT_MIRROR_BRANCH_NAME);
         assertAlternatesFileExists(testGitDir);
         assertThat("isShallow?", workspace.cgit().isShallowRepository(), is(true));
         String shallow = ".git" + File.separator + "shallow";
         assertThat("shallow file existence: " + shallow, new File(testGitDir, shallow).exists(), is(true));
+    }
+
+    @Test
+    public void test_fetch_shallow_depth() throws Exception {
+        fetch_shallow_depth(2);
+    }
+
+    @Test
+    public void test_fetch_shallow_null_depth() throws Exception {
+        fetch_shallow_depth(null);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -511,7 +511,7 @@ public class GitClientFetchTest {
     public void test_fetch_default_timeout_logging() throws Exception {
         testGitClient.clone_().url(workspace.localMirror()).repositoryName("origin").execute();
         String randomBranchName = checkoutRandomBranch();
-        testGitClient.fetch_().from(new URIish("origin"), null).prune(true).execute();
+        testGitClient.fetch_().from(new URIish("origin"), null).prune().execute();
         assertTimeout(testGitClient, "fetch", CliGitAPIImpl.TIMEOUT);
         assertRevParseNotCalled(testGitClient, randomBranchName);
     }


### PR DESCRIPTION
## Increase test coverage

The increases are minor changes that cover a few more JGit methods without significantly increasing test time.

- Call prune() instead of prune(true) at least once
- Test null depth for shallow fetch
- Test shared() in addition to shared(true)
- Call tags(boolean) from a test
- Test push.force()

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Tests
