### PR TITLE
Only run actions from jenkinsci organization

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'jenkinsci'
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
## Only run actions from jenkinsci organization

Using this condition will help avoid unnecessary runs in repositories where the workflow is not applicable. This same check is implemented in [gitlab-plugin](https://github.com/jenkinsci/gitlab-plugin) project in file https://github.com/jenkinsci/gitlab-plugin/blob/master/.github/workflows/release-drafter.yml

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spot bugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
