### PR TITLE
Fix Javadoc link to JGit user guide

### DIFF
--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -18,7 +18,7 @@ and the branch source plugins (GitHub branch source, Bitbucket branch source, Gi
 instead of the legacy IGitAPI.
 
 <p>The plugin isolates low-level git commands from the git-plugin, allowing alternate git implementations
-(like <a href="http://wiki.eclipse.org/JGit/User_Guide"  target="_blank">JGit</a>).</p>
+(like <a href="https://github.com/eclipse-jgit/jgit/wiki/User-Guide"  target="_blank">JGit</a>).</p>
 
 <p>For backwards compatibility, this plugin uses API classes from the hudson.plugins.git package.</p>
 


### PR DESCRIPTION
## Fix Javadoc link to JGit user guide

The JGit project has moved their wiki to GitHub.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Documentation
