### PR TITLE
Name JenkinsRule variable consistently

### DIFF
--- a/src/test/java/hudson/plugins/git/GitToolResolverTest.java
+++ b/src/test/java/hudson/plugins/git/GitToolResolverTest.java
@@ -20,7 +20,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class GitToolResolverTest {
 
     @Rule
-    public JenkinsRule j = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     private GitTool gitTool;
 
@@ -34,7 +34,7 @@ public class GitToolResolverTest {
     public void shouldResolveToolsOnMaster() throws Exception {
         // Jenkins 2.307+ uses "built-in" for the label on the controller node
         // Before 2.307, used the deprecated term "master"
-        final String label = j.jenkins.getSelfLabel().getName();
+        final String label = r.jenkins.getSelfLabel().getName();
         final String command = "echo Hello";
         final String toolHome = "TOOL_HOME";
         AbstractCommandInstaller installer = isWindows()
@@ -47,7 +47,7 @@ public class GitToolResolverTest {
         t.getDescriptor().setInstallations(t);
 
         GitTool defaultTool = GitTool.getDefaultInstallation();
-        GitTool resolved = (GitTool) defaultTool.translate(j.jenkins, new EnvVars(), TaskListener.NULL);
+        GitTool resolved = (GitTool) defaultTool.translate(r.jenkins, new EnvVars(), TaskListener.NULL);
         assertThat(resolved.getGitExe(), containsString(toolHome));
     }
 

--- a/src/test/java/hudson/plugins/git/GitToolTest.java
+++ b/src/test/java/hudson/plugins/git/GitToolTest.java
@@ -24,7 +24,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class GitToolTest {
 
     @ClassRule
-    public static JenkinsRule j = new JenkinsRule();
+    public static JenkinsRule r = new JenkinsRule();
 
     private GitTool gitTool;
 
@@ -41,7 +41,7 @@ public class GitToolTest {
 
     @Test
     public void testForNode() throws Exception {
-        DumbSlave agent = j.createSlave();
+        DumbSlave agent = r.createSlave();
         agent.setMode(Node.Mode.EXCLUSIVE);
         TaskListener log = StreamTaskListener.fromStdout();
         GitTool newTool = gitTool.forNode(agent, log);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -58,7 +58,7 @@ public class CredentialsTest {
 
     // Required for credentials use
     @ClassRule
-    public static final JenkinsRule j = new JenkinsRule();
+    public static final JenkinsRule r = new JenkinsRule();
 
     private final String gitImpl;
     private final String gitRepoURL;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitJenkinsRuleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitJenkinsRuleTest.java
@@ -15,7 +15,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class GitJenkinsRuleTest {
 
     @Rule
-    public JenkinsRule j = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     @Test
     public void testMockClient() throws IOException, InterruptedException {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorJenkinsRuleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitToolConfiguratorJenkinsRuleTest.java
@@ -52,7 +52,7 @@ public class GitToolConfiguratorJenkinsRuleTest {
     }
 
     @Rule
-    public JenkinsRule j = new JenkinsRule();
+    public JenkinsRule r = new JenkinsRule();
 
     @Test
     public void testDescribeGitToolEmptyProperties() throws Exception {


### PR DESCRIPTION
## Name the JenkinsRule variables consistently

A confusing naming convention was being used.  Use the same naming convention as the git plugin and the same naming convention that is used in many plugins.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Refactor for clarity
