### PR TITLE
Omit spotbugs CT_CONSTRUCTOR_THROWS visitor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,9 @@
     <jgit.version>6.8.0.202311291450-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
+    <!-- TODO: Remove when plugin pom includes this omitVisitors -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef</spotbugs.omitVisitors>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -5,15 +5,6 @@
     false positives.
   -->
   <Match>
-    <!-- Jenkins plugins generally not vulnerable to Finalizer attacks -->
-    <Bug pattern="CT_CONSTRUCTOR_THROW" />
-    <Or>
-      <Class name="hudson.plugins.git.GitAPI" />
-      <Class name="org.jenkinsci.plugins.gitclient.JGitAPIImpl$FileRepositoryImpl" />
-      <Class name="org.jenkinsci.plugins.gitclient.trilead.TrileadSession$ProcessImpl" />
-    </Or>
-  </Match>
-  <Match>
     <!-- These primitive attributes need to be public to preserve the API -->
     <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE" />
     <Class name="hudson.plugins.git.Tag" />


### PR DESCRIPTION
From https://github.com/jenkinsci/plugin-pom/pull/869#issuecomment-1860918407

> Discussion in spotbugs/spotbugs#2695
> https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions
> seems to relate to libraries used with SecurityManager which is dead
> and certainly does not apply to Jenkins; we do not expect untrusted code
> to be running inside the controller JVM, and it does not seem plausible
> that finalizer abuse would happen by accident.
