### PR TITLE
Use gson-api plugin instead of bundling gson-api jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.401.x</artifactId>
-        <version>2612.v3d6a_2128c0ef</version>
+        <version>2641.v88e707466454</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -87,6 +87,11 @@
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <optional>true</optional>
+    </dependency>
+    <!-- Use gson api plugin rather than JGit LFS transitive dependency inclusion of gson -->
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>gson-api</artifactId>
     </dependency>
     <dependency>
       <!-- Use mina api common plugin rather than JGit transitive dependency inclusion of Apache Mina sshd common -->
@@ -147,6 +152,12 @@
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit.lfs</artifactId>
       <version>${jgit.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>


### PR DESCRIPTION
## Depend on gson-api plugin instead of bundling gson-api jar

Do not bundle the gson-api jar  file as a transitive dependency when there is already a gson-api Jenkins plugin available.

Added to bom so that the version number can be retrieved from the plugin bill of materials in a future BOM release:

* https://github.com/jenkinsci/bom/pull/2723

- [x] Remove version when bom is released
- [x] Rebase PR when #1078 merged

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
