### PR TITLE
Remove outdated tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1499,10 +1499,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     }
                     if (isAtLeastVersion(1, 8, 4, 0)) {
                         args.add("--depth=" + depth);
-                    } else {
-                        listener.getLogger()
-                                .println(
-                                        "[WARNING] Git client older than 1.8.4 doesn't support shallow submodule updates. This flag is ignored.");
                     }
                 }
 
@@ -1749,7 +1745,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /**
      * Returns true if this repository is configured as a shallow clone.
-     * Shallow clone requires command line git 1.9 or later.
      * @return true if this repository is configured as a shallow clone
      */
     public boolean isShallowRepository() {
@@ -2930,10 +2925,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                 if (tags) {
                     args.add("--tags");
-                }
-
-                if (!isAtLeastVersion(1, 9, 0, 0) && isShallowRepository()) {
-                    throw new GitException("Can't push from shallow repository using git client older than 1.9.0");
                 }
 
                 StandardCredentials cred = credentials.get(remote.toPrivateString());

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -653,8 +653,7 @@ public interface GitClient {
      * @param remoteRepoUrl Remote repository URL.
      * @param pattern       Only references matching the given pattern are displayed.
      * @return a map of reference names and their underlying references. Empty if none or if the remote does not report
-     * symbolic references (i.e. Git 1.8.4 or earlier) or if the client does not support reporting symbolic references
-     * (e.g. command line Git prior to 2.8.0).
+     * symbolic references or if the command line git version does not support reporting symbolic references.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException  if interrupted.
      */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/SubmoduleUpdateCommand.java
@@ -16,11 +16,11 @@ public interface SubmoduleUpdateCommand extends GitCommand {
     /**
      * If set true and if the git version supports it, update the
      * submodules to the tip of the branch rather than to a specific
-     * SHA1.  Refer to git documentation for details.  First available
-     * in command line git 1.8.2.  Default is to update to a specific
-     * SHA1 (compatible with previous versions of git)
+     * SHA1.  Refer to git documentation for details.  Default is to
+     * update to a specific SHA1 (compatible with previous versions of
+     * git)
      *
-     * @param remoteTracking if true, will update the submodule to the tip of the branch requested (requires git&gt;=1.8.2)
+     * @param remoteTracking if true, will update the submodule to the tip of the branch requested
      * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
      */
     SubmoduleUpdateCommand remoteTracking(boolean remoteTracking);
@@ -63,7 +63,7 @@ public interface SubmoduleUpdateCommand extends GitCommand {
      * Only clone the most recent history, not preceding history.  Depth of the
      * shallow clone is controlled by the #depth method.
      *
-     * @param shallow boolean controlling whether the clone is shallow (requires git&gt;=1.8.4)
+     * @param shallow boolean controlling whether the clone is shallow
      * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
      */
     SubmoduleUpdateCommand shallow(boolean shallow);
@@ -72,7 +72,7 @@ public interface SubmoduleUpdateCommand extends GitCommand {
      * When shallow cloning, allow for a depth to be set in cases where you need more than the immediate last commit.
      * Has no effect if shallow is set to false (default).
      *
-     * @param depth number of revisions to be included in shallow clone (requires git&gt;=1.8.4)
+     * @param depth number of revisions to be included in shallow clone
      * @return a {@link org.jenkinsci.plugins.gitclient.SubmoduleUpdateCommand} object.
      */
     SubmoduleUpdateCommand depth(Integer depth);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -16,11 +16,6 @@ public class CliGitAPIImplTest extends GitAPITestUpdateCliGit {
         return Git.with(listener, env).in(ws).using("git").getClient();
     }
 
-    @Override
-    protected boolean hasWorkingGetRemoteSymbolicReferences() {
-        return ((CliGitAPIImpl) (w.git)).isAtLeastVersion(2, 8, 0, 0);
-    }
-
     public static class VersionTest {
 
         private boolean expectedIsAtLeastVersion;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPIForCliGitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPIForCliGitTest.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.gitclient;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import hudson.Util;
@@ -156,21 +155,10 @@ public class GitAPIForCliGitTest {
         testGitClient.commit("commit2");
         ObjectId sha1 = workspace.head();
 
-        try {
-            testGitClient.push("origin", defaultBranchName);
-            assertTrue(
-                    "git < 1.9.0 can push from shallow repository",
-                    workspace.cgit().isAtLeastVersion(1, 9, 0, 0));
-            String remoteSha1 =
-                    remote.launchCommand("git", "rev-parse", defaultBranchName).substring(0, 40);
-            assertEquals(sha1.name(), remoteSha1);
-        } catch (GitException ge) {
-            // expected for git cli < 1.9.0
-            assertExceptionMessageContains(ge, "push from shallow repository");
-            assertFalse(
-                    "git >= 1.9.0 can't push from shallow repository",
-                    workspace.cgit().isAtLeastVersion(1, 9, 0, 0));
-        }
+        testGitClient.push("origin", defaultBranchName);
+        String remoteSha1 =
+                remote.launchCommand("git", "rev-parse", defaultBranchName).substring(0, 40);
+        assertEquals(sha1.name(), remoteSha1);
     }
 
     private void assertExceptionMessageContains(GitException ge, String expectedSubstring) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -1219,8 +1219,6 @@ public abstract class GitAPITestUpdate {
         }
     }
 
-    protected abstract boolean hasWorkingGetRemoteSymbolicReferences();
-
     private Properties parseLsRemote(File file) throws IOException {
         Properties properties = new Properties();
         Pattern pattern = Pattern.compile("([a-f0-9]{40})\\s*(.*)");
@@ -1243,10 +1241,6 @@ public abstract class GitAPITestUpdate {
      */
     @Test
     public void testGetRemoteSymbolicReferencesWithMatchingPattern() throws Exception {
-        if (!hasWorkingGetRemoteSymbolicReferences()) {
-            /* Do not distract warnings system by using assumeThat to skip tests */
-            return;
-        }
         Map<String, String> references = w.git.getRemoteSymbolicReferences(remoteMirrorURL, Constants.HEAD);
         assertThat(references, hasEntry(is(Constants.HEAD), is(Constants.R_HEADS + DEFAULT_JGIT_BRANCH_NAME)));
         assertThat(references.size(), is(1));
@@ -1800,10 +1794,6 @@ public abstract class GitAPITestUpdate {
      */
     @Test
     public void testGetRemoteSymbolicReferences() throws Exception {
-        if (!hasWorkingGetRemoteSymbolicReferences()) {
-            /* Do not distract warnings system by using assumeThat to skip tests */
-            return;
-        }
         Map<String, String> references = w.git.getRemoteSymbolicReferences(remoteMirrorURL, null);
         assertThat(references, hasEntry(is(Constants.HEAD), is(Constants.R_HEADS + DEFAULT_JGIT_BRANCH_NAME)));
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -284,42 +284,18 @@ public class GitClientFetchTest {
                 .getHeadRev(bareWorkspace.getGitFileDir().getAbsolutePath(), defaultBranchName);
         assertThat("bare5 != working5", bareCommit5, is(commit5));
 
-        /* Fetch into newArea repo with null RefSpec - should only
-         * pull tags, not commits in git versions prior to git 1.9.0.
-         * In git 1.9.0, fetch -t pulls tags and versions. */
+        /* Fetch into newArea repo with null RefSpec. */
         newAreaWorkspace.getGitClient().fetch("origin", null, null);
         assertThat(
                 "null refSpec fetch modified local repo",
                 newAreaWorkspace.getGitClient().revParse("HEAD"),
                 is(bareCommit4));
-        ObjectId expectedHead = bareCommit4;
-        if (gitImplName.startsWith("jgit") || workspace.cgit().isAtLeastVersion(1, 9, 0, 0)) {
-            newAreaWorkspace
-                    .getGitClient()
-                    .merge()
-                    .setRevisionToMerge(bareCommit5)
-                    .execute();
-            expectedHead = bareCommit5;
-        } else {
-            GitException gitException = assertThrows(GitException.class, () -> newAreaWorkspace
-                    .getGitClient()
-                    .merge()
-                    .setRevisionToMerge(bareCommit5)
-                    .execute());
-            assertThat(
-                    gitException.getMessage(),
-                    anyOf(
-                            containsString("Could not merge"),
-                            containsString("not something we can merge"),
-                            containsString("does not point to a commit")));
-        }
-        /* Assert that expected change is in repo after merge.  With
-         * git 1.7 and 1.8, it should be bareCommit4.  With git 1.9
-         * and later, it should be bareCommit5. */
+        ObjectId expectedHead = bareCommit5;
+        newAreaWorkspace.getGitClient().merge().setRevisionToMerge(bareCommit5).execute();
         assertThat(
                 "null refSpec fetch modified local repo",
                 newAreaWorkspace.getGitClient().revParse("HEAD"),
-                is(expectedHead));
+                is(bareCommit5));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
@@ -63,10 +63,6 @@ public class GitClientSecurityTest {
         this.enableRemoteCheckUrl = enableRemoteCheckUrl;
     }
 
-    /* Capabilities of command line git in current environment */
-    private static final boolean CLI_GIT_SUPPORTS_OPERAND_SEPARATOR;
-    private static final boolean CLI_GIT_SUPPORTS_SYMREF;
-
     static {
         CliGitAPIImpl tempGitClient;
         try {
@@ -76,13 +72,6 @@ public class GitClientSecurityTest {
                     .getClient();
         } catch (Exception e) {
             tempGitClient = null;
-        }
-        if (tempGitClient != null) {
-            CLI_GIT_SUPPORTS_OPERAND_SEPARATOR = tempGitClient.isAtLeastVersion(2, 8, 0, 0);
-            CLI_GIT_SUPPORTS_SYMREF = tempGitClient.isAtLeastVersion(2, 8, 0, 0);
-        } else {
-            CLI_GIT_SUPPORTS_OPERAND_SEPARATOR = false;
-            CLI_GIT_SUPPORTS_SYMREF = false;
         }
     }
 
@@ -100,23 +89,14 @@ public class GitClientSecurityTest {
      *
      * This function returns a randomly selected value to enable or
      * disable the repository URL check based on the contents of the
-     * attack string. If remote check is selected to be disabled and
-     * the command line git implementation does not have full support
-     * for the '--' separator between options and operands and the
+     * attack string. If remote check is selected to be disabled and the
      * attack is one of a known list of strings, then this function
      * will always return 'true' so that the remote checks will be
      * enabled.
-     *
-     * Returning 'false' in those cases on certain older command line
-     * git implementations (git 1.8.3 on CentOS 7, git 2.7.4 on Ubuntu
-     * 16) would cause the tested code to not throw an exception
-     * because those command line git versions do not fully support
-     * '--' to separate options and operands.
      */
     private static boolean enableRemoteCheck(String attack) {
         boolean enabled = CONFIG_RANDOM.nextBoolean();
         if (!enabled
-                && !CLI_GIT_SUPPORTS_OPERAND_SEPARATOR
                 && (attack.equals("-q")
                         || attack.equals("--quiet")
                         || attack.equals("-t")
@@ -298,9 +278,6 @@ public class GitClientSecurityTest {
     @Test
     @Issue("SECURITY-1534")
     public void testGetRemoteSymbolicReferences_SECURITY_1534() {
-        if (!CLI_GIT_SUPPORTS_SYMREF) {
-            return;
-        }
         String expectedMessage = enableRemoteCheckUrl ? "Invalid remote URL: " + badRemoteUrl : badRemoteUrl.trim();
         GitException e = assertThrows(
                 GitException.class, () -> gitClient.getRemoteSymbolicReferences(badRemoteUrl, DEFAULT_BRANCH_NAME));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplTest.java
@@ -12,11 +12,6 @@ public class JGitAPIImplTest extends GitAPITestUpdate {
     }
 
     @Override
-    protected boolean hasWorkingGetRemoteSymbolicReferences() {
-        return true; // JGit 5.10 has getRemoteSymbolicReferences, prior did not
-    }
-
-    @Override
     protected boolean getTimeoutVisibleInCurrentTest() {
         return true; // git client plugin 3.11.0 supports JGit timeout
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitApacheAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitApacheAPIImplTest.java
@@ -12,11 +12,6 @@ public class JGitApacheAPIImplTest extends GitAPITestUpdate {
     }
 
     @Override
-    protected boolean hasWorkingGetRemoteSymbolicReferences() {
-        return true; // JGit 5.10 gets remote symbolic references, prior did not
-    }
-
-    @Override
     protected boolean getTimeoutVisibleInCurrentTest() {
         return true; // git client plugin 3.11.0 supports JGit timeout
     }


### PR DESCRIPTION
## Remove outdated tests

The git client plugin no longer needs to support command line git older than 2.11 because all the operating systems supoprted by Jenkins include command line git 2.11 or newer.  No need for conditionals to check for older versions.

The command line git versions supported by the git client plugin all include symref functionality.  No need to test for support of symref, since all supported versions of command line git include it.

https://www.jenkins.io/blog/2023/05/30/operating-system-end-of-life/ is the May 2023 blog post that announced the end of life for RHEL 7 and its derivatives.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Tests
