### PR TITLE
Require Jenkins 2.401.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.401.3</jenkins.version>
     <jgit.version>6.8.0.202311291450-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -75,8 +75,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.401.x</artifactId>
+        <version>2612.v3d6a_2128c0ef</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.401.3 or newer

The gson-api plugin has been [added to the bom-2.401.x line](https://github.com/jenkinsci/bom/pull/2723). That will allow the plugin to stop bundling the transitive dependency on the gson-api jar file.  That reduces the size of the hpi file and avoids duplicating the gson-api file in multiple locations inside Jenkins.

@jonesbusy inspired this pull request with:

* https://github.com/jenkinsci/git-client-plugin/pull/1077

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
