### PR TITLE
Use proxy.getSecretPassword(), not deprecated proxy.getPassword()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2168,7 +2168,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         if (StringUtils.isNotEmpty(proxy.getUserName())) {
                             userInfo = proxy.getUserName();
                             if (StringUtils.isNotEmpty(proxy.getPassword())) {
-                                userInfo += ":" + proxy.getPassword();
+                                userInfo += ":" + proxy.getSecretPassword();
                             }
                         }
                         try {


### PR DESCRIPTION
## Use proxy.getSecretPassword(), not deprecated proxy.getPassword()

Thanks to @StefanSpieker for the pointer to the [deprecated core API usage report](https://ci.jenkins.io/job/Reporting/job/deprecated-usage-in-plugins/) where it shows that `proxy.getPassword()` is the only deprecated core API used in the git client plugin.  Easy to fix.  

Not tested by automation.  Adding useful proxy configuration tests is beyond the scope of this pull request.

Tested interactively by temporarily adding a logging statement to report the value of `userInfo` after the assignment.  I defined a proxy in the "Advanced settings" of the plugin manager page, then attempted to clone a git repository over https.  The logging statement displayed the expected value in the userInfo string.  I removed the temporary logging statement.  

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Maintenance improvement (replace deprecated API use with non-deprecated API)
