### PR TITLE
Declare API's that throw `GitException`

### DIFF
--- a/src/main/java/hudson/plugins/git/IGitAPI.java
+++ b/src/main/java/hudson/plugins/git/IGitAPI.java
@@ -138,7 +138,7 @@ public interface IGitAPI extends GitClient {
      * @param remoteRepository remote configuration from which refs will be retrieved
      * @throws java.lang.InterruptedException if interrupted.
      */
-    void fetch(RemoteConfig remoteRepository) throws InterruptedException;
+    void fetch(RemoteConfig remoteRepository) throws GitException, InterruptedException;
 
     /**
      * Retrieve commits from default remote.
@@ -281,7 +281,7 @@ public interface IGitAPI extends GitClient {
      * @return a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @throws java.lang.InterruptedException if interrupted.
      */
-    ObjectId mergeBase(ObjectId sha1, ObjectId sha2) throws InterruptedException;
+    ObjectId mergeBase(ObjectId sha1, ObjectId sha2) throws GitException, InterruptedException;
 
     /**
      * showRevision.
@@ -304,5 +304,5 @@ public interface IGitAPI extends GitClient {
      */
     @Restricted(NoExternalUse.class)
     @Deprecated
-    String getAllLogEntries(String branch) throws InterruptedException;
+    String getAllLogEntries(String branch) throws GitException, InterruptedException;
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
@@ -23,7 +23,7 @@ import org.eclipse.jgit.lib.Repository;
 abstract class AbstractGitAPIImpl implements GitClient, Serializable {
     /** {@inheritDoc} */
     @Override
-    public <T> T withRepository(RepositoryCallback<T> callable) throws IOException, InterruptedException {
+    public <T> T withRepository(RepositoryCallback<T> callable) throws GitException, IOException, InterruptedException {
         try (Repository repo = getRepository()) {
             return callable.invoke(repo, FilePath.localChannel);
         }
@@ -40,7 +40,7 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
 
     /** {@inheritDoc} */
     @Override
-    public void setAuthor(PersonIdent p) {
+    public void setAuthor(PersonIdent p) throws GitException {
         if (p != null) {
             setAuthor(p.getName(), p.getEmailAddress());
         }
@@ -48,7 +48,7 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
 
     /** {@inheritDoc} */
     @Override
-    public void setCommitter(PersonIdent p) {
+    public void setCommitter(PersonIdent p) throws GitException {
         if (p != null) {
             setCommitter(p.getName(), p.getEmailAddress());
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.gitclient;
 
+import hudson.plugins.git.GitException;
 import java.io.Writer;
 import org.eclipse.jgit.lib.ObjectId;
 
@@ -55,7 +56,7 @@ public interface ChangelogCommand extends GitCommand {
      * @param rev a {@link java.lang.String} object.
      * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
      */
-    ChangelogCommand excludes(String rev);
+    ChangelogCommand excludes(String rev) throws GitException;
 
     /**
      * excludes.
@@ -63,7 +64,7 @@ public interface ChangelogCommand extends GitCommand {
      * @param rev a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
      */
-    ChangelogCommand excludes(ObjectId rev);
+    ChangelogCommand excludes(ObjectId rev) throws GitException;
 
     /**
      * Adds the revision to include in the log.
@@ -73,7 +74,7 @@ public interface ChangelogCommand extends GitCommand {
      * @param rev a {@link java.lang.String} object.
      * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
      */
-    ChangelogCommand includes(String rev);
+    ChangelogCommand includes(String rev) throws GitException;
 
     /**
      * includes.
@@ -81,7 +82,7 @@ public interface ChangelogCommand extends GitCommand {
      * @param rev a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
      */
-    ChangelogCommand includes(ObjectId rev);
+    ChangelogCommand includes(ObjectId rev) throws GitException;
 
     /**
      * Sets the {@link java.io.OutputStream} that receives the changelog.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -465,7 +465,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * custom pack programs. Reject a URL if it includes invalid
      * content.
      */
-    private void addCheckedRemoteUrl(@NonNull ArgumentListBuilder args, @NonNull String url) {
+    private void addCheckedRemoteUrl(@NonNull ArgumentListBuilder args, @NonNull String url) throws GitException {
         String trimmedUrl = url.trim();
         /* Don't check for invalid args if URL starts with known good cases.
          * Known good cases include:
@@ -1211,7 +1211,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     @SuppressFBWarnings(
             value = "RV_DONT_JUST_NULL_CHECK_READLINE",
             justification = "Only needs first line, exception if multiple detected")
-    private @CheckForNull String firstLine(String result) {
+    private @CheckForNull String firstLine(String result) throws GitException {
         BufferedReader reader = new BufferedReader(new StringReader(result));
         String line;
         try {
@@ -2355,7 +2355,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
     }
 
-    private Path createSshKeyFile(SSHUserPrivateKey sshUser) throws IOException {
+    private Path createSshKeyFile(SSHUserPrivateKey sshUser) throws GitException, IOException {
         Path key = createTempFile("ssh", ".key");
         try (BufferedWriter w = Files.newBufferedWriter(key, Charset.forName(encoding))) {
             List<String> privateKeys = sshUser.getPrivateKeys();
@@ -2951,7 +2951,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @param fos output of "git branch -v --no-abbrev"
      * @return a {@link java.util.Set} object.
      */
-    /*package*/ Set<Branch> parseBranches(String fos) {
+    /*package*/ Set<Branch> parseBranches(String fos) throws GitException {
         // JENKINS-34309 if the commit message contains line breaks,
         // "git branch -v --no-abbrev" output will include CR (Carriage Return) characters.
         // Replace all CR characters to avoid interpreting them as line endings
@@ -3473,7 +3473,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /** {@inheritDoc} */
     @Override
-    public boolean isCommitInRepo(ObjectId commit) throws InterruptedException {
+    public boolean isCommitInRepo(ObjectId commit) throws GitException, InterruptedException {
         if (commit == null) {
             return false;
         }
@@ -3910,7 +3910,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     @Deprecated
     @Override
-    public ObjectId mergeBase(ObjectId id1, ObjectId id2) throws InterruptedException {
+    public ObjectId mergeBase(ObjectId id1, ObjectId id2) throws GitException, InterruptedException {
         try {
             String result;
             try {
@@ -3926,7 +3926,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 // Add the SHA1
                 return ObjectId.fromString(line);
             }
-        } catch (IOException | GitException e) {
+        } catch (IOException e) {
             throw new GitException("Error parsing merge base", e);
         }
 
@@ -3936,7 +3936,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     @Deprecated
     @Override
-    public String getAllLogEntries(String branch) throws InterruptedException {
+    public String getAllLogEntries(String branch) throws GitException, InterruptedException {
         // BROKEN: --all and branch are conflicting.
         return launchCommand("log", "--all", "--pretty=format:'%H#%ct'", branch);
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -130,7 +130,7 @@ public interface GitClient {
      * @throws java.io.IOException in case of IO error
      * @throws java.lang.InterruptedException if interrupted
      */
-    <T> T withRepository(RepositoryCallback<T> callable) throws IOException, InterruptedException;
+    <T> T withRepository(RepositoryCallback<T> callable) throws GitException, IOException, InterruptedException;
 
     /**
      * The working tree of this repository.
@@ -857,7 +857,7 @@ public interface GitClient {
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
      */
-    ChangelogCommand changelog();
+    ChangelogCommand changelog() throws GitException;
 
     /**
      * Appends to an existing git-note on the current HEAD commit.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1250,7 +1250,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
      */
     @Override
-    public ChangelogCommand changelog() {
+    public ChangelogCommand changelog() throws GitException {
         return new ChangelogCommand() {
             private Repository repo = getRepository();
             private ObjectReader or = repo.newObjectReader();
@@ -1259,7 +1259,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private boolean hasIncludedRev = false;
 
             @Override
-            public ChangelogCommand excludes(String rev) {
+            public ChangelogCommand excludes(String rev) throws GitException {
                 try {
                     return excludes(repo.resolve(rev));
                 } catch (IOException e) {
@@ -1268,7 +1268,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
-            public ChangelogCommand excludes(ObjectId rev) {
+            public ChangelogCommand excludes(ObjectId rev) throws GitException {
                 try {
                     walk.markUninteresting(walk.lookupCommit(rev));
                     return this;
@@ -1278,7 +1278,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
-            public ChangelogCommand includes(String rev) {
+            public ChangelogCommand includes(String rev) throws GitException {
                 try {
                     includes(repo.resolve(rev));
                     hasIncludedRev = true;
@@ -1289,7 +1289,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
-            public ChangelogCommand includes(ObjectId rev) {
+            public ChangelogCommand includes(ObjectId rev) throws GitException {
                 try {
                     walk.markStart(walk.lookupCommit(rev));
                     hasIncludedRev = true;
@@ -1396,7 +1396,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         @SuppressFBWarnings(
                 value = "VA_FORMAT_STRING_USES_NEWLINE",
                 justification = "Windows git implementation requires specific line termination")
-        void format(RevCommit commit, RevCommit parent, PrintWriter pw, Boolean useRawOutput) throws IOException {
+        void format(RevCommit commit, RevCommit parent, PrintWriter pw, Boolean useRawOutput)
+                throws GitException, IOException {
             if (parent != null) {
                 pw.printf("commit %s (from %s)\n", commit.name(), parent.name());
             } else {
@@ -2091,7 +2092,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private Set<String> listRemoteBranches(String remote)
-            throws NotSupportedException, TransportException, URISyntaxException {
+            throws GitException, NotSupportedException, TransportException, URISyntaxException {
         Set<String> branches = new HashSet<>();
         try (final Repository repo = getRepository()) {
             StoredConfig config = repo.getConfig();
@@ -2453,7 +2454,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
     }
 
-    private Iterable<JGitAPIImpl> submodules() throws IOException {
+    private Iterable<JGitAPIImpl> submodules() throws GitException, IOException {
         List<JGitAPIImpl> submodules = new ArrayList<>();
         try (Repository repo = getRepository()) {
             SubmoduleWalk generator = SubmoduleWalk.forIndex(repo);
@@ -2709,7 +2710,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
     }
 
-    private List<Ref> getAllBranchRefs(boolean originBranches) {
+    private List<Ref> getAllBranchRefs(boolean originBranches) throws GitException {
         List<Ref> branches = new ArrayList<>();
         try (Repository repo = getRepository()) {
             for (Ref r : repo.getAllRefs().values()) {
@@ -2725,7 +2726,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     @Deprecated
     @Override
-    public ObjectId mergeBase(ObjectId id1, ObjectId id2) {
+    public ObjectId mergeBase(ObjectId id1, ObjectId id2) throws GitException {
         try (Repository repo = getRepository();
                 ObjectReader or = repo.newObjectReader();
                 RevWalk walk = new RevWalk(or)) {
@@ -2748,7 +2749,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     @Deprecated
     @Override
-    public String getAllLogEntries(String branch) {
+    public String getAllLogEntries(String branch) throws GitException {
         try (Repository repo = getRepository();
                 ObjectReader or = repo.newObjectReader();
                 RevWalk walk = new RevWalk(or)) {
@@ -2772,14 +2773,14 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /**
      * Adds all the refs as start commits.
      */
-    private void markAllRefs(RevWalk walk) throws IOException {
+    private void markAllRefs(RevWalk walk) throws GitException, IOException {
         markRefs(walk, unused -> true);
     }
 
     /**
      * Adds all matching refs as start commits.
      */
-    private void markRefs(RevWalk walk, Predicate<Ref> filter) throws IOException {
+    private void markRefs(RevWalk walk, Predicate<Ref> filter) throws GitException, IOException {
         try (Repository repo = getRepository()) {
             for (Ref r : repo.getAllRefs().values()) {
                 if (filter.test(r)) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImpl.java
@@ -113,7 +113,7 @@ abstract class LegacyCompatibleGitAPIImpl extends AbstractGitAPIImpl implements 
     /** {@inheritDoc} */
     @Override
     @Deprecated
-    public void fetch(RemoteConfig remoteRepository) throws InterruptedException {
+    public void fetch(RemoteConfig remoteRepository) throws GitException, InterruptedException {
         // Assume there is only 1 URL for simplicity
         fetch(remoteRepository.getURIs().get(0), remoteRepository.getFetchRefSpecs());
     }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/Netrc.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/Netrc.java
@@ -38,7 +38,7 @@ class Netrc {
      *
      * @return a {@link org.jenkinsci.plugins.gitclient.Netrc} object.
      */
-    public static Netrc getInstance() {
+    public static Netrc getInstance() throws GitException {
         File netrc = getDefaultFile();
         return getInstance(netrc);
     }
@@ -49,7 +49,7 @@ class Netrc {
      * @param netrcPath a {@link java.lang.String} object.
      * @return a {@link org.jenkinsci.plugins.gitclient.Netrc} object.
      */
-    public static Netrc getInstance(@NonNull String netrcPath) {
+    public static Netrc getInstance(@NonNull String netrcPath) throws GitException {
         File netrc = new File(netrcPath);
         return netrc.exists() ? getInstance(new File(netrcPath)) : null;
     }
@@ -60,7 +60,7 @@ class Netrc {
      * @param netrc a {@link java.io.File} object.
      * @return a {@link org.jenkinsci.plugins.gitclient.Netrc} object.
      */
-    public static Netrc getInstance(File netrc) {
+    public static Netrc getInstance(File netrc) throws GitException {
         return new Netrc(netrc).parse();
     }
 
@@ -79,7 +79,7 @@ class Netrc {
      * @param host a {@link java.lang.String} object.
      * @return a {@link org.apache.http.auth.Credentials} object.
      */
-    public synchronized Credentials getCredentials(String host) {
+    public synchronized Credentials getCredentials(String host) throws GitException {
         if (!this.netrc.exists()) {
             return null;
         }
@@ -93,7 +93,7 @@ class Netrc {
         this.netrc = netrc;
     }
 
-    private synchronized Netrc parse() {
+    private synchronized Netrc parse() throws GitException {
         if (!netrc.exists()) {
             return this;
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -257,7 +257,7 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
 
     /** {@inheritDoc} */
     @Override
-    public <T> T withRepository(RepositoryCallback<T> callable) throws IOException, InterruptedException {
+    public <T> T withRepository(RepositoryCallback<T> callable) throws GitException, IOException, InterruptedException {
         return proxy.withRepository(callable);
     }
 
@@ -386,13 +386,13 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
 
     /** {@inheritDoc} */
     @Override
-    public ObjectId mergeBase(ObjectId sha1, ObjectId sha12) throws InterruptedException {
+    public ObjectId mergeBase(ObjectId sha1, ObjectId sha12) throws GitException, InterruptedException {
         return getGitAPI().mergeBase(sha1, sha12);
     }
 
     /** {@inheritDoc} */
     @Override
-    public String getAllLogEntries(String branch) throws InterruptedException {
+    public String getAllLogEntries(String branch) throws GitException, InterruptedException {
         return getGitAPI().getAllLogEntries(branch);
     }
 
@@ -945,7 +945,7 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
 
     /** {@inheritDoc} */
     @Override
-    public void fetch(RemoteConfig remoteRepository) throws InterruptedException {
+    public void fetch(RemoteConfig remoteRepository) throws GitException, InterruptedException {
         getGitAPI().fetch(remoteRepository);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RepositoryCallback.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RepositoryCallback.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.gitclient;
 
 import hudson.FilePath.FileCallable;
+import hudson.plugins.git.GitException;
 import hudson.remoting.VirtualChannel;
 import java.io.IOException;
 import java.io.Serializable;
@@ -31,5 +32,5 @@ public interface RepositoryCallback<T> extends Serializable {
      * @throws java.io.IOException if any IO failure
      * @throws java.lang.InterruptedException if interrupted.
      */
-    T invoke(Repository repo, VirtualChannel channel) throws IOException, InterruptedException;
+    T invoke(Repository repo, VirtualChannel channel) throws GitException, IOException, InterruptedException;
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/cgit/GitCommandsExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/cgit/GitCommandsExecutor.java
@@ -56,7 +56,7 @@ public class GitCommandsExecutor {
     }
 
     private <T> void invokeAll(ExecutorService executorService, Collection<Callable<T>> commands)
-            throws InterruptedException {
+            throws GitException, InterruptedException {
         CompletionService<T> completionService = new ExecutorCompletionService<>(executorService);
         Iterator<Callable<T>> remainingCommands = commands.iterator();
         int nCommands = commands.size();
@@ -78,7 +78,7 @@ public class GitCommandsExecutor {
         }
     }
 
-    private <T> void checkResult(Future<T> result) throws InterruptedException {
+    private <T> void checkResult(Future<T> result) throws GitException, InterruptedException {
         try {
             result.get();
         } catch (ExecutionException e) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitCommand.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitCommand.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
@@ -32,7 +33,7 @@ class CliGitCommand {
     private String[] output;
     private ArgumentListBuilder args;
 
-    CliGitCommand(GitClient client) {
+    CliGitCommand(GitClient client) throws GitException {
         listener = StreamTaskListener.NULL;
         launcher = new Launcher.LocalLauncher(listener);
         env = new EnvVars();
@@ -54,17 +55,18 @@ class CliGitCommand {
         args = null;
     }
 
-    CliGitCommand(GitClient client, String... arguments) {
+    CliGitCommand(GitClient client, String... arguments) throws GitException {
         this(client);
         args = new ArgumentListBuilder("git");
         args.add(arguments);
     }
 
-    void initializeRepository() throws IOException, InterruptedException {
+    void initializeRepository() throws GitException, IOException, InterruptedException {
         initializeRepository("git-client-user", "git-client-user@example.com");
     }
 
-    void initializeRepository(String userName, String userEmail) throws IOException, InterruptedException {
+    void initializeRepository(String userName, String userEmail)
+            throws GitException, IOException, InterruptedException {
         gitClient.config(GitClient.ConfigLevel.LOCAL, "user.name", userName);
         gitClient.config(GitClient.ConfigLevel.LOCAL, "user.email", userEmail);
         gitClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", "false");
@@ -75,7 +77,7 @@ class CliGitCommand {
         gitClient.config(GitClient.ConfigLevel.LOCAL, "gpg.format", "openpgp");
     }
 
-    void removeRepositorySettings() throws IOException, InterruptedException {
+    void removeRepositorySettings() throws GitException, IOException, InterruptedException {
         gitClient.config(GitClient.ConfigLevel.LOCAL, "user.name", null);
         gitClient.config(GitClient.ConfigLevel.LOCAL, "user.email", null);
         gitClient.config(GitClient.ConfigLevel.LOCAL, "commit.gpgsign", null);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
-import org.eclipse.jgit.errors.ConfigInvalidException;
 import org.eclipse.jgit.util.SystemReader;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -49,7 +48,7 @@ public class FilePermissionsTest {
     private static File repo;
 
     @BeforeClass
-    public static void createTestRepo() throws IOException, InterruptedException, ConfigInvalidException {
+    public static void createTestRepo() throws Exception {
         if (isWindows()) {
             return;
         }
@@ -88,7 +87,7 @@ public class FilePermissionsTest {
     }
 
     @AfterClass
-    public static void verifyTestRepo() throws IOException, InterruptedException {
+    public static void verifyTestRepo() throws Exception {
         if (isWindows()) {
             return;
         }
@@ -109,7 +108,7 @@ public class FilePermissionsTest {
         }
     }
 
-    private static File cloneTestRepo(File repo) throws IOException, InterruptedException {
+    private static File cloneTestRepo(File repo) throws Exception {
         File newRepo = Files.createTempDirectory(null).toFile();
         GitClient git = Git.with(listener, new hudson.EnvVars())
                 .in(newRepo)

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPICliGitNotIntializedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPICliGitNotIntializedTest.java
@@ -153,7 +153,7 @@ public class GitAPICliGitNotIntializedTest {
 
     private static boolean cliGitDefaultsSet = false;
 
-    private void setCliGitDefaults() {
+    private void setCliGitDefaults() throws Exception {
         if (!cliGitDefaultsSet) {
             CliGitCommand gitCmd = new CliGitCommand(null);
         }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPINotIntializedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPINotIntializedTest.java
@@ -218,7 +218,7 @@ public class GitAPINotIntializedTest {
 
     private static boolean cliGitDefaultsSet = false;
 
-    private void setCliGitDefaults() {
+    private void setCliGitDefaults() throws Exception {
         if (!cliGitDefaultsSet) {
             CliGitCommand gitCmd = new CliGitCommand(null);
         }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -202,7 +202,7 @@ public abstract class GitAPITestUpdate {
             return repo.getAbsolutePath();
         }
 
-        GitAPITestUpdate.WorkingArea init() throws IOException, InterruptedException {
+        GitAPITestUpdate.WorkingArea init() throws GitException, IOException, InterruptedException {
             git.init();
             String userName = "root";
             String emailAddress = "root@mydomain.com";
@@ -213,7 +213,7 @@ public abstract class GitAPITestUpdate {
             return this;
         }
 
-        GitAPITestUpdate.WorkingArea init(boolean bare) throws IOException, InterruptedException {
+        GitAPITestUpdate.WorkingArea init(boolean bare) throws GitException, IOException, InterruptedException {
             git.init_().workspace(repoPath()).bare(bare).execute();
             return this;
         }
@@ -317,7 +317,7 @@ public abstract class GitAPITestUpdate {
         /**
          * Obtain the current HEAD revision
          */
-        ObjectId head() throws IOException, InterruptedException {
+        ObjectId head() throws GitException, IOException, InterruptedException {
             return git.revParse("HEAD");
         }
 
@@ -328,7 +328,8 @@ public abstract class GitAPITestUpdate {
             return (IGitAPI) git;
         }
 
-        void initializeWorkingArea(String userName, String userEmail) throws IOException, InterruptedException {
+        void initializeWorkingArea(String userName, String userEmail)
+                throws GitException, IOException, InterruptedException {
             CliGitCommand gitCmd = new CliGitCommand(git);
             gitCmd.initializeRepository(userName, userEmail);
         }
@@ -1392,7 +1393,7 @@ public abstract class GitAPITestUpdate {
 
     @Deprecated
     @Test
-    public void testLsTreeNonRecursive() throws IOException, InterruptedException {
+    public void testLsTreeNonRecursive() throws Exception {
         w.init();
         w.touch("file1", "file1 fixed content");
         w.git.add("file1");
@@ -1409,7 +1410,7 @@ public abstract class GitAPITestUpdate {
 
     @Deprecated
     @Test
-    public void testLsTreeRecursive() throws IOException, InterruptedException {
+    public void testLsTreeRecursive() throws Exception {
         w.init();
         assertTrue("mkdir dir1 failed", w.file("dir1").mkdir());
         w.touch("dir1/file1", "dir1/file1 fixed content");
@@ -1479,7 +1480,7 @@ public abstract class GitAPITestUpdate {
         }
     }
 
-    private void checkHeadRev(String repoURL, ObjectId expectedId) throws InterruptedException {
+    private void checkHeadRev(String repoURL, ObjectId expectedId) throws Exception {
         final ObjectId originDefaultBranch = w.git.getHeadRev(repoURL, DEFAULT_MIRROR_BRANCH_NAME);
         assertEquals("origin default branch mismatch", expectedId, originDefaultBranch);
 
@@ -1595,7 +1596,7 @@ public abstract class GitAPITestUpdate {
      */
     @Deprecated
     @Test
-    public void testReset() throws IOException, InterruptedException {
+    public void testReset() throws Exception {
         w.init();
         /* No valid HEAD yet - nothing to reset, should give no error */
         w.igit().reset(false);
@@ -1704,7 +1705,7 @@ public abstract class GitAPITestUpdate {
     }
 
     private void checkBoundedChangelogSha1(final String sha1Begin, final String sha1End, final String branchName)
-            throws InterruptedException {
+            throws GitException, InterruptedException {
         StringWriter writer = new StringWriter();
         w.git.changelog(sha1Begin, sha1End, writer);
         String splitLog[] = writer.toString().split("[\\n\\r]", 3); // Extract first line of changelog

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -153,7 +153,7 @@ public class GitClientCloneTest {
     }
 
     @Test
-    public void test_clone_repositoryName() throws IOException, InterruptedException {
+    public void test_clone_repositoryName() throws Exception {
         CloneCommand cmd = testGitClient.clone_().url(workspace.localMirror()).repositoryName("upstream");
         if (random.nextBoolean()) {
             cmd.noCheckout(); // Randomly confirm this deprecated call is a no-op
@@ -204,7 +204,7 @@ public class GitClientCloneTest {
     }
 
     @Test
-    public void test_clone_shared() throws IOException, InterruptedException {
+    public void test_clone_shared() throws Exception {
         testGitClient
                 .clone_()
                 .url(workspace.localMirror())
@@ -220,7 +220,7 @@ public class GitClientCloneTest {
     }
 
     @Test
-    public void test_clone_null_branch() throws IOException, InterruptedException {
+    public void test_clone_null_branch() throws Exception {
         testGitClient
                 .clone_()
                 .url(workspace.localMirror())
@@ -235,7 +235,7 @@ public class GitClientCloneTest {
     }
 
     @Test
-    public void test_clone_unshared() throws IOException, InterruptedException {
+    public void test_clone_unshared() throws Exception {
         testGitClient
                 .clone_()
                 .url(workspace.localMirror())
@@ -272,7 +272,7 @@ public class GitClientCloneTest {
     private static final String SRC_DIR = (new File(".")).getAbsolutePath();
 
     @Test
-    public void test_clone_reference_working_repo() throws IOException, InterruptedException {
+    public void test_clone_reference_working_repo() throws Exception {
         assertThat(new File(SRC_DIR + File.separator + ".git"), is(anExistingDirectory()));
         final File shallowFile = new File(SRC_DIR + File.separator + ".git" + File.separator + "shallow");
         if (shallowFile.exists()) {
@@ -500,7 +500,7 @@ public class GitClientCloneTest {
     }
 
     private void check_remote_url(WorkspaceWithRepo workspace, GitClient gitClient, final String repositoryName)
-            throws InterruptedException, IOException {
+            throws Exception {
         assertThat("Remote URL", gitClient.getRemoteUrl(repositoryName), is(workspace.localMirror()));
         String remotes = workspace.launchCommand("git", "remote", "-v");
         assertThat("Updated URL", remotes, containsString(workspace.localMirror()));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -21,7 +21,6 @@ import hudson.plugins.git.Branch;
 import hudson.plugins.git.GitException;
 import hudson.util.StreamTaskListener;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -623,7 +622,7 @@ public class GitClientFetchTest {
     }
 
     private void check_remote_url(WorkspaceWithRepo workspace, GitClient gitClient, final String repositoryName)
-            throws InterruptedException, IOException {
+            throws Exception {
         assertThat("Wrong remote URL", gitClient.getRemoteUrl(repositoryName), is(workspace.localMirror()));
         String remotes = workspace.launchCommand("git", "remote", "-v");
         assertThat("remote URL has not been updated", remotes.contains(workspace.localMirror()), is(true));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientMaintenanceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientMaintenanceTest.java
@@ -14,7 +14,6 @@ import static org.hamcrest.io.FileMatchers.anExistingDirectory;
 
 import hudson.EnvVars;
 import hudson.model.TaskListener;
-import hudson.plugins.git.GitException;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -151,7 +150,7 @@ public class GitClientMaintenanceTest {
     private boolean looseObjectsSupported = true;
 
     @Before
-    public void setGitClient() throws IOException, InterruptedException {
+    public void setGitClient() throws Exception {
         repoRoot = tempFolder.newFolder();
         handler = new LogHandler();
         TaskListener listener = newListener(handler);
@@ -232,7 +231,7 @@ public class GitClientMaintenanceTest {
         return headList.get(0);
     }
 
-    private void createFile(String path, String content) {
+    private void createFile(String path, String content) throws Exception {
         File aFile = new File(repoRoot, path);
         File parentDir = aFile.getParentFile();
         if (parentDir != null) {
@@ -240,8 +239,6 @@ public class GitClientMaintenanceTest {
         }
         try (PrintWriter writer = new PrintWriter(aFile, StandardCharsets.UTF_8)) {
             writer.printf(content);
-        } catch (IOException ex) {
-            throw new GitException(ex);
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
@@ -10,7 +10,6 @@ import hudson.EnvVars;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitException;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -155,7 +154,7 @@ public class GitClientSecurityTest {
     }
 
     @Before
-    public void setGitClient() throws IOException, InterruptedException {
+    public void setGitClient() throws Exception {
         repoRoot = tempFolder.newFolder();
         gitClient = Git.with(TaskListener.NULL, new EnvVars())
                 .in(repoRoot)

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -117,7 +117,7 @@ public class GitClientTest {
 
     private File repoRoot = null;
 
-    public GitClientTest(final String gitImplName) throws IOException, InterruptedException {
+    public GitClientTest(final String gitImplName) throws Exception {
         this.gitImplName = gitImplName;
         this.srcGitClient = Git.with(TaskListener.NULL, new EnvVars())
                 .in(srcRepoDir)
@@ -288,7 +288,7 @@ public class GitClientTest {
     }
 
     @Before
-    public void setGitClient() throws IOException, InterruptedException {
+    public void setGitClient() throws Exception {
         repoRoot = tempFolder.newFolder();
         gitClient = Git.with(TaskListener.NULL, new EnvVars())
                 .in(repoRoot)
@@ -340,7 +340,7 @@ public class GitClientTest {
         return headList.get(0);
     }
 
-    private void createFile(String path, String content) {
+    private void createFile(String path, String content) throws Exception {
         File aFile = new File(repoRoot, path);
         File parentDir = aFile.getParentFile();
         if (parentDir != null) {
@@ -348,8 +348,6 @@ public class GitClientTest {
         }
         try (PrintWriter writer = new PrintWriter(aFile, StandardCharsets.UTF_8)) {
             writer.printf(content);
-        } catch (IOException ex) {
-            throw new GitException(ex);
         }
     }
 
@@ -593,7 +591,7 @@ public class GitClientTest {
     }
 
     @Test
-    public void testGetRepository() {
+    public void testGetRepository() throws Exception {
         File expectedRepo = new File(repoRoot, ".git");
         assertEquals(expectedRepo, gitClient.getRepository().getDirectory());
     }
@@ -789,7 +787,7 @@ public class GitClientTest {
                 actual.contains(expectedSubstring));
     }
 
-    private IGitAPI IGitAPIForTrueBareRepositoryTests() throws IOException, InterruptedException {
+    private IGitAPI IGitAPIForTrueBareRepositoryTests() throws Exception {
         // provides iGitAPI with bare repository initialization
         File repoRootTemp = tempFolder.newFolder();
         GitClient gitClientTemp = Git.with(TaskListener.NULL, new EnvVars())
@@ -806,14 +804,14 @@ public class GitClientTest {
 
     @Test
     @Deprecated
-    public void testIsBareRepositoryBareDot() throws InterruptedException, IOException {
+    public void testIsBareRepositoryBareDot() throws Exception {
         IGitAPI gitAPI = IGitAPIForTrueBareRepositoryTests();
         assertTrue(". is not a bare repository", gitAPI.isBareRepository("."));
     }
 
     @Test
     @Deprecated
-    public void testIsBareRepositoryWorkingDotGit() throws IOException, InterruptedException {
+    public void testIsBareRepositoryWorkingDotGit() throws Exception {
         gitClient.init_().workspace(repoRoot.getAbsolutePath()).bare(true).execute();
         IGitAPI gitAPI = (IGitAPI) gitClient;
         FilePath gitClientFilePath = gitClient.getWorkTree();
@@ -825,7 +823,7 @@ public class GitClientTest {
 
     @Test
     @Deprecated
-    public void testIsBareRepositoryBareDotGit() throws IOException, InterruptedException {
+    public void testIsBareRepositoryBareDotGit() throws Exception {
         IGitAPI gitAPI = IGitAPIForTrueBareRepositoryTests();
         /* Bare repository does not have a .git directory.  This is
          * another no-such-location test but is included here for
@@ -849,7 +847,7 @@ public class GitClientTest {
 
     @Test
     @Deprecated
-    public void testIsBareRepositoryWorkingNoSuchLocation() throws IOException, InterruptedException {
+    public void testIsBareRepositoryWorkingNoSuchLocation() throws Exception {
         gitClient.init_().workspace(repoRoot.getAbsolutePath()).bare(true).execute();
         IGitAPI gitAPI = (IGitAPI) gitClient;
         FilePath gitClientFilePath = gitClient.getWorkTree();
@@ -869,7 +867,7 @@ public class GitClientTest {
 
     @Test
     @Deprecated
-    public void testIsBareRepositoryBareNoSuchLocation() throws IOException, InterruptedException {
+    public void testIsBareRepositoryBareNoSuchLocation() throws Exception {
         IGitAPI gitAPI = IGitAPIForTrueBareRepositoryTests();
         try {
             assertTrue("non-existent location is in a bare repository", gitAPI.isBareRepository("no-such-location"));
@@ -884,14 +882,14 @@ public class GitClientTest {
 
     @Deprecated
     @Test
-    public void testIsBareRepositoryBareEmptyString() throws IOException, InterruptedException {
+    public void testIsBareRepositoryBareEmptyString() throws Exception {
         IGitAPI gitAPI = IGitAPIForTrueBareRepositoryTests();
         assertTrue("empty string is not a bare repository", gitAPI.isBareRepository(""));
     }
 
     @Deprecated
     @Test
-    public void testIsBareRepositoryWorkingEmptyString() throws IOException, InterruptedException {
+    public void testIsBareRepositoryWorkingEmptyString() throws Exception {
         gitClient.init_().workspace(repoRoot.getAbsolutePath()).bare(true).execute();
         IGitAPI gitAPI = (IGitAPI) gitClient;
         FilePath gitClientFilePath = gitClient.getWorkTree();
@@ -903,14 +901,14 @@ public class GitClientTest {
 
     @Deprecated
     @Test
-    public void testIsBareRepositoryBareNoArg() throws IOException, InterruptedException {
+    public void testIsBareRepositoryBareNoArg() throws Exception {
         IGitAPI gitAPI = IGitAPIForTrueBareRepositoryTests();
         assertTrue("no arg is not a bare repository", gitAPI.isBareRepository());
     }
 
     @Deprecated
     @Test
-    public void testIsBareRepositoryWorkingNoArg() throws IOException, InterruptedException {
+    public void testIsBareRepositoryWorkingNoArg() throws Exception {
         gitClient.init_().workspace(repoRoot.getAbsolutePath()).bare(true).execute();
         IGitAPI gitAPI = (IGitAPI) gitClient;
         FilePath gitClientFilePath = gitClient.getWorkTree();
@@ -921,7 +919,7 @@ public class GitClientTest {
     }
 
     @Test
-    public void testBareRepoInit() throws IOException, InterruptedException {
+    public void testBareRepoInit() throws Exception {
         IGitAPI gitAPI = IGitAPIForTrueBareRepositoryTests();
         File tempDir = gitAPI.withRepository((repo, channel) -> repo.getWorkTree());
         File gitFile = new File(tempDir, ".git");
@@ -940,7 +938,7 @@ public class GitClientTest {
 
     @Deprecated
     @Test
-    public void testIsBareRepositoryWorkingRepoPathDotGit() throws IOException, InterruptedException {
+    public void testIsBareRepositoryWorkingRepoPathDotGit() throws Exception {
         gitClient.init_().workspace(repoRoot.getAbsolutePath()).bare(true).execute();
         IGitAPI gitAPI = (IGitAPI) gitClient;
         FilePath gitClientFilePath = gitClient.getWorkTree();
@@ -954,7 +952,7 @@ public class GitClientTest {
 
     @Deprecated
     @Test
-    public void testIsBareRepositoryWorkingNull() throws IOException, InterruptedException {
+    public void testIsBareRepositoryWorkingNull() throws Exception {
         gitClient.init_().workspace(repoRoot.getAbsolutePath()).bare(true).execute();
         IGitAPI gitAPI = (IGitAPI) gitClient;
         FilePath gitClientFilePath = gitClient.getWorkTree();
@@ -971,7 +969,7 @@ public class GitClientTest {
 
     @Deprecated
     @Test
-    public void testIsBareRepositoryBareNull() throws IOException, InterruptedException {
+    public void testIsBareRepositoryBareNull() throws Exception {
         IGitAPI gitAPI = IGitAPIForTrueBareRepositoryTests();
         try {
             assertTrue("null is not a bare repository", gitAPI.isBareRepository(null));
@@ -983,7 +981,7 @@ public class GitClientTest {
 
     @Deprecated
     @Test
-    public void test_isBareRepository_bare_repoPath() throws IOException, InterruptedException {
+    public void test_isBareRepository_bare_repoPath() throws Exception {
         IGitAPI gitAPI = IGitAPIForTrueBareRepositoryTests();
         File tempRepoDir = gitAPI.withRepository((repo, channel) -> repo.getWorkTree());
         File dotFile = new File(tempRepoDir, ".");
@@ -1086,7 +1084,7 @@ public class GitClientTest {
         assertThat(refNames, contains("refs/heads/" + defaultBranchName));
     }
 
-    private static FilePath getClientTmpFilePath(GitClient gitClientTemp) throws IOException, InterruptedException {
+    private static FilePath getClientTmpFilePath(GitClient gitClientTemp) throws Exception {
         CliGitCommand gitCmd = new CliGitCommand(gitClientTemp);
         gitCmd.initializeRepository("Vojtěch GitClientTest temp Zweibrücken-Šafařík", "email.by.client@example.com");
         FilePath gitClientFilePath = gitClientTemp.getWorkTree();
@@ -2452,7 +2450,7 @@ public class GitClientTest {
      * than 256 characters and that the checkout operation will
      * attempt to create a directory path greater than 256 characters.
      */
-    private void enableLongPaths(GitClient gitClient) throws InterruptedException {
+    private void enableLongPaths(GitClient gitClient) throws Exception {
         CliGitAPIImpl cliGitClient;
         if (gitClient instanceof CliGitAPIImpl && isWindows()) {
             /* Enable core.longpaths prior to fetch on Windows -
@@ -3322,7 +3320,7 @@ public class GitClientTest {
     }
 
     @Test
-    public void test_git_branch_with_line_breaks_and_long_strings() {
+    public void test_git_branch_with_line_breaks_and_long_strings() throws Exception {
         if (!gitImplName.equals("git")) {
             return;
         }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertTrue;
 
 import hudson.FilePath;
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import org.eclipse.jgit.lib.ObjectId;
@@ -37,7 +36,7 @@ public class GitTest {
     }
 
     @Test
-    public void testWith() throws IOException, InterruptedException {
+    public void testWith() throws Exception {
         Git git = Git.with(null, null);
         assertTrue("Wrong default client type", git.getClient() instanceof JGitAPIImpl);
         assertTrue("Missing expected commit", git.getClient().isCommitInRepo(expectedCommit));
@@ -51,14 +50,14 @@ public class GitTest {
     }
 
     @Test
-    public void testIn_File() throws IOException, InterruptedException {
+    public void testIn_File() throws Exception {
         Git git = new Git(null, null).in(new File("."));
         assertTrue("Wrong client type", git.getClient() instanceof JGitAPIImpl);
         assertTrue("Missing expected commit", git.getClient().isCommitInRepo(expectedCommit));
     }
 
     @Test
-    public void testIn_FileUsing() throws IOException, InterruptedException {
+    public void testIn_FileUsing() throws Exception {
         Git git = new Git(null, null).in(new File(".")).using(implementation);
         assertTrue(
                 "Wrong client type",
@@ -69,14 +68,14 @@ public class GitTest {
     }
 
     @Test
-    public void testIn_FilePath() throws IOException, InterruptedException {
+    public void testIn_FilePath() throws Exception {
         Git git = new Git(null, null).in(new FilePath(new File(".")));
         assertTrue("Wrong client type", git.getClient() instanceof JGitAPIImpl);
         assertTrue("Missing expected commit", git.getClient().isCommitInRepo(expectedCommit));
     }
 
     @Test
-    public void testIn_FilePathUsing() throws IOException, InterruptedException {
+    public void testIn_FilePathUsing() throws Exception {
         Git git = new Git(null, null).in(new File(".")).using(implementation);
         assertTrue(
                 "Wrong client type",
@@ -87,7 +86,7 @@ public class GitTest {
     }
 
     @Test
-    public void testUsing() throws IOException, InterruptedException {
+    public void testUsing() throws Exception {
         Git git = new Git(null, null).using(implementation);
         assertTrue(
                 "Wrong client type",

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitLightweightTagTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitLightweightTagTest.java
@@ -47,7 +47,7 @@ public class JGitLightweightTagTest {
     private File repoRootGitDir; // .git directory in temporary repository
 
     @Before
-    public void setGitClientEtc() throws IOException, InterruptedException {
+    public void setGitClientEtc() throws Exception {
         repoRoot = tempFolder.newFolder();
         gitClient = Git.with(TaskListener.NULL, new EnvVars())
                 .in(repoRoot)

--- a/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImplTest.java
@@ -10,13 +10,11 @@ import hudson.plugins.git.Tag;
 import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import org.eclipse.jgit.errors.ConfigInvalidException;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.transport.RemoteConfig;
@@ -71,7 +69,7 @@ public class LegacyCompatibleGitAPIImplTest {
     }
 
     @Before
-    public void setUp() throws IOException, InterruptedException {
+    public void setUp() throws Exception {
         repo = tempFolder.newFolder();
         assertNotGitRepo(repo);
         git = (LegacyCompatibleGitAPIImpl)
@@ -103,8 +101,7 @@ public class LegacyCompatibleGitAPIImplTest {
 
     @Test
     @Deprecated
-    public void testCloneRemoteConfig()
-            throws URISyntaxException, InterruptedException, IOException, ConfigInvalidException {
+    public void testCloneRemoteConfig() throws Exception {
         if (gitImpl.equals("jgit")) {
             return;
         }
@@ -125,14 +122,14 @@ public class LegacyCompatibleGitAPIImplTest {
 
     @Test
     @Deprecated
-    public void testHasGitModules_default_ignored_arg() {
+    public void testHasGitModules_default_ignored_arg() throws Exception {
         assertFalse((new File(repo, ".gitmodules")).exists());
         assertFalse(git.hasGitModules("ignored treeIsh argument 1"));
     }
 
     @Test
     @Deprecated
-    public void testHasGitModules_default_no_arg() {
+    public void testHasGitModules_default_no_arg() throws Exception {
         assertFalse((new File(repo, ".gitmodules")).exists());
         assertFalse(git.hasGitModules());
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/MergeCommandTest.java
@@ -83,7 +83,7 @@ public class MergeCommandTest {
     }
 
     @Before
-    public void createMergeTestRepo() throws IOException, InterruptedException {
+    public void createMergeTestRepo() throws Exception {
         EnvVars env = new hudson.EnvVars();
         TaskListener listener = StreamTaskListener.fromStdout();
         File repo = tempFolder.newFolder();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/NetrcTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/NetrcTest.java
@@ -106,19 +106,19 @@ public class NetrcTest {
     }
 
     @Test
-    public void testGetInstanceString() {
+    public void testGetInstanceString() throws Exception {
         Netrc netrc = Netrc.getInstance(testFilePath_1);
         assertNotNull(netrc);
     }
 
     @Test
-    public void testGetInstanceFile() {
+    public void testGetInstanceFile() throws Exception {
         Netrc netrc = Netrc.getInstance(new File(testFilePath_1));
         assertNotNull(netrc);
     }
 
     @Test
-    public void testGetCredentialsPath() {
+    public void testGetCredentialsPath() throws Exception {
         Netrc netrc = Netrc.getInstance(testFilePath_1);
         assertNotNull(netrc);
 
@@ -142,7 +142,7 @@ public class NetrcTest {
     }
 
     @Test
-    public void testGetCredentialsFile() {
+    public void testGetCredentialsFile() throws Exception {
         Netrc netrc = Netrc.getInstance(new File(testFilePath_1));
         assertNotNull(netrc);
 
@@ -166,7 +166,7 @@ public class NetrcTest {
     }
 
     @Test
-    public void testGetCredentialsModifyFile() throws IOException {
+    public void testGetCredentialsModifyFile() throws Exception {
         String testFilePath = testFilePath_1 + "_m";
 
         copyFileContents(testFilePath_1, testFilePath);
@@ -213,7 +213,7 @@ public class NetrcTest {
     }
 
     @Test
-    public void testGetCredentialsOtherFile() {
+    public void testGetCredentialsOtherFile() throws Exception {
         Netrc netrc = Netrc.getInstance(testFilePath_1);
         assertNotNull(netrc);
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
@@ -147,7 +147,7 @@ public class PushTest {
     }
 
     @Before
-    public void createWorkingRepository() throws IOException, InterruptedException {
+    public void createWorkingRepository() throws Exception {
         hudson.EnvVars env = new hudson.EnvVars();
         TaskListener listener = StreamTaskListener.fromStderr();
         workingRepo = temporaryFolder.newFolder();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/RemoteGitImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/RemoteGitImplTest.java
@@ -121,14 +121,14 @@ public class RemoteGitImplTest {
     }
 
     @Test
-    public void testSetAuthor_String_String() {
+    public void testSetAuthor_String_String() throws Exception {
         String name = "charlie";
         String email = "charlie@example.com";
         remoteGit.setAuthor(name, email);
     }
 
     @Test
-    public void testSetAuthor_PersonIdent() {
+    public void testSetAuthor_PersonIdent() throws Exception {
         String name = "charlie";
         String email = "charlie@example.com";
         PersonIdent p = new PersonIdent(name, email);
@@ -136,14 +136,14 @@ public class RemoteGitImplTest {
     }
 
     @Test
-    public void testSetCommitter_String_String() {
+    public void testSetCommitter_String_String() throws Exception {
         String name = "charlie";
         String email = "charlie@example.com";
         remoteGit.setCommitter(name, email);
     }
 
     @Test
-    public void testSetCommitter_PersonIdent() {
+    public void testSetCommitter_PersonIdent() throws Exception {
         String name = "charlie";
         String email = "charlie@example.com";
         PersonIdent p = new PersonIdent(name, email);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/WarnTempDirValueTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/WarnTempDirValueTest.java
@@ -84,7 +84,7 @@ public class WarnTempDirValueTest {
     }
 
     @Test
-    public void noWarningForDefaultValue() throws IOException, InterruptedException {
+    public void noWarningForDefaultValue() throws Exception {
         EnvVars env = new hudson.EnvVars();
         assertFalse(env.get(envVarName, "/tmp").contains(" "));
         GitClient git = Git.with(listener, env).in(repo).using("git").getClient();
@@ -94,7 +94,7 @@ public class WarnTempDirValueTest {
 
     @Test
     @Issue("JENKINS-22706")
-    public void warnWhenValueContainsSpaceCharacter() throws IOException, InterruptedException {
+    public void warnWhenValueContainsSpaceCharacter() throws Exception {
         EnvVars env = new hudson.EnvVars();
         assertFalse(env.get(envVarName, "/tmp").contains(" "));
         env.put(envVarName, "/tmp/has a space/");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/WorkspaceWithRepo.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/WorkspaceWithRepo.java
@@ -8,6 +8,7 @@ import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -166,7 +167,7 @@ public class WorkspaceWithRepo {
         return output;
     }
 
-    void initBareRepo(GitClient gitClient, boolean bare) throws InterruptedException {
+    void initBareRepo(GitClient gitClient, boolean bare) throws GitException, InterruptedException {
         gitClient.init_().workspace(gitFileDir.getAbsolutePath()).bare(bare).execute();
     }
 
@@ -206,7 +207,7 @@ public class WorkspaceWithRepo {
                 Git.with(listener, new EnvVars()).in(gitFileDir).using("jgit").getClient();
     }
 
-    ObjectId head() throws IOException, InterruptedException {
+    ObjectId head() throws GitException, IOException, InterruptedException {
         return gitClient.revParse("HEAD");
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/cgit/GitCommandsExecutorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/cgit/GitCommandsExecutorTest.java
@@ -172,6 +172,8 @@ public class GitCommandsExecutorTest {
                 new GitCommandsExecutor(threads, listener).invokeAll(commands);
             } catch (InterruptedException e) {
                 isCallerInterrupted.set(true);
+            } catch (GitException x) {
+                throw new AssertionError(x);
             }
         });
 


### PR DESCRIPTION
I noticed that methods were not consistently marked as throwing `GitException` even when they in fact could. Fixed by temporarily making this extend `Exception` rather than `RuntimeException` and then fixing resulting compiler errors.