### PR TITLE
Remove local repo config changes at end of tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -4079,6 +4079,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return isExecuted;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void config(ConfigLevel configLevel, String key, String value) throws GitException, InterruptedException {
         ArgumentListBuilder args = new ArgumentListBuilder("config");
@@ -4087,7 +4088,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         } else {
             args.add("--" + ConfigLevel.LOCAL.toString().toLowerCase(Locale.getDefault()));
         }
-        args.add(key, value);
+        if (value != null) {
+            args.add(key, value);
+        } else {
+            args.add("--unset", key);
+        }
         launchCommand(args);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -1007,22 +1007,26 @@ public interface GitClient {
     boolean maintenance(String task) throws InterruptedException;
 
     /**
-     * Execute git config at local level
+     * Execute git config at local level.  If value is null, the key will be removed from the configuration.
      * @param configLevel the config level to use can be null and default will ${{@link ConfigLevel#LOCAL}}
      * @param key configuration section ${code user.name} format section[.subsection].name
-     * @param value configuration value
+     * @param value configuration value.  If null, the key will be removed from the configuration (unset)
      * @throws GitException on Git exception
      * @throws InterruptedException on thread interruption
      */
     void config(ConfigLevel configLevel, String key, String value) throws GitException, InterruptedException;
 
     /**
-     * config level (see git documentation)
+     * Level of git configuration that will be adjusted by configuration changes.
+     * Refer to the git documentation for more details.
      *
      */
     enum ConfigLevel {
+        /** Configure the current repository. */
         LOCAL,
+        /** Configure the current user. */
         SYSTEM,
+        /** Configure all users. */
         GLOBAL;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -3036,6 +3036,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return false;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void config(ConfigLevel configLevel, String key, String value) throws GitException, InterruptedException {
         if (configLevel != ConfigLevel.LOCAL) {
@@ -3056,7 +3057,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             name = keys[2];
         }
         StoredConfig storedConfig = getRepository().getConfig();
-        storedConfig.setString(section, subsection, name, value);
+        if (value != null) {
+            storedConfig.setString(section, subsection, name, value);
+        } else {
+            storedConfig.unset(section, subsection, name);
+        }
         try {
             storedConfig.save();
         } catch (IOException e) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitCommand.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitCommand.java
@@ -75,6 +75,14 @@ class CliGitCommand {
         gitClient.config(GitClient.ConfigLevel.LOCAL, "gpg.format", "openpgp");
     }
 
+    void removeRepositorySettings() throws IOException, InterruptedException {
+        gitClient.config(GitClient.ConfigLevel.LOCAL, "user.name", null);
+        gitClient.config(GitClient.ConfigLevel.LOCAL, "user.email", null);
+        gitClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", null);
+        gitClient.config(GitClient.ConfigLevel.LOCAL, "tag.gpgSign", null);
+        gitClient.config(GitClient.ConfigLevel.LOCAL, "gpg.format", null);
+    }
+
     String[] run(String... arguments) throws IOException, InterruptedException {
         args = new ArgumentListBuilder("git");
         args.add(arguments);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -204,8 +204,6 @@ public class GitClientTest {
                 .using("git")
                 .getClient();
         boolean currentDirIsShallow = currentDirCliGit.isShallowRepository();
-        CliGitCommand gitCmd = new CliGitCommand(currentDirCliGit);
-        gitCmd.initializeRepository();
 
         mirrorParent = Files.createTempDirectory("mirror").toFile();
         /* Clone mirror into mirrorParent/git-client-plugin.git as a bare repo */
@@ -266,6 +264,28 @@ public class GitClientTest {
             }
         }
         assertTrue("Failed to delete temporary readGitConfig directory", configDir.delete());
+    }
+
+    @BeforeClass
+    public static void addLocalGitConfigChanges() throws Exception {
+        File currentDir = new File(".");
+        CliGitAPIImpl currentDirCliGit = (CliGitAPIImpl) Git.with(TaskListener.NULL, new EnvVars())
+                .in(currentDir)
+                .using("git")
+                .getClient();
+        CliGitCommand gitCmd = new CliGitCommand(currentDirCliGit);
+        gitCmd.initializeRepository();
+    }
+
+    @AfterClass
+    public static void removeLocalGitConfigChanges() throws Exception {
+        File currentDir = new File(".");
+        CliGitAPIImpl currentDirCliGit = (CliGitAPIImpl) Git.with(TaskListener.NULL, new EnvVars())
+                .in(currentDir)
+                .using("git")
+                .getClient();
+        CliGitCommand gitCmd = new CliGitCommand(currentDirCliGit);
+        gitCmd.removeRepositorySettings();
     }
 
     @AfterClass


### PR DESCRIPTION
## Remove local repo config changes at end of tests

Local configuration changes that are performed in GitClientTest allow the tests to run in environments where commit signing is the user or system level default.  Remove those local configuration changes at the end of the tests, since they were specifically performed for the test.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Tests
