### PR TITLE
[JENKINS-70303] Ignore leading and trailing spaces in refspecs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -267,7 +267,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public CheckoutCommand ref(String ref) {
-                this.ref = ref.trim();
+                this.ref = (ref != null) ? ref.trim() : ref;
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -267,7 +267,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public CheckoutCommand ref(String ref) {
-                this.ref = ref;
+                this.ref = ref.trim();
                 return this;
             }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -40,6 +40,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.Issue;
 
 @RunWith(Parameterized.class)
 public class GitClientCloneTest {
@@ -328,11 +329,16 @@ public class GitClientCloneTest {
                         }));
     }
 
+    private String randomSpace() {
+        return random.nextBoolean() ? " " : "";
+    }
+
     @Test
+    @Issue("JENKINS-70303") // spaces at start or end of refspec should be ignored
     public void test_clone_refspecs() throws Exception {
         List<RefSpec> refspecs = Arrays.asList(
-                new RefSpec("+refs/heads/master:refs/remotes/origin/master"),
-                new RefSpec("+refs/heads/1.4.x:refs/remotes/origin/1.4.x"));
+                new RefSpec(randomSpace() + "+refs/heads/master:refs/remotes/origin/master" + randomSpace()),
+                new RefSpec(randomSpace() + "+refs/heads/1.4.x:refs/remotes/origin/1.4.x" + randomSpace()));
         testGitClient
                 .clone_()
                 .url(workspace.localMirror())


### PR DESCRIPTION
## [JENKINS-70303](https://issues.jenkins.io/browse/JENKINS-70303) - ignore leading and trailing spaces in refspecs

I am using trim() method to remove the leading space characters.

Describe the big picture of your changes here to explain to the maintainers why this pull request should be accepted.
If it fixes a bug or resolves a feature request, include a link to the issue.
The Link to the issue: https://issues.jenkins.io/browse/JENKINS-70303

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
