### PR TITLE
Forward compatibility with Guava 32.0.0

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/cgit/GitCommandsExecutorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/cgit/GitCommandsExecutorTest.java
@@ -5,8 +5,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.theInstance;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -196,15 +196,7 @@ public class GitCommandsExecutorTest {
     public void commandWasInterrupted() throws Exception {
         Exception commandException = new InterruptedException("some interrupt");
         List<Callable<String>> commands = Collections.singletonList(erroneousCommand(commandException));
-
-        try {
-            new GitCommandsExecutor(threads, listener).invokeAll(commands);
-            fail("Expected an exception but none was thrown");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(InterruptedException.class));
-            assertThat(e.getMessage(), is(nullValue()));
-            assertThat(e.getCause(), is(theInstance(commandException)));
-        }
+        assertThrows(InterruptedException.class, () -> new GitCommandsExecutor(threads, listener).invokeAll(commands));
     }
 
     @Test


### PR DESCRIPTION
Guava 32.0.0 from https://github.com/jenkinsci/jenkins/pull/8064 turns up the following new PCT failure:

```
java.lang.AssertionError: 

Expected: is sameInstance(<java.lang.InterruptedException: some interrupt>)
     but: was null
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at org.jenkinsci.plugins.gitclient.cgit.GitCommandsExecutorTest.commandWasInterrupted(GitCommandsExecutorTest.java:209)
```

likely due to google/guava@8f0350a21a713e2367cbcb526aa7bc5bf381fcb9. There does not seem to be any issue in production code here; rather, the test is overly fussy about what kind of `InterruptedException` it is getting. Loosening up the test allows it to work in both the old and new versions of Guava. This will need to be merged and released for BOM for tomorrow's weekly.