### PR TITLE
Add host key logging

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifier.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Base64;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -82,7 +83,10 @@ public class AcceptFirstConnectionVerifier extends HostKeyVerifierFactory {
             }
 
             if (!isValid) {
-                LOGGER.log(Level.WARNING, "Host key {0} was not accepted.", hostnamePort);
+                LOGGER.log(
+                        Level.FINER,
+                        "Host key for {0} was not accepted on accept first verifier known hosts file {1}",
+                        new Object[] {hostnamePort, path.toString()});
                 listener.getLogger().printf("Host key for host %s was not accepted.%n", hostnamePort);
             }
 
@@ -93,6 +97,15 @@ public class AcceptFirstConnectionVerifier extends HostKeyVerifierFactory {
                 File knownHostsFile, String hostnamePort, String serverHostKeyAlgorithm, byte[] serverHostKey)
                 throws IOException {
             listener.getLogger().println("Adding " + hostnamePort + " to " + knownHostsFile.toPath());
+            LOGGER.log(
+                    Level.FINEST,
+                    "Adding {0} to known hosts {1} in accept first verifier with host key {2} {3}",
+                    new Object[] {
+                        hostnamePort,
+                        knownHostsFile.toPath().toString(),
+                        serverHostKeyAlgorithm,
+                        Base64.getEncoder().encodeToString(serverHostKey)
+                    });
             KnownHosts.addHostkeyToFile(
                     knownHostsFile,
                     new String[] {KnownHosts.createHashedHostname(hostnamePort)},

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifier.java
@@ -7,6 +7,7 @@ import hudson.model.TaskListener;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Base64;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -20,6 +21,10 @@ public class KnownHostsFileVerifier extends HostKeyVerifierFactory {
             listener.getLogger().println("Verifying host key using known hosts file");
             if (Files.notExists(new File(SshHostKeyVerificationStrategy.KNOWN_HOSTS_DEFAULT).toPath())) {
                 logHint(listener);
+            } else {
+                LOGGER.log(Level.FINEST, "Verifying host key using known hosts file {0}", new Object[] {
+                    SshHostKeyVerificationStrategy.KNOWN_HOSTS_DEFAULT
+                });
             }
             return "-o StrictHostKeyChecking=yes";
         };
@@ -63,6 +68,13 @@ public class KnownHostsFileVerifier extends HostKeyVerifierFactory {
                     .printf(
                             "Verifying host key for %s using %s %n",
                             hostname, getKnownHostsFile().toPath());
+            LOGGER.log(Level.FINEST, "Verifying {0}:{1} in known hosts file {2} with host key {3} {4}", new Object[] {
+                hostname,
+                port,
+                SshHostKeyVerificationStrategy.KNOWN_HOSTS_DEFAULT,
+                serverHostKeyAlgorithm,
+                Base64.getEncoder().encodeToString(serverHostKey)
+            });
             return verifyServerHostKey(
                     listener, getKnownHosts(), hostname, port, serverHostKeyAlgorithm, serverHostKey);
         }
@@ -76,5 +88,9 @@ public class KnownHostsFileVerifier extends HostKeyVerifierFactory {
                                 + " but your known_hosts file does not exist, please go to "
                                 + "'Manage Jenkins' -> 'Configure Global Security' -> 'Git Host Key Verification Configuration' "
                                 + "and configure host key verification."));
+        LOGGER.log(
+                Level.FINEST,
+                "Known hosts file {0} not found, but verifying host keys with known hosts file",
+                new Object[] {SshHostKeyVerificationStrategy.KNOWN_HOSTS_DEFAULT});
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifier.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Base64;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -25,6 +26,10 @@ public class ManuallyProvidedKeyVerifier extends HostKeyVerifierFactory {
         return tempKnownHosts -> {
             Files.write(tempKnownHosts, (approvedHostKeys + System.lineSeparator()).getBytes(StandardCharsets.UTF_8));
             listener.getLogger().println("Verifying host key using manually-configured host key entries");
+            LOGGER.log(
+                    Level.FINEST,
+                    "Verifying manually-configured host keys entry in {0} with host keys {1}",
+                    new Object[] {tempKnownHosts.toAbsolutePath(), approvedHostKeys});
             String userKnownHostsFileFlag;
             if (File.pathSeparatorChar
                     == ';') { // check whether on Windows or not without sending Functions over remoting
@@ -71,6 +76,9 @@ public class ManuallyProvidedKeyVerifier extends HostKeyVerifierFactory {
                 String hostname, int port, String serverHostKeyAlgorithm, byte[] serverHostKey) throws Exception {
             listener.getLogger()
                     .printf("Verifying host key for %s using manually-configured host key entries %n", hostname);
+            LOGGER.log(Level.FINEST, "Verifying host {0}:{1} with manually-configured host key {2} {3}", new Object[] {
+                hostname, port, serverHostKeyAlgorithm, Base64.getEncoder().encodeToString(serverHostKey)
+            });
             return verifyServerHostKey(
                     listener, getKnownHosts(), hostname, port, serverHostKeyAlgorithm, serverHostKey);
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifier.java
@@ -3,8 +3,13 @@ package org.jenkinsci.plugins.gitclient.verifier;
 import com.trilead.ssh2.Connection;
 import com.trilead.ssh2.KnownHosts;
 import hudson.model.TaskListener;
+import java.util.Base64;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class NoHostKeyVerifier extends HostKeyVerifierFactory {
+
+    private static final Logger LOGGER = Logger.getLogger(NoHostKeyVerifier.class.getName());
 
     @Override
     public AbstractCliGitHostKeyVerifier forCliGit(TaskListener listener) {
@@ -23,6 +28,15 @@ public class NoHostKeyVerifier extends HostKeyVerifierFactory {
             @Override
             public boolean verifyServerHostKey(
                     String hostname, int port, String serverHostKeyAlgorithm, byte[] serverHostKey) {
+                LOGGER.log(
+                        Level.FINEST,
+                        "No host key verifier, host {0}:{1} not verified with host key {2} {3}",
+                        new Object[] {
+                            hostname,
+                            port,
+                            serverHostKeyAlgorithm,
+                            Base64.getEncoder().encodeToString(serverHostKey)
+                        });
                 return true;
             }
         };


### PR DESCRIPTION
## Add more host key verfication logging

Bitbucket addition of an ED-25519 host key lead me to find the existing log files insufficient to confirm that the host key was being used as expected.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Maintenance
