### PR TITLE
Activate Spotless via Maven property rather than file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.60</version>
+    <version>4.61</version>
     <relativePath />
   </parent>
 
@@ -66,6 +66,7 @@
     <jgit.version>6.5.0.202303070854-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Medium</spotbugs.threshold>
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Many thanks for adopting the standard Spotless configuration, which has enabled me to streamline its activation in plugin parent POM 4.61. It is now possible to delete `.mvn_exec_spotless` and add `<spotless.check.skip>false</spotless.check.skip>` instead, which I think makes for a more readable configuration.