### PR TITLE
[JENKINS-70303] Remove leading and trailing spaces from refspec

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -1,12 +1,15 @@
 package hudson.plugins.git;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
-import java.io.*;
-import java.util.List;
-import java.util.Set;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
@@ -113,9 +116,9 @@ public class GitAPI extends CliGitAPIImpl {
     @Override
     public void push(String remoteName, String refspec) throws GitException, InterruptedException {
         if (Git.USE_CLI) {
-            super.push(remoteName, refspec);
+            super.push(remoteName, refspec.trim());
         } else {
-            jgit.push(remoteName, refspec);
+            jgit.push(remoteName, refspec.trim());
         }
     }
 
@@ -368,10 +371,16 @@ public class GitAPI extends CliGitAPIImpl {
     @SuppressWarnings("deprecation")
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
         /* Intentionally using the deprecated method because the replacement method is not serializable. */
+        List<RefSpec> trimmedRefSpecs = new ArrayList<>();
+        for (RefSpec rs : refspecs) {
+            if (rs != null) {
+                trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
+            }
+        }
         if (Git.USE_CLI) {
-            super.fetch(url, refspecs);
+            super.fetch(url, trimmedRefSpecs);
         } else {
-            jgit.fetch(url, refspecs);
+            jgit.fetch(url, trimmedRefSpecs);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1,5 +1,28 @@
 package org.jenkinsci.plugins.gitclient;
 
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Launcher.LocalLauncher;
+import hudson.Proc;
+import hudson.Util;
+import hudson.console.HyperlinkNote;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
+import hudson.plugins.git.GitObject;
+import hudson.plugins.git.IGitAPI;
+import hudson.plugins.git.IndexEntry;
+import hudson.plugins.git.Revision;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.Secret;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
@@ -45,30 +68,6 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.EnvVars;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.Launcher.LocalLauncher;
-import hudson.Proc;
-import hudson.Util;
-import hudson.console.HyperlinkNote;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Branch;
-import hudson.plugins.git.GitException;
-import hudson.plugins.git.GitLockFailedException;
-import hudson.plugins.git.GitObject;
-import hudson.plugins.git.IGitAPI;
-import hudson.plugins.git.IndexEntry;
-import hudson.plugins.git.Revision;
-import hudson.util.ArgumentListBuilder;
-import hudson.util.Secret;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -871,7 +870,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 }
 
                 if (refspecs == null) {
-                    refspecs = Collections.singletonList(new RefSpec("+refs/heads/*:refs/remotes/" + origin + "/*".trim()));
+                    refspecs = Collections.singletonList(
+                            new RefSpec("+refs/heads/*:refs/remotes/" + origin + "/*".trim()));
                 }
                 fetch_().from(urIish, refspecs)
                         .shallow(shallow)

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1,5 +1,28 @@
 package org.jenkinsci.plugins.gitclient;
 
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Launcher.LocalLauncher;
+import hudson.Proc;
+import hudson.Util;
+import hudson.console.HyperlinkNote;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
+import hudson.plugins.git.GitObject;
+import hudson.plugins.git.IGitAPI;
+import hudson.plugins.git.IndexEntry;
+import hudson.plugins.git.Revision;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.Secret;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
@@ -45,30 +68,6 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.EnvVars;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.Launcher.LocalLauncher;
-import hudson.Proc;
-import hudson.Util;
-import hudson.console.HyperlinkNote;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Branch;
-import hudson.plugins.git.GitException;
-import hudson.plugins.git.GitLockFailedException;
-import hudson.plugins.git.GitObject;
-import hudson.plugins.git.IGitAPI;
-import hudson.plugins.git.IndexEntry;
-import hudson.plugins.git.Revision;
-import hudson.util.ArgumentListBuilder;
-import hudson.util.Secret;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -800,7 +799,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @Override
             public CloneCommand refspecs(List<RefSpec> refspecs) {
                 List<RefSpec> refSpecsList = new ArrayList<RefSpec>();
-                for (RefSpec ref: refspecs) {
+                for (RefSpec ref : refspecs) {
                     refSpecsList.add(new RefSpec(ref.toString().trim()));
                 }
                 this.refspecs = refSpecsList;
@@ -875,7 +874,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 }
 
                 if (refspecs == null) {
-                    refspecs = Collections.singletonList(new RefSpec("+refs/heads/*:refs/remotes/" + origin + "/*".trim()));
+                    refspecs = Collections.singletonList(new RefSpec("+refs/heads/*:refs/remotes/" + origin + "/*"));
                 }
                 fetch_().from(urIish, refspecs)
                         .shallow(shallow)
@@ -885,7 +884,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         .execute();
                 setRemoteUrl(origin, url);
                 for (RefSpec refSpec : refspecs) {
-                    launchCommand("config", "--add", "remote." + origin + ".fetch", refSpec.toString().trim());
+                    launchCommand("config", "--add", "remote." + origin + ".fetch", refSpec.toString());
                 }
             }
         };

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -871,7 +871,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (refspecs == null) {
                     refspecs = Collections.singletonList(
-                            new RefSpec("+refs/heads/*:refs/remotes/" + origin + "/*".trim()));
+                            new RefSpec("+refs/heads/*:refs/remotes/" + origin.trim() + "/*"));
                 }
                 fetch_().from(urIish, refspecs)
                         .shallow(shallow)

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1,29 +1,15 @@
 package org.jenkinsci.plugins.gitclient;
 
-import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.EnvVars;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.Launcher.LocalLauncher;
-import hudson.Proc;
-import hudson.Util;
-import hudson.console.HyperlinkNote;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Branch;
-import hudson.plugins.git.GitException;
-import hudson.plugins.git.GitLockFailedException;
-import hudson.plugins.git.GitObject;
-import hudson.plugins.git.IGitAPI;
-import hudson.plugins.git.IndexEntry;
-import hudson.plugins.git.Revision;
-import hudson.util.ArgumentListBuilder;
-import hudson.util.Secret;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -59,6 +45,30 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Launcher.LocalLauncher;
+import hudson.Proc;
+import hudson.Util;
+import hudson.console.HyperlinkNote;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
+import hudson.plugins.git.GitObject;
+import hudson.plugins.git.IGitAPI;
+import hudson.plugins.git.IndexEntry;
+import hudson.plugins.git.Revision;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.Secret;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -612,7 +622,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 if (refspecs != null) {
                     for (RefSpec rs : refspecs) {
                         if (rs != null) {
-                            args.add(rs.toString());
+                            args.add(rs.toString().trim());
                         }
                     }
                 }
@@ -667,7 +677,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         if (refspec != null && refspec.length > 0) {
             for (RefSpec rs : refspec) {
                 if (rs != null) {
-                    args.add(rs.toString());
+                    args.add(rs.toString().trim());
                 }
             }
         }
@@ -861,7 +871,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 }
 
                 if (refspecs == null) {
-                    refspecs = Collections.singletonList(new RefSpec("+refs/heads/*:refs/remotes/" + origin + "/*"));
+                    refspecs = Collections.singletonList(new RefSpec("+refs/heads/*:refs/remotes/" + origin + "/*".trim()));
                 }
                 fetch_().from(urIish, refspecs)
                         .shallow(shallow)

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -535,8 +535,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public FetchCommand from(URIish remote, List<RefSpec> refspecs) {
                 this.url = remote;
                 List<RefSpec> trimmedRefSpecs = new ArrayList<>();
-                for (RefSpec rs : refspecs) {
-                    if (rs != null) {
+                if (refspecs != null) {
+                    for (RefSpec rs : refspecs) {
                         trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
                     }
                 }
@@ -627,9 +627,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (refspecs != null) {
                     for (RefSpec rs : refspecs) {
-                        if (rs != null) {
-                            args.add(rs.toString().trim());
-                        }
+                        args.add(rs.toString().trim());
                     }
                 }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -535,7 +535,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public FetchCommand from(URIish remote, List<RefSpec> refspecs) {
                 this.url = remote;
                 List<RefSpec> trimmedRefSpecs = new ArrayList<>();
-                if (!refspecs.isEmpty() && refspecs != null) {
+                if (refspecs != null && !refspecs.isEmpty()) {
                     for (RefSpec rs : refspecs) {
                         trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
                     }
@@ -625,7 +625,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     addCheckedRemoteUrl(args, url.toString());
                 }
 
-                if (!refspecs.isEmpty() && refspecs != null) {
+                if (refspecs != null && !refspecs.isEmpty()) {
                     for (RefSpec rs : refspecs) {
                         args.add(rs.toString().trim());
                     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -535,7 +535,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public FetchCommand from(URIish remote, List<RefSpec> refspecs) {
                 this.url = remote;
                 List<RefSpec> trimmedRefSpecs = new ArrayList<>();
-                if (refspecs != null) {
+                if (!refspecs.isEmpty() && refspecs != null) {
                     for (RefSpec rs : refspecs) {
                         trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
                     }
@@ -625,7 +625,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     addCheckedRemoteUrl(args, url.toString());
                 }
 
-                if (refspecs != null) {
+                if (!refspecs.isEmpty() && refspecs != null) {
                     for (RefSpec rs : refspecs) {
                         args.add(rs.toString().trim());
                     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -798,7 +798,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public CloneCommand refspecs(List<RefSpec> refspecs) {
-                List<RefSpec> refSpecsList = new ArrayList<RefSpec>();
+                List<RefSpec> refSpecsList = new ArrayList<>();
                 for (RefSpec ref : refspecs) {
                     refSpecsList.add(new RefSpec(ref.toString().trim()));
                 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1,28 +1,5 @@
 package org.jenkinsci.plugins.gitclient;
 
-import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.EnvVars;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.Launcher.LocalLauncher;
-import hudson.Proc;
-import hudson.Util;
-import hudson.console.HyperlinkNote;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Branch;
-import hudson.plugins.git.GitException;
-import hudson.plugins.git.GitLockFailedException;
-import hudson.plugins.git.GitObject;
-import hudson.plugins.git.IGitAPI;
-import hudson.plugins.git.IndexEntry;
-import hudson.plugins.git.Revision;
-import hudson.util.ArgumentListBuilder;
-import hudson.util.Secret;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
@@ -68,6 +45,30 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Launcher.LocalLauncher;
+import hudson.Proc;
+import hudson.Util;
+import hudson.console.HyperlinkNote;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
+import hudson.plugins.git.GitObject;
+import hudson.plugins.git.IGitAPI;
+import hudson.plugins.git.IndexEntry;
+import hudson.plugins.git.Revision;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.Secret;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -798,7 +799,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public CloneCommand refspecs(List<RefSpec> refspecs) {
-                this.refspecs = new ArrayList<>(refspecs);
+                List<RefSpec> refSpecsList = new ArrayList<RefSpec>();
+                for (RefSpec ref: refspecs) {
+                    refSpecsList.add(new RefSpec(ref.toString().trim()));
+                }
+                this.refspecs = refSpecsList;
                 return this;
             }
 
@@ -870,8 +875,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 }
 
                 if (refspecs == null) {
-                    refspecs = Collections.singletonList(
-                            new RefSpec("+refs/heads/*:refs/remotes/" + origin.trim() + "/*"));
+                    refspecs = Collections.singletonList(new RefSpec("+refs/heads/*:refs/remotes/" + origin + "/*".trim()));
                 }
                 fetch_().from(urIish, refspecs)
                         .shallow(shallow)
@@ -881,7 +885,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         .execute();
                 setRemoteUrl(origin, url);
                 for (RefSpec refSpec : refspecs) {
-                    launchCommand("config", "--add", "remote." + origin + ".fetch", refSpec.toString());
+                    launchCommand("config", "--add", "remote." + origin + ".fetch", refSpec.toString().trim());
                 }
             }
         };

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1,28 +1,5 @@
 package org.jenkinsci.plugins.gitclient;
 
-import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.EnvVars;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.Launcher.LocalLauncher;
-import hudson.Proc;
-import hudson.Util;
-import hudson.console.HyperlinkNote;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Branch;
-import hudson.plugins.git.GitException;
-import hudson.plugins.git.GitLockFailedException;
-import hudson.plugins.git.GitObject;
-import hudson.plugins.git.IGitAPI;
-import hudson.plugins.git.IndexEntry;
-import hudson.plugins.git.Revision;
-import hudson.util.ArgumentListBuilder;
-import hudson.util.Secret;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
@@ -68,6 +45,30 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Launcher.LocalLauncher;
+import hudson.Proc;
+import hudson.Util;
+import hudson.console.HyperlinkNote;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
+import hudson.plugins.git.GitObject;
+import hudson.plugins.git.IGitAPI;
+import hudson.plugins.git.IndexEntry;
+import hudson.plugins.git.Revision;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.Secret;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -533,7 +534,13 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @Override
             public FetchCommand from(URIish remote, List<RefSpec> refspecs) {
                 this.url = remote;
-                this.refspecs = refspecs;
+                List<RefSpec> trimmedRefSpecs = new ArrayList<>();
+                for (RefSpec rs : refspecs) {
+                    if (rs != null) {
+                        trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
+                    }
+                }
+                this.refspecs = trimmedRefSpecs;
                 return this;
             }
 
@@ -2894,7 +2901,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public PushCommand ref(String refspec) {
-                this.refspec = refspec;
+                this.refspec = refspec.trim();
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -676,7 +676,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     Git git = git(repo);
 
                     List<RefSpec> allRefSpecs = new ArrayList<>();
-                    if (refspecs != null) {
+                    if (!refspecs.isEmpty() && refspecs != null) {
                         for (RefSpec rs : refspecs) {
                             allRefSpecs.add(rs);
                         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -14,18 +14,6 @@ import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.UP_TO_DATE;
 import static org.jenkinsci.plugins.gitclient.CliGitAPIImpl.TIMEOUT;
 import static org.jenkinsci.plugins.gitclient.CliGitAPIImpl.TIMEOUT_LOG_PREFIX;
 
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.FilePath;
-import hudson.Util;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Branch;
-import hudson.plugins.git.GitException;
-import hudson.plugins.git.GitLockFailedException;
-import hudson.plugins.git.GitObject;
-import hudson.plugins.git.IndexEntry;
-import hudson.plugins.git.Revision;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -49,6 +37,19 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
+import hudson.plugins.git.GitObject;
+import hudson.plugins.git.IndexEntry;
+import hudson.plugins.git.Revision;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.time.FastDateFormat;
 import org.eclipse.jgit.api.AddNoteCommand;
@@ -624,7 +625,13 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @Override
             public org.jenkinsci.plugins.gitclient.FetchCommand from(URIish remote, List<RefSpec> refspecs) {
                 this.url = remote;
-                this.refspecs = refspecs;
+                List<RefSpec> trimmedRefSpecs = new ArrayList<RefSpec>();
+                for (RefSpec rs : refspecs) {
+                    if (rs != null) {
+                        trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
+                    }
+                }
+                this.refspecs = trimmedRefSpecs;
                 return this;
             }
 
@@ -1996,7 +2003,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public PushCommand ref(String refspec) {
-                this.refspec = refspec;
+                this.refspec = refspec.trim();
                 return this;
             }
 
@@ -2027,8 +2034,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public void execute() throws GitException {
                 try (Repository repo = getRepository()) {
                     RefSpec ref =
-                            (refspec != null) ? new RefSpec(fixRefSpec(refspec, repo)) : Transport.REFSPEC_PUSH_ALL;
-                    listener.getLogger().println("RefSpec is \"" + ref + "\".");
+                            (refspec != null) ? new RefSpec(fixRefSpec(refspec.trim(), repo)) : Transport.REFSPEC_PUSH_ALL;
+                    listener.getLogger().println("RefSpec is \"" + ref.toString().trim() + "\".");
                     Git g = git(repo);
                     Config config = g.getRepository().getConfig();
                     if (remote == null) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -14,6 +14,18 @@ import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.UP_TO_DATE;
 import static org.jenkinsci.plugins.gitclient.CliGitAPIImpl.TIMEOUT;
 import static org.jenkinsci.plugins.gitclient.CliGitAPIImpl.TIMEOUT_LOG_PREFIX;
 
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
+import hudson.plugins.git.GitObject;
+import hudson.plugins.git.IndexEntry;
+import hudson.plugins.git.Revision;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -37,19 +49,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.FilePath;
-import hudson.Util;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Branch;
-import hudson.plugins.git.GitException;
-import hudson.plugins.git.GitLockFailedException;
-import hudson.plugins.git.GitObject;
-import hudson.plugins.git.IndexEntry;
-import hudson.plugins.git.Revision;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.time.FastDateFormat;
 import org.eclipse.jgit.api.AddNoteCommand;
@@ -1433,7 +1432,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public CloneCommand refspecs(List<RefSpec> refspecs) {
-                this.refspecs = new ArrayList<>(refspecs);
+                List<RefSpec> refSpecsList = new ArrayList<RefSpec>();
+                for (RefSpec ref : refspecs) {
+                    refSpecsList.add(new RefSpec(ref.toString().trim()));
+                }
+                this.refspecs = refSpecsList;
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1554,7 +1554,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     FetchCommand fetch = new Git(repository)
                             .fetch()
                             .setProgressMonitor(new JGitProgressMonitor(listener))
-                            .setRemote(url.trim())
+                            .setRemote(url)
                             .setCredentialsProvider(getProvider())
                             .setTagOpt(tags ? TagOpt.FETCH_TAGS : TagOpt.NO_TAGS)
                             .setRefSpecs(refspecs);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -626,8 +626,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public org.jenkinsci.plugins.gitclient.FetchCommand from(URIish remote, List<RefSpec> refspecs) {
                 this.url = remote;
                 List<RefSpec> trimmedRefSpecs = new ArrayList<>();
-                for (RefSpec rs : refspecs) {
-                    if (rs != null) {
+                if (!refspecs.isEmpty() && refspecs != null) {
+                    for (RefSpec rs : refspecs) {
                         trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
                     }
                 }
@@ -678,9 +678,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     List<RefSpec> allRefSpecs = new ArrayList<>();
                     if (refspecs != null) {
                         for (RefSpec rs : refspecs) {
-                            if (rs != null) {
-                                allRefSpecs.add(rs);
-                            }
+                            allRefSpecs.add(rs);
                         }
                     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -14,18 +14,6 @@ import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.UP_TO_DATE;
 import static org.jenkinsci.plugins.gitclient.CliGitAPIImpl.TIMEOUT;
 import static org.jenkinsci.plugins.gitclient.CliGitAPIImpl.TIMEOUT_LOG_PREFIX;
 
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.FilePath;
-import hudson.Util;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Branch;
-import hudson.plugins.git.GitException;
-import hudson.plugins.git.GitLockFailedException;
-import hudson.plugins.git.GitObject;
-import hudson.plugins.git.IndexEntry;
-import hudson.plugins.git.Revision;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -49,6 +37,19 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.GitLockFailedException;
+import hudson.plugins.git.GitObject;
+import hudson.plugins.git.IndexEntry;
+import hudson.plugins.git.Revision;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.time.FastDateFormat;
 import org.eclipse.jgit.api.AddNoteCommand;
@@ -1550,7 +1551,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     FetchCommand fetch = new Git(repository)
                             .fetch()
                             .setProgressMonitor(new JGitProgressMonitor(listener))
-                            .setRemote(url)
+                            .setRemote(url.trim())
                             .setCredentialsProvider(getProvider())
                             .setTagOpt(tags ? TagOpt.FETCH_TAGS : TagOpt.NO_TAGS)
                             .setRefSpecs(refspecs);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -625,7 +625,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @Override
             public org.jenkinsci.plugins.gitclient.FetchCommand from(URIish remote, List<RefSpec> refspecs) {
                 this.url = remote;
-                List<RefSpec> trimmedRefSpecs = new ArrayList<RefSpec>();
+                List<RefSpec> trimmedRefSpecs = new ArrayList<>();
                 for (RefSpec rs : refspecs) {
                     if (rs != null) {
                         trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
@@ -1439,7 +1439,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public CloneCommand refspecs(List<RefSpec> refspecs) {
-                List<RefSpec> refSpecsList = new ArrayList<RefSpec>();
+                List<RefSpec> refSpecsList = new ArrayList<>();
                 for (RefSpec ref : refspecs) {
                     refSpecsList.add(new RefSpec(ref.toString().trim()));
                 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -626,7 +626,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             public org.jenkinsci.plugins.gitclient.FetchCommand from(URIish remote, List<RefSpec> refspecs) {
                 this.url = remote;
                 List<RefSpec> trimmedRefSpecs = new ArrayList<>();
-                if (!refspecs.isEmpty() && refspecs != null) {
+                if (refspecs != null && !refspecs.isEmpty()) {
                     for (RefSpec rs : refspecs) {
                         trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
                     }
@@ -676,7 +676,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     Git git = git(repo);
 
                     List<RefSpec> allRefSpecs = new ArrayList<>();
-                    if (!refspecs.isEmpty() && refspecs != null) {
+                    if (refspecs != null && !refspecs.isEmpty()) {
                         for (RefSpec rs : refspecs) {
                             allRefSpecs.add(rs);
                         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImpl.java
@@ -3,6 +3,13 @@ package org.jenkinsci.plugins.gitclient;
 import static java.util.Arrays.copyOfRange;
 import static org.apache.commons.lang.StringUtils.join;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.IGitAPI;
@@ -10,12 +17,6 @@ import hudson.plugins.git.IndexEntry;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.Tag;
 import hudson.remoting.Channel;
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
@@ -107,7 +108,7 @@ abstract class LegacyCompatibleGitAPIImpl extends AbstractGitAPIImpl implements 
     @Override
     @Deprecated
     public void fetch(String repository, String refspec) throws GitException, InterruptedException {
-        fetch(repository, new RefSpec(refspec));
+        fetch(repository, new RefSpec(refspec.trim()));
     }
 
     /** {@inheritDoc} */
@@ -146,7 +147,7 @@ abstract class LegacyCompatibleGitAPIImpl extends AbstractGitAPIImpl implements 
     @Override
     @Deprecated
     public void push(URIish url, String refspec) throws GitException, InterruptedException {
-        push().ref(refspec).to(url).execute();
+        push().ref(refspec.trim()).to(url).execute();
     }
 
     /** {@inheritDoc} */
@@ -159,7 +160,7 @@ abstract class LegacyCompatibleGitAPIImpl extends AbstractGitAPIImpl implements 
         }
 
         try {
-            push(new URIish(url), refspec);
+            push(new URIish(url), refspec.trim());
         } catch (URISyntaxException e) {
             throw new GitException("bad repository URL", e);
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -482,7 +482,7 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
         /* Intentionally using the deprecated method because the replacement method is not serializable. */
         List<RefSpec> trimmedRefSpecs = new ArrayList<>();
-        if (!refspecs.isEmpty() && refspecs != null) {
+        if (refspecs != null && !refspecs.isEmpty()) {
             for (RefSpec rs : refspecs) {
                 trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -482,7 +482,7 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
         /* Intentionally using the deprecated method because the replacement method is not serializable. */
         List<RefSpec> trimmedRefSpecs = new ArrayList<>();
-        if (refspecs != null) {
+        if (!refspecs.isEmpty() && refspecs != null) {
             for (RefSpec rs : refspecs) {
                 trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -482,8 +482,8 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
         /* Intentionally using the deprecated method because the replacement method is not serializable. */
         List<RefSpec> trimmedRefSpecs = new ArrayList<>();
-        for (RefSpec rs : refspecs) {
-            if (rs != null) {
+        if (refspecs != null) {
+            for (RefSpec rs : refspecs) {
                 trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -1,5 +1,18 @@
 package org.jenkinsci.plugins.gitclient;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.io.Writer;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
@@ -16,18 +29,6 @@ import hudson.plugins.git.Tag;
 import hudson.remoting.Channel;
 import hudson.remoting.RemoteOutputStream;
 import hudson.remoting.RemoteWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Serializable;
-import java.io.Writer;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
@@ -480,31 +481,43 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
     @Override
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
         /* Intentionally using the deprecated method because the replacement method is not serializable. */
-        proxy.fetch(url, refspecs);
+        List<RefSpec> trimmedRefSpecs = new ArrayList<>();
+        for (RefSpec rs : refspecs) {
+            if (rs != null) {
+                trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
+            }
+        }
+        proxy.fetch(url, trimmedRefSpecs);
     }
 
     /** {@inheritDoc} */
     @Override
     public void fetch(String remoteName, RefSpec... refspec) throws GitException, InterruptedException {
-        proxy.fetch(remoteName, refspec);
+        List<RefSpec> trimmedRefSpecs = new ArrayList<>();
+        for (RefSpec rs : refspec) {
+            if (rs != null) {
+                trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
+            }
+        }
+        proxy.fetch(remoteName, (RefSpec) trimmedRefSpecs);
     }
 
     /** {@inheritDoc} */
     @Override
     public void fetch(String remoteName, RefSpec refspec) throws GitException, InterruptedException {
-        fetch(remoteName, new RefSpec[] {refspec});
+        fetch(remoteName, new RefSpec[] { new RefSpec(refspec.toString().trim())});
     }
 
     /** {@inheritDoc} */
     @Override
     public void push(String remoteName, String refspec) throws GitException, InterruptedException {
-        proxy.push(remoteName, refspec);
+        proxy.push(remoteName, refspec.trim());
     }
 
     /** {@inheritDoc} */
     @Override
     public void push(URIish url, String refspec) throws GitException, InterruptedException {
-        proxy.push(url, refspec);
+        proxy.push(url, refspec.trim());
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -493,13 +493,7 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
     /** {@inheritDoc} */
     @Override
     public void fetch(String remoteName, RefSpec... refspec) throws GitException, InterruptedException {
-        List<RefSpec> trimmedRefSpecs = new ArrayList<>();
-        for (RefSpec rs : refspec) {
-            if (rs != null) {
-                trimmedRefSpecs.add(new RefSpec(rs.toString().trim()));
-            }
-        }
-        proxy.fetch(remoteName, (RefSpec) trimmedRefSpecs);
+        proxy.fetch(remoteName, refspec);
     }
 
     /** {@inheritDoc} */

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitCommand.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitCommand.java
@@ -1,12 +1,9 @@
 package org.jenkinsci.plugins.gitclient;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import hudson.EnvVars;
-import hudson.Launcher;
-import hudson.model.TaskListener;
-import hudson.util.ArgumentListBuilder;
-import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -16,13 +13,20 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.model.TaskListener;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.StreamTaskListener;
+
 /**
  * Run a command line git command, return output as array of String, optionally
  * assert on contents of command output.
  *
  * @author Mark Waite
  */
-class CliGitCommand {
+class
+CliGitCommand {
 
     private final TaskListener listener;
     private final transient Launcher launcher;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitCommand.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitCommand.java
@@ -4,6 +4,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.model.TaskListener;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -13,20 +18,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import hudson.EnvVars;
-import hudson.Launcher;
-import hudson.model.TaskListener;
-import hudson.util.ArgumentListBuilder;
-import hudson.util.StreamTaskListener;
-
 /**
  * Run a command line git command, return output as array of String, optionally
  * assert on contents of command output.
  *
  * @author Mark Waite
  */
-class
-CliGitCommand {
+class CliGitCommand {
 
     private final TaskListener listener;
     private final transient Launcher launcher;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -40,6 +40,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.Issue;
 
 @RunWith(Parameterized.class)
 public class GitClientCloneTest {
@@ -328,11 +329,16 @@ public class GitClientCloneTest {
                         }));
     }
 
+    private String randomSpace() {
+        return random.nextBoolean() ? " " : "";
+    }
+
     @Test
+    @Issue("JENKINS-70303") // spaces at start or end of refspec should be ignored
     public void test_clone_refspecs() throws Exception {
         List<RefSpec> refspecs = Arrays.asList(
-                new RefSpec("+refs/heads/master:refs/remotes/origin/master"),
-                new RefSpec("+refs/heads/1.4.x:refs/remotes/origin/1.4.x"));
+                new RefSpec(randomSpace() + "+refs/heads/master:refs/remotes/origin/master" + randomSpace()),
+                new RefSpec(randomSpace() + "+refs/heads/1.4.x:refs/remotes/origin/1.4.x" + randomSpace()));
         testGitClient
                 .clone_()
                 .url(workspace.localMirror())

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -15,6 +15,11 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.junit.Assert.assertThrows;
 
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -28,12 +33,6 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-
-import hudson.Util;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Branch;
-import hudson.plugins.git.GitException;
-import hudson.util.StreamTaskListener;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.transport.RefSpec;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -12,14 +12,9 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.io.FileMatchers.*;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.junit.Assert.assertThrows;
 
-import hudson.Util;
-import hudson.model.TaskListener;
-import hudson.plugins.git.Branch;
-import hudson.plugins.git.GitException;
-import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,6 +28,12 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import hudson.Util;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.GitException;
+import hudson.util.StreamTaskListener;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.transport.RefSpec;
@@ -109,6 +110,7 @@ public class GitClientFetchTest {
                 .in(configDir)
                 .using("git")
                 .getClient());
+
         String[] output = getDefaultBranchNameCmd.runWithoutAssert("config", "--get", "init.defaultBranch");
         for (String s : output) {
             String result = s.trim();
@@ -151,6 +153,10 @@ public class GitClientFetchTest {
         testGitClient.init();
         cliGitCommand.run("config", "user.name", "Vojtěch GitClientFetchTest Zweibrücken-Šafařík");
         cliGitCommand.run("config", "user.email", "email.by.git.client.test@example.com");
+    }
+
+    private String randomSpace() {
+        return random.nextBoolean() ? " " : "";
     }
 
     /* Workspace -> original repo, bareWorkspace -> bare repo and newAreaWorkspace -> newArea repo */
@@ -215,7 +221,7 @@ public class GitClientFetchTest {
                 is(commit2));
 
         /* Fetch new change into newArea repo */
-        RefSpec defaultRefSpec = new RefSpec("+refs/heads/*:refs/remotes/origin/*");
+        RefSpec defaultRefSpec = new RefSpec(randomSpace() + "+refs/heads/*:refs/remotes/origin/*" + randomSpace());
         List<RefSpec> refSpecs = new ArrayList<>();
         refSpecs.add(defaultRefSpec);
         newAreaWorkspace.launchCommand("git", "config", "fetch.prune", "false");


### PR DESCRIPTION
## [JENKINS-70303](https://issues.jenkins.io/browse/JENKINS-70303) - Remove leading and trailing spaces from refspec

If a refspec is included in the checkout scm definition of a multibranch Pipeline using JGit for checkout and the refspec has a leading space character, the checkout fails with the JGit message

```
Remote does not have  available for fetch.
```

The same refspec with leading spaces does not affect command line git checkout.  It works in either case with command line git.  Leading space handling by command line git is preferred rather than the way that the git client plugin honors the leading spaces and passes them to JGit.

Command line git does not see the issue because extra spaces between arguments of a command line program are generally not an issue.  Lucky circumstances that allow the CLI git checkout to be better behaved than the JGit checkout.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
