### PR TITLE
Use JGit 7.0.0, require Java 17 and Jenkins 2.463 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,15 +58,19 @@
   </scm>
 
   <properties>
-    <revision>5.0.1</revision>
+    <revision>6.0.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- Character set tests fail unless file.encoding is set -->
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.440</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <jgit.version>6.10.0.202406032230-r</jgit.version>
+    <jenkins.baseline>2.462</jenkins.baseline>
+    <!-- TODO Replace with the standard jenkins.baseline references after LTS requires Java 17  -->
+    <!-- <jenkins.version>${jenkins.baseline}.1</jenkins.version> -->
+    <jenkins.version>2.463</jenkins.version>
+    <jgit.version>7.0.0.202409031743-r</jgit.version>
+    <!-- TODO JENKINS-73339 until in parent POM -->
+    <maven.compiler.release>17</maven.compiler.release>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>


### PR DESCRIPTION
## Use JGit 7.0.0, require Java 17 and Jenkins 2.463 or newer

JGit 7.0.0 requires Java 17.  Jenkins 2.463 requires Java 17.

Use the plugin bill of materials from 2.462.x because it is the closest we have to 2.463.  The plugin is expected to work with any release 2.463 or later.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-client-plugin/blob/master/CONTRIBUTING.adoc) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No Javadoc warnings were introduced with my changes
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)
