### PR TITLE
Fix character set tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
   <properties>
     <revision>4.3.1</revision>
     <changelist>-SNAPSHOT</changelist>
+    <!-- Character set tests fail unless file.encoding is set -->
+    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.version>2.387.3</jenkins.version>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITest.java
@@ -485,10 +485,8 @@ public class GitAPITest {
          */
         final String fileName = "\uD835\uDD65-\u5c4f\u5e55\u622a\u56fe-\u0041\u030a-\u00c5-\u212b-fileName.xml";
         workspace.touch(testGitDir, fileName, "content " + fileName);
-        withSystemLocaleReporting(fileName, () -> {
-            testGitClient.add(fileName);
-            testGitClient.commit(fileName);
-        });
+        testGitClient.add(fileName);
+        testGitClient.commit(fileName);
 
         /* JENKINS-27910 reported that certain cyrillic file names
          * failed to delete if the encoding was not UTF-8.
@@ -496,17 +494,13 @@ public class GitAPITest {
         final String fileNameSwim =
                 "\u00d0\u00bf\u00d0\u00bb\u00d0\u00b0\u00d0\u00b2\u00d0\u00b0\u00d0\u00bd\u00d0\u00b8\u00d0\u00b5-swim.png";
         workspace.touch(testGitDir, fileNameSwim, "content " + fileNameSwim);
-        withSystemLocaleReporting(fileNameSwim, () -> {
-            testGitClient.add(fileNameSwim);
-            testGitClient.commit(fileNameSwim);
-        });
+        testGitClient.add(fileNameSwim);
+        testGitClient.commit(fileNameSwim);
 
         final String fileNameFace = "\u00d0\u00bb\u00d0\u00b8\u00d1\u2020\u00d0\u00be-face.png";
         workspace.touch(testGitDir, fileNameFace, "content " + fileNameFace);
-        withSystemLocaleReporting(fileNameFace, () -> {
-            testGitClient.add(fileNameFace);
-            testGitClient.commit(fileNameFace);
-        });
+        testGitClient.add(fileNameFace);
+        testGitClient.commit(fileNameFace);
 
         workspace.touch(testGitDir, ".gitignore", ".test");
         testGitClient.add(".gitignore");
@@ -1712,25 +1706,5 @@ public class GitAPITest {
      */
     private boolean isWindows() {
         return File.pathSeparatorChar == ';';
-    }
-
-    private void withSystemLocaleReporting(String fileName, TestedCode code) throws Exception {
-        try {
-            code.run();
-        } catch (GitException ge) {
-            // Exception message should contain the actual file name.
-            // It may just contain ? for characters that are not encoded correctly due to the system locale.
-            // If such a mangled file name is seen instead, throw a clear exception to indicate the root cause.
-            assertTrue(
-                    "System locale does not support filename '" + fileName + "'",
-                    ge.getMessage().contains("?"));
-            // Rethrow exception for all other issues.
-            throw ge;
-        }
-    }
-
-    @FunctionalInterface
-    interface TestedCode {
-        void run() throws Exception;
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientMaintenanceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientMaintenanceTest.java
@@ -275,7 +275,7 @@ public class GitClientMaintenanceTest {
         // CLI git 2.41 adds a new ".rev" suffixed file that is ignored in these assertions
         List<String> fileNames = Arrays.asList(looseObjectPackFile);
         List<String> requiredSuffixes = Arrays.asList(".idx", ".pack");
-        requiredSuffixes.forEach(expected -> assertThat(fileNames, hasItem(endsWith(expected))));
+        requiredSuffixes.forEach(expected -> collector.checkThat(fileNames, hasItem(endsWith(expected))));
 
         // Clean the loose objects present in the repo.
         isExecuted = gitClient.maintenance("loose-objects");


### PR DESCRIPTION
## Fix character set tests

- Use collector consistently in the maintenance test
- Set file encoding for tests
- Remove flawed character set assertion

## Checklist

Tests were broken when I removed the source file character set encoding argument, though the deleted assertions were incorrect long before that.

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Tests
