### PR TITLE
Calculate hashCode with arguments that are consistent with equals

### DIFF
--- a/src/main/java/hudson/plugins/git/Branch.java
+++ b/src/main/java/hudson/plugins/git/Branch.java
@@ -50,7 +50,7 @@ public class Branch extends GitObject {
      */
     @Override
     public int hashCode() {
-        return super.hashCode();
+        return Objects.hash(name, sha1);
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/Branch.java
+++ b/src/main/java/hudson/plugins/git/Branch.java
@@ -39,7 +39,7 @@ public class Branch extends GitObject {
      */
     @Override
     public String toString() {
-        return "Branch " + name + "(" + getSHA1String() + ")";
+        return String.format("Branch %s(%s)", name, getSHA1String());
     }
 
     /**


### PR DESCRIPTION
## Calculate hashCode with arguments that are consistent with equals

I used `String.format()` function for better consistency and it is more understandable.

Instead of relying on the `hashCode` of the superclass I've used the `Object.hash()` method to generate a hashcode. I think it is easier to understand and more explicit.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)

