### PR TITLE
Simplify dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,55 +1,11 @@
 # Per https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - dependencies
-  ignore:
-  - dependency-name: io.jenkins:configuration-as-code
-    versions:
-    - ">= 1.37.a, < 1.38"
-  - dependency-name: io.jenkins:configuration-as-code
-    versions:
-    - ">= 1.38.a, < 1.39"
-  - dependency-name: io.jenkins:configuration-as-code
-    versions:
-    - ">= 1.39.a, < 1.40"
-  - dependency-name: io.jenkins:configuration-as-code
-    versions:
-    - ">= 1.40.a, < 1.41"
-  - dependency-name: io.jenkins:configuration-as-code
-    versions:
-    - ">= 1.41.a, < 1.42"
-  - dependency-name: io.jenkins.configuration-as-code:test-harness
-    versions:
-    - ">= 1.37.a, < 1.38"
-  - dependency-name: io.jenkins.configuration-as-code:test-harness
-    versions:
-    - ">= 1.38.a, < 1.39"
-  - dependency-name: io.jenkins.configuration-as-code:test-harness
-    versions:
-    - ">= 1.39.a, < 1.40"
-  - dependency-name: io.jenkins.configuration-as-code:test-harness
-    versions:
-    - ">= 1.40.a, < 1.41"
-  - dependency-name: io.jenkins.configuration-as-code:test-harness
-    versions:
-    - ">= 1.41.a, < 1.42"
-  - dependency-name: org.jenkins-ci.plugins:trilead-api
-    versions:
-    - ">= 1.0.6.a, < 1.0.7"
-  - dependency-name: com.github.ben-manes.caffeine:caffeine
-    # caffeine 3.0.0 and later requires JDK 11
-    versions:
-    - ">= 3.0.0"
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: monthly
+  - package-ecosystem: "maven"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Simplify dependabot configuration

Exclusions are no longer needed because versions of the excluded items are now managed by the plugin bill of materials.

Open pull request limit is not needed because pull requests are merged or closed promptly.

Target branch is not needed because the default matches this repository.

Reviewers is not needed because I'm already reviewing them regularly without being assigned as a reviewer.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
