### PR TITLE
Revert added 3 second delay in test

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
@@ -77,7 +77,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
                 .execute();
         w.git.submoduleInit();
         w.git.submoduleUpdate().threads(3).execute();
-        Thread.sleep(3000);
+
         assertTrue("modules/firewall does not exist", w.exists("modules/firewall"));
         assertTrue("modules/ntp does not exist", w.exists("modules/ntp"));
         // JGit submodule implementation doesn't handle renamed submodules


### PR DESCRIPTION
## Revert added 3 second delay in test

[Prior discussion](https://github.com/jenkinsci/git-client-plugin/pull/1122#discussion_r1644289890) notes that the sleep does not actually help the test other than to delay its completion.

This reverts commit fb9d2ca1189fd2c02e593ffda9922b3cf10fca45.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Test
