### PR TITLE
[BEE-47337] added a delay of 3 seconds

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
@@ -77,7 +77,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
                 .execute();
         w.git.submoduleInit();
         w.git.submoduleUpdate().threads(3).execute();
-
+        Thread.sleep(3000);
         assertTrue("modules/firewall does not exist", w.exists("modules/firewall"));
         assertTrue("modules/ntp does not exist", w.exists("modules/ntp"));
         // JGit submodule implementation doesn't handle renamed submodules


### PR DESCRIPTION
## [BEE-47337](https://cloudbees.atlassian.net/browse/BEE-47337) 

The test case is failing at the assertion and clearly its the problem at Threads, where in the submoduleUpdate has not been completed yet and its proceeding to the assertions, adding a slight delay will make sure the submoduleupdate is complete.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [ ] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [ ] No Javadoc warnings were introduced with my changes
- [ ] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [ ] Infrastructure change (non-breaking change which updates dependencies or improves infrastructure)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.
