### PR TITLE
Operating systems with outdated OpenSSH are no longer supported

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -124,11 +124,15 @@ image::images/ssh-host-key-verification.png[Configure Ssh host key verification]
 [NOTE]
 ====
 OpenSSH releases prior to link:https://www.openssh.com/txt/release-7.6[OpenSSH 7.6 (released Oct 2017)] do not support the ssh command line argument used to accept first connection.
-Red Hat Enterprise Linux 7, CentOS 7, AWS Linux 2, and Debian 9 all deliver OpenSSH releases older than OpenSSH 7.6.
+Red Hat Enterprise Linux 7, CentOS 7, Oracle Linux 7, Scientific Linux 7, Amazon Linux 2, Debian 9, and Ubuntu 16.04 all deliver OpenSSH releases older than OpenSSH 7.6.
 The "Git Host Key Verification Configuration" for those systems cannot use the "Accept first connection" strategy with command line git.
+
+Those operating systems are no longer supported by the Jenkins project.
+More details are available in the link:https://www.jenkins.io/blog/2023/05/30/operating-system-end-of-life/[end of life operating systems blog post].
 
 Users of those operating systems have the following options:
 
+* Upgrade to a supported operating system
 * Use the "Manually provided keys" host key verification strategy and provide host keys for their git hosts
 * Use the "Known hosts file" host key verification strategy and provide a known_hosts file on the agents with values for the required hosts
 * Enable JGit and use JGit instead of command line git on agents and controllers with those older OpenSSH versions


### PR DESCRIPTION
## Operating systems with outdated OpenSSH are no longer supported

Note that Jenkins no longer supports any known operating systems with an OpenSSH version prior to OpenSSH 7.6.  The `accept-new` option is available on all the implementations of OpenSSH on operating systems supported by Jenkins.

Add the most important option to resolve the issue, upgrade to a supported operating system.

List more operating systems so that web searches will find the page for those operating systems.

Link to the operating system end of life blog post.

Correct the name of Amazon Linux.

### Related issue reports

* [JENKINS-72546](https://issues.jenkins.io/browse/JENKINS-72546) is a reminder that this information is still useful and still needed.
* [JENKINS-69149](https://issues.jenkins.io/browse/JENKINS-69149) is an earlier report of the same issue.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Documentation
