### PR TITLE
Require Jenkins 2.440.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.version>2.426.3</jenkins.version>
+    <jenkins.version>2.440.3</jenkins.version>
     <jgit.version>6.10.0.202406032230-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -75,7 +75,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.426.x</artifactId>
+        <artifactId>bom-2.440.x</artifactId>
         <version>3120.v4d898e1e9fc4</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.440.3 or newer

[Plugin installation statistics](https://stats.jenkins.io/pluginversions/git-client.html) show that 76% of all installations of git client plugin 4.7.0 are already running Jenkins 2.440.3 or newer.

[SECURITY-3386](https://www.jenkins.io/security/advisory/2024-04-17/#SECURITY-3386) security advisory requires Jenkins 2.440.3 or newer to avoid [CVE-2023-48795](https://www.cve.org/CVERecord?id=CVE-2023-48795).

[Choosing a Jenkins version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) recommends either 2.426.3 or 2.440.3.  In this case, I think that 2.440.3 is the better choice.

@olamy and @jtnord I would appreciate your input on this pull request.  I think this is the right time to increase the minimum required Jenkins version for the git client plugin so that a narrower range of Jenkins core versions are supported.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Maintenance
