### PR TITLE
[Jenkins-72819] Fix NPE in CliGitAPIImpl.launchCommandIn() caused by InterruptedException

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2849,7 +2849,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             return stdout;
         } catch (GitException | InterruptedException e) {
-            if (e.getMessage().contains("unsupported option \"accept-new\"")) {
+            if (e.getMessage() != null && e.getMessage().contains("unsupported option \"accept-new\"")) {
                 listener.getLogger()
                         .println(
                                 HyperlinkNote.encodeTo(


### PR DESCRIPTION
## [JENKINS-72918](https://issues.jenkins.io/browse/JENKINS-72918) - Fix null pointer exception when reading exception message

Accessing message in exception handler is missing null check. 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
