### PR TITLE
Simplify loose objects test for CLI git 2.41

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientMaintenanceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientMaintenanceTest.java
@@ -272,10 +272,10 @@ public class GitClientMaintenanceTest {
         // Confirm loose-object pack file is present in the pack directory
         File looseObjectPackFilePath = new File(objectsPath.getAbsolutePath(), "pack");
         String[] looseObjectPackFile = looseObjectPackFilePath.list((dir1, name) -> name.startsWith("loose-"));
-        collector.checkThat(
-                "Missing expected loose objects in git dir, only found " + String.join(",", looseObjectPackFile),
-                looseObjectPackFile.length,
-                is(2)); // Contains loose-${hash}.pack and loose-${hash}.idx
+        // CLI git 2.41 adds a new ".rev" suffixed file that is ignored in these assertions
+        List<String> fileNames = Arrays.asList(looseObjectPackFile);
+        List<String> requiredSuffixes = Arrays.asList(".idx", ".pack");
+        requiredSuffixes.forEach(expected -> assertThat(fileNames, hasItem(endsWith(expected))));
 
         // Clean the loose objects present in the repo.
         isExecuted = gitClient.maintenance("loose-objects");


### PR DESCRIPTION
## Simplify loose objects test for CLI git 2.41

Command line git 2.41 adds a new file suffix when it writes a loose object.  The new file suffix is not relevant to the assertion in this test.  Simplify the assertion to check that there is at least one file with the '.idx' suffix and at least one file with the '.pack' suffix.  Other files are allowed and other suffixes are allowed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test
