### PR TITLE
Remove unnecessary argLine property from pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
     <revision>4.2.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.version>2.361.4</jenkins.version>
     <jgit.version>6.5.0.202303070854-r</jgit.version>


### PR DESCRIPTION
## Remove unnecessary argLine property from pom file

Simplify the pom file by removing the unnecessary argLine property

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Maintenance reduction
