### PR TITLE
Use correct name for MinGit in documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -91,10 +91,10 @@ image::images/mingit-for-windows-as-a-tool.png[Configure MinGit for Windows to i
 
 * Configure a global git tool from "Manage Jenkins" >> "Tools" with `git` as the `Path to Git executable`
 * Set the label `windows` to limit the tool installer to agents with the `windows` label
-* Set the `Download URL for binary archive` as the URL of your locally downloaded copy of the link:https://github.com/git-for-windows/git/releases/[MinGit zip file]
+* Set the `Download URL for binary archive` as the URL of your **locally downloaded copy** of the link:https://github.com/git-for-windows/git/releases/[MinGit zip file]
 * Specify `mingw64\bin\git.exe` as the `Subdirectory of extracted archive`.
 
-Git for Windows Portable will be installed on each agent in `tools\git\mingw64`.
+MinGit will be installed on each agent in `tools\git\mingw64`.
 The path to the git executable will be `tools\git\mingw64\bin\git.exe`.
 
 [#windows-credentials-manager]


### PR DESCRIPTION
## Use correct name for MinGit in documentation

Portable git reference is from older documentation

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Documentation
