### PR TITLE
Remove duplicated 'Git installations' title in Tools page

### DIFF
--- a/src/main/resources/hudson/plugins/git/GitTool/global.jelly
+++ b/src/main/resources/hudson/plugins/git/GitTool/global.jelly
@@ -24,12 +24,10 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section title="${descriptor.displayName}">
-    <f:entry title="${%Git installations}">
-      <f:hetero-list name="tool" items="${descriptor.installations}"
-                     descriptors="${descriptor.getApplicableDesccriptors()}"
-                     addCaption="${%Add Git}" hasHeader="true"
-                     deleteCaption="${%Delete Git}"/>
-    </f:entry>
+  <f:section title="${%Git installations}">
+    <f:hetero-list name="tool" items="${descriptor.installations}"
+                   descriptors="${descriptor.getApplicableDescriptors()}"
+                   addCaption="${%Add Git}" hasHeader="true"
+                   deleteCaption="${%Delete Git}"/>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
<img width="342" alt="image" src="https://user-images.githubusercontent.com/43062514/224579132-fec2bec2-1d76-4458-b17e-c5a69025219b.png">

* Removes the entry wrapper so the title isn't repeated, relates to https://github.com/jenkinsci/jenkins/pull/7716

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

Also replaces a reference to the deprecated method `getApplicableDesccriptors` (note the spelling error in `Desccriptors`) with the standard method `getApplicableDescriptors`