### PR TITLE
Use Java 17 features in source code

### DIFF
--- a/src/main/java/hudson/plugins/git/Branch.java
+++ b/src/main/java/hudson/plugins/git/Branch.java
@@ -39,7 +39,7 @@ public class Branch extends GitObject {
      */
     @Override
     public String toString() {
-        return String.format("Branch %s(%s)", name, getSHA1String());
+        return "Branch %s(%s)".formatted(name, getSHA1String());
     }
 
     /**

--- a/src/main/java/hudson/plugins/git/IndexEntry.java
+++ b/src/main/java/hudson/plugins/git/IndexEntry.java
@@ -91,7 +91,7 @@ public class IndexEntry implements Serializable {
      */
     @Override
     public String toString() {
-        return String.format("IndexEntry[mode=%s,type=%s,file=%s,object=%s]", mode, type, file, object);
+        return "IndexEntry[mode=%s,type=%s,file=%s,object=%s]".formatted(mode, type, file, object);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -30,7 +30,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
@@ -1976,7 +1975,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return createTempFileInSystemDir(prefix, suffix);
             }
         }
-        Path tmpPath = Paths.get(workspaceTmp.getAbsolutePath());
+        Path tmpPath = Path.of(workspaceTmp.getAbsolutePath());
         if (workspaceTmp.getAbsolutePath().contains("%")) {
             // Avoid ssh token expansion on all platforms
             return createTempFileInSystemDir(prefix, suffix);
@@ -2098,8 +2097,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
         }
         try {
-            if (credentials instanceof SSHUserPrivateKey) {
-                SSHUserPrivateKey sshUser = (SSHUserPrivateKey) credentials;
+            if (credentials instanceof SSHUserPrivateKey sshUser) {
                 listener.getLogger().println("using GIT_SSH to set credentials " + sshUser.getDescription());
 
                 key = createSshKeyFile(sshUser);
@@ -2130,8 +2128,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     env.put("DISPLAY", ":");
                 }
 
-            } else if (credentials instanceof StandardUsernamePasswordCredentials) {
-                StandardUsernamePasswordCredentials userPass = (StandardUsernamePasswordCredentials) credentials;
+            } else if (credentials instanceof StandardUsernamePasswordCredentials userPass) {
                 listener.getLogger().println("using GIT_ASKPASS to set credentials " + userPass.getDescription());
 
                 usernameFile = createUsernameFile(userPass);
@@ -2207,7 +2204,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         // "untrusted" key files.
         // Check that tools exist and then if SELinux subsystem is activated
         // Otherwise calling the tools just pollutes build log with errors
-        if (Files.isExecutable(Paths.get("/usr/bin/chcon"))) {
+        if (Files.isExecutable(Path.of("/usr/bin/chcon"))) {
             // SELinux may actually forbid us to read system paths, so
             // there are a couple of ways to try checking if it is enabled
             // (whether this run needs to worry about security labels) and
@@ -2222,10 +2219,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             try {
                 // A process should always have rights to inspect itself, but
                 // on some systems even this read returns "Invalid argument"
-                if (Files.isRegularFile(Paths.get("/proc/self/attr/current"))) {
+                if (Files.isRegularFile(Path.of("/proc/self/attr/current"))) {
                     String s;
                     try (BufferedReader br =
-                            Files.newBufferedReader(Paths.get("/proc/self/attr/current"), StandardCharsets.UTF_8)) {
+                            Files.newBufferedReader(Path.of("/proc/self/attr/current"), StandardCharsets.UTF_8)) {
                         s = br.readLine();
                     }
                     if ("unconfined".equals(s)) {
@@ -2244,16 +2241,16 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             try {
-                if (!Files.isDirectory(Paths.get("/sys/fs/selinux"))) {
+                if (!Files.isDirectory(Path.of("/sys/fs/selinux"))) {
                     // Assuming that lack of rights to read this is an
                     // exception caught below, not a false return here?
                     return true;
                 }
 
-                if (Files.isRegularFile(Paths.get("/sys/fs/selinux/enforce"))) {
+                if (Files.isRegularFile(Path.of("/sys/fs/selinux/enforce"))) {
                     String s;
                     try (BufferedReader br =
-                            Files.newBufferedReader(Paths.get("/sys/fs/selinux/enforce"), StandardCharsets.UTF_8)) {
+                            Files.newBufferedReader(Path.of("/sys/fs/selinux/enforce"), StandardCharsets.UTF_8)) {
                         s = br.readLine();
                     }
                     if ("0".equals(s)) {
@@ -2292,10 +2289,13 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             if (!clue_sysfs && !clue_proc) { // && !clue_ls
                 listener.getLogger()
-                        .println("[INFO] SELinux is present on the host "
-                                + "and we could not confirm that it does not apply actively: "
-                                + "will try to relabel temporary files now; this may complain "
-                                + "if context labeling not applicable after all");
+                        .println(
+                                """
+                                [INFO] SELinux is present on the host \
+                                and we could not confirm that it does not apply actively: \
+                                will try to relabel temporary files now; this may complain \
+                                if context labeling not applicable after all\
+                                """);
             }
 
             ArgumentListBuilder args = new ArgumentListBuilder();
@@ -2721,7 +2721,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     private Path createNonBusyExecutable(Path p) throws IOException {
         p.toFile().setExecutable(true, true);
-        Path p_copy = Paths.get(p.toString() + "-copy");
+        Path p_copy = Path.of(p.toString() + "-copy");
 
         // JENKINS-48258 git client plugin occasionally fails with "text file busy" error
         // The following creates a copy of the generated file and deletes the original

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitToolConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitToolConfigurator.java
@@ -101,8 +101,7 @@ public class GitToolConfigurator extends BaseConfigurator<GitTool> {
             return toolProperties;
         }
         final Configurator<ToolProperty> configurator = context.lookupOrFail(ToolProperty.class);
-        if (props instanceof Sequence) {
-            Sequence s = (Sequence) props;
+        if (props instanceof Sequence s) {
             for (CNode cNode : s) {
                 toolProperties.add(configurator.configure(cNode, context));
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -41,7 +41,6 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -236,7 +235,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 .setConfigStoreFactory((homeDir, configFile, localUserName) -> {
                     String configFilePath = SystemProperties.getString(SSH_CONFIG_PATH);
                     if (configFilePath != null) {
-                        Path path = Paths.get(configFilePath);
+                        Path path = Path.of(configFilePath);
                         homeDir = path.toFile().getParentFile();
                         configFile = path.toFile();
                     }
@@ -955,8 +954,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     private TransportConfigCallback getTransportConfigCallback() {
         return transport -> {
-            if (transport instanceof SshTransport) {
-                ((SshTransport) transport).setSshSessionFactory(buildSshdSessionFactory(this.hostKeyVerifierFactory));
+            if (transport instanceof SshTransport sshTransport) {
+                sshTransport.setSshSessionFactory(buildSshdSessionFactory(this.hostKeyVerifierFactory));
             }
             if (transport instanceof HttpTransport) {
                 ((TransportHttp) transport)
@@ -966,8 +965,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private void decorateTransport(Transport tn) {
-        if (tn instanceof SshTransport) {
-            ((SshTransport) tn).setSshSessionFactory(buildSshdSessionFactory(getHostKeyFactory()));
+        if (tn instanceof SshTransport transport) {
+            transport.setSshSessionFactory(buildSshdSessionFactory(getHostKeyFactory()));
         }
         if (tn instanceof HttpTransport) {
             ((TransportHttp) tn).setHttpConnectionFactory(new PreemptiveAuthHttpClientConnectionFactory(getProvider()));
@@ -2239,7 +2238,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                             case 0: // for the source ref. we use the repository to determine what should be pushed
                                 Ref ref = repository.findRef(specs[spec]);
                                 if (ref == null) {
-                                    throw new IOException(String.format("Ref %s not found.", specs[spec]));
+                                    throw new IOException("Ref %s not found.".formatted(specs[spec]));
                                 }
                                 specs[spec] = ref.getTarget().getName();
                                 break;
@@ -2947,11 +2946,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 }
 
                 public String describe(ObjectId tip) throws IOException {
-                    return String.format(
-                            "%s-%d-g%s",
-                            tag.getName().substring(R_TAGS.length()),
-                            depth,
-                            or.abbreviate(tip).name());
+                    return "%s-%d-g%s"
+                            .formatted(
+                                    tag.getName().substring(R_TAGS.length()),
+                                    depth,
+                                    or.abbreviate(tip).name());
                 }
             }
             List<Candidate> candidates = new ArrayList<>(); // all the candidates we find
@@ -3049,7 +3048,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             while (tree.next()) {
                 RevObject rev = w.parseAny(tree.getObjectId(0));
                 r.add(new IndexEntry(
-                        String.format("%06o", tree.getRawMode(0)),
+                        "%06o".formatted(tree.getRawMode(0)),
                         typeString(rev.getType()),
                         tree.getObjectId(0).name(),
                         tree.getNameString()));

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -79,11 +79,11 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
                 parameterTypes[i] = paramTypes[i].getName();
             }
             for (int i = 0; i < args.length; i++) {
-                if (args[i] instanceof OutputStream) {
-                    args[i] = new RemoteOutputStream((OutputStream) args[i]);
+                if (args[i] instanceof OutputStream stream) {
+                    args[i] = new RemoteOutputStream(stream);
                 }
-                if (args[i] instanceof Writer) {
-                    args[i] = new RemoteWriter((Writer) args[i]);
+                if (args[i] instanceof Writer writer) {
+                    args[i] = new RemoteWriter(writer);
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/jgit/CredentialsProviderImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/jgit/CredentialsProviderImpl.java
@@ -85,18 +85,17 @@ public class CredentialsProviderImpl extends CredentialsProvider {
         StandardUsernamePasswordCredentials _cred = (StandardUsernamePasswordCredentials) cred;
 
         for (CredentialItem i : items) {
-            if (i instanceof CredentialItem.Username) {
-                ((CredentialItem.Username) i).setValue(_cred.getUsername());
+            if (i instanceof CredentialItem.Username username) {
+                username.setValue(_cred.getUsername());
                 continue;
             }
-            if (i instanceof CredentialItem.Password) {
-                ((CredentialItem.Password) i)
-                        .setValue(_cred.getPassword().getPlainText().toCharArray());
+            if (i instanceof CredentialItem.Password password) {
+                password.setValue(_cred.getPassword().getPlainText().toCharArray());
                 continue;
             }
-            if (i instanceof CredentialItem.StringType) {
+            if (i instanceof CredentialItem.StringType type) {
                 if (i.getPromptText().equals("Password: ")) {
-                    ((CredentialItem.StringType) i).setValue(_cred.getPassword().getPlainText());
+                    type.setValue(_cred.getPassword().getPlainText());
                     continue;
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/jgit/PreemptiveAuthHttpClientConnection.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/jgit/PreemptiveAuthHttpClientConnection.java
@@ -261,8 +261,7 @@ public class PreemptiveAuthHttpClientConnection implements HttpConnection {
     private static void configureProxy(final HttpClientBuilder builder, final Proxy proxy) {
         if (proxy != null && !Proxy.NO_PROXY.equals(proxy)) {
             final SocketAddress socketAddress = proxy.address();
-            if (socketAddress instanceof InetSocketAddress) {
-                final InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
+            if (socketAddress instanceof InetSocketAddress inetSocketAddress) {
                 final String proxyHost = inetSocketAddress.getHostName();
                 final int proxyPort = inetSocketAddress.getPort();
                 final HttpHost httpHost = new HttpHost(proxyHost, proxyPort);
@@ -310,8 +309,7 @@ public class PreemptiveAuthHttpClientConnection implements HttpConnection {
     private void execute() throws IOException {
         if (resp == null) {
             if (entity != null) {
-                if (req instanceof HttpEntityEnclosingRequest) {
-                    HttpEntityEnclosingRequest eReq = (HttpEntityEnclosingRequest) req;
+                if (req instanceof HttpEntityEnclosingRequest eReq) {
                     eReq.setEntity(entity);
                 }
                 resp = getClient().execute(req);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/jgit/SmartCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/jgit/SmartCredentialsProvider.java
@@ -156,26 +156,23 @@ public class SmartCredentialsProvider extends CredentialsProvider {
             return false;
         }
         for (CredentialItem i : credentialItems) {
-            if (i instanceof StandardUsernameCredentialsCredentialItem && c instanceof StandardUsernameCredentials) {
-                ((StandardUsernameCredentialsCredentialItem) i).setValue((StandardUsernameCredentials) c);
+            if (i instanceof StandardUsernameCredentialsCredentialItem item
+                    && c instanceof StandardUsernameCredentials credentials) {
+                item.setValue(credentials);
                 continue;
             }
-            if (i instanceof CredentialItem.Username && c instanceof UsernameCredentials) {
-                ((CredentialItem.Username) i).setValue(((UsernameCredentials) c).getUsername());
+            if (i instanceof CredentialItem.Username username && c instanceof UsernameCredentials credentials) {
+                username.setValue(credentials.getUsername());
                 continue;
             }
-            if (i instanceof CredentialItem.Password && c instanceof PasswordCredentials) {
-                ((CredentialItem.Password) i)
-                        .setValue(((PasswordCredentials) c)
-                                .getPassword()
-                                .getPlainText()
-                                .toCharArray());
+            if (i instanceof CredentialItem.Password password && c instanceof PasswordCredentials credentials) {
+                password.setValue(credentials.getPassword().getPlainText().toCharArray());
                 continue;
             }
             if (i instanceof CredentialItem.StringType) {
-                if (i.getPromptText().equals("Password: ") && c instanceof PasswordCredentials) {
+                if (i.getPromptText().equals("Password: ") && c instanceof PasswordCredentials credentials) {
                     ((CredentialItem.StringType) i)
-                            .setValue(((PasswordCredentials) c).getPassword().getPlainText());
+                            .setValue(credentials.getPassword().getPlainText());
                     continue;
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifier.java
@@ -65,12 +65,15 @@ public class KnownHostsFileVerifier extends HostKeyVerifierFactory {
 
     private void logHint(TaskListener listener) {
         listener.getLogger()
-                .println(HyperlinkNote.encodeTo(
-                        "https://plugins.jenkins.io/git-client/#plugin-content-ssh-host-key-verification",
-                        "You're using 'Known hosts file' strategy to verify ssh host keys,"
-                                + " but your known_hosts file does not exist, please go to "
-                                + "'Manage Jenkins' -> 'Security' -> 'Git Host Key Verification Configuration' "
-                                + "and configure host key verification."));
+                .println(
+                        HyperlinkNote.encodeTo(
+                                "https://plugins.jenkins.io/git-client/#plugin-content-ssh-host-key-verification",
+                                """
+                        You're using 'Known hosts file' strategy to verify ssh host keys,\
+                         but your known_hosts file does not exist, please go to \
+                        'Manage Jenkins' -> 'Security' -> 'Git Host Key Verification Configuration' \
+                        and configure host key verification.\
+                        """));
         LOGGER.log(
                 Level.FINEST,
                 "Known hosts file {0} not found, but verifying host keys with known hosts file",

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifier.java
@@ -34,11 +34,11 @@ public class ManuallyProvidedKeyVerifier extends HostKeyVerifierFactory {
             if (File.pathSeparatorChar
                     == ';') { // check whether on Windows or not without sending Functions over remoting
                 // no escaping for windows because created temp file can't contain spaces
-                userKnownHostsFileFlag = String.format(" -o UserKnownHostsFile=%s", escapePath(tempKnownHosts));
+                userKnownHostsFileFlag = " -o UserKnownHostsFile=%s".formatted(escapePath(tempKnownHosts));
             } else {
                 // escaping needed in case job name contains spaces
                 userKnownHostsFileFlag =
-                        String.format(" -o UserKnownHostsFile=\\\"\"\"%s\\\"\"\"", escapePath(tempKnownHosts));
+                        " -o UserKnownHostsFile=\\\"\"\"%s\\\"\"\"".formatted(escapePath(tempKnownHosts));
             }
             return "-o StrictHostKeyChecking=yes " + userKnownHostsFileFlag;
         };

--- a/src/main/java/org/jenkinsci/plugins/gitclient/verifier/SshHostKeyVerificationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/verifier/SshHostKeyVerificationStrategy.java
@@ -4,7 +4,7 @@ import hudson.ExtensionPoint;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import java.io.File;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
@@ -12,7 +12,7 @@ public abstract class SshHostKeyVerificationStrategy<T extends HostKeyVerifierFa
         extends AbstractDescribableImpl<SshHostKeyVerificationStrategy<T>> implements ExtensionPoint {
 
     public static final String KNOWN_HOSTS_DEFAULT =
-            Paths.get(System.getProperty("user.home"), ".ssh", "known_hosts").toString();
+            Path.of(System.getProperty("user.home"), ".ssh", "known_hosts").toString();
     private static final String JGIT_KNOWN_HOSTS_PROPERTY =
             SshHostKeyVerificationStrategy.class.getName() + ".jgit_known_hosts_file";
     private static final String JGIT_KNOWN_HOSTS_FILE_PATH =

--- a/src/test/java/jmh/benchmark/BenchmarkRunner.java
+++ b/src/test/java/jmh/benchmark/BenchmarkRunner.java
@@ -2,7 +2,7 @@ package jmh.benchmark;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import jenkins.benchmark.jmh.BenchmarkFinder;
 import org.junit.Test;
@@ -29,7 +29,7 @@ public class BenchmarkRunner {
     public void runJmhBenchmarks() throws Exception {
         if (!shouldRunBenchmarks()) {
             String msg = "{\"benchmark.run\": false, \"reason\": \"Benchmark not run because benchmark.run is false\"}";
-            Files.write(Paths.get("jmh-report.json"), msg.getBytes(StandardCharsets.UTF_8));
+            Files.write(Path.of("jmh-report.json"), msg.getBytes(StandardCharsets.UTF_8));
             return;
         }
         ChainedOptionsBuilder options = new OptionsBuilder()

--- a/src/test/java/jmh/benchmark/FolderForBenchmark.java
+++ b/src/test/java/jmh/benchmark/FolderForBenchmark.java
@@ -92,8 +92,11 @@ public class FolderForBenchmark {
     private void validateFolderName(String folderName) throws IOException {
         File tempFile = new File(folderName);
         if (tempFile.getParent() != null) {
-            String errorMsg = "Folder name cannot consist of multiple path components separated by a file separator."
-                    + " Please use newFolder('MyParentFolder','MyFolder') to create hierarchies of folders";
+            String errorMsg =
+                    """
+                    Folder name cannot consist of multiple path components separated by a file separator.\
+                     Please use newFolder('MyParentFolder','MyFolder') to create hierarchies of folders\
+                    """;
             throw new IOException(errorMsg);
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/FilePermissionsTest.java
@@ -121,7 +121,7 @@ public class FilePermissionsTest {
     }
 
     private static void verifyFile(File repo, int staticPerm) throws IOException {
-        String fileName = String.format("git-%03o.txt", staticPerm);
+        String fileName = "git-%03o.txt".formatted(staticPerm);
         File file = new File(repo, fileName);
         assertTrue("Missing " + file.getAbsolutePath(), file.exists());
         String content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
@@ -167,7 +167,7 @@ public class FilePermissionsTest {
     }
 
     private String getFileName() {
-        return String.format("git-%03o.txt", permission);
+        return "git-%03o.txt".formatted(permission);
     }
 
     private void addFile() throws IOException, GitException, InterruptedException {
@@ -184,7 +184,7 @@ public class FilePermissionsTest {
         Path path = FileSystems.getDefault().getPath(added.getPath());
         assertEquals(path, Files.setPosixFilePermissions(path, filePerms(permission)));
         git.add(fileName);
-        git.commit(String.format("Perms %03o %s", permission, fileName));
+        git.commit("Perms %03o %s".formatted(permission, fileName));
     }
 
     private void modifyFile() throws IOException, GitException, InterruptedException {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -288,8 +288,8 @@ public abstract class GitAPITestUpdate {
          * JGit impl.
          */
         CliGitAPIImpl cgit() throws Exception {
-            if (git instanceof CliGitAPIImpl) {
-                return (CliGitAPIImpl) git;
+            if (git instanceof CliGitAPIImpl impl) {
+                return impl;
             }
             if (cachedCliGitAPIImpl != null) {
                 return cachedCliGitAPIImpl;
@@ -495,23 +495,24 @@ public abstract class GitAPITestUpdate {
     private void checkGetHeadRev(String remote, String branchSpec, ObjectId expectedObjectId) throws Exception {
         ObjectId actualObjectId = w.git.getHeadRev(remote, branchSpec);
         assertNotNull(
-                String.format(
-                        "Expected ObjectId is null expectedObjectId '%s', remote '%s', branchSpec '%s'.",
-                        expectedObjectId, remote, branchSpec),
+                "Expected ObjectId is null expectedObjectId '%s', remote '%s', branchSpec '%s'."
+                        .formatted(expectedObjectId, remote, branchSpec),
                 expectedObjectId);
         assertNotNull(
-                String.format(
-                        "Actual ObjectId is null. expectedObjectId '%s', remote '%s', branchSpec '%s'.",
-                        expectedObjectId, remote, branchSpec),
+                "Actual ObjectId is null. expectedObjectId '%s', remote '%s', branchSpec '%s'."
+                        .formatted(expectedObjectId, remote, branchSpec),
                 actualObjectId);
         assertEquals(
-                String.format(
-                        "Actual ObjectId differs from expected one for branchSpec '%s', remote '%s':\n"
-                                + "Actual %s,\nExpected %s\n",
-                        branchSpec,
-                        remote,
-                        StringUtils.join(getBranches(actualObjectId), ", "),
-                        StringUtils.join(getBranches(expectedObjectId), ", ")),
+                ("""
+                        Actual ObjectId differs from expected one for branchSpec '%s', remote '%s':
+                        Actual %s,
+                        Expected %s
+                        """)
+                        .formatted(
+                                branchSpec,
+                                remote,
+                                StringUtils.join(getBranches(actualObjectId), ", "),
+                                StringUtils.join(getBranches(expectedObjectId), ", ")),
                 expectedObjectId,
                 actualObjectId);
     }
@@ -1001,9 +1002,11 @@ public abstract class GitAPITestUpdate {
                 .execute();
         List<IndexEntry> r = w.git.getSubmodules("HEAD");
         assertEquals(
-                "[IndexEntry[mode=160000,type=commit,file=modules/firewall,object=978c8b223b33e203a5c766ecf79704a5ea9b35c8], "
-                        + "IndexEntry[mode=160000,type=commit,file=modules/ntp,object=b62fabbc2bb37908c44ded233e0f4bf479e45609], "
-                        + "IndexEntry[mode=160000,type=commit,file=modules/sshkeys,object=689c45ed57f0829735f9a2b16760c14236fe21d9]]",
+                """
+                [IndexEntry[mode=160000,type=commit,file=modules/firewall,object=978c8b223b33e203a5c766ecf79704a5ea9b35c8], \
+                IndexEntry[mode=160000,type=commit,file=modules/ntp,object=b62fabbc2bb37908c44ded233e0f4bf479e45609], \
+                IndexEntry[mode=160000,type=commit,file=modules/sshkeys,object=689c45ed57f0829735f9a2b16760c14236fe21d9]]\
+                """,
                 r.toString());
         w.git.submoduleInit();
         w.git.submoduleUpdate().execute();
@@ -1032,7 +1035,7 @@ public abstract class GitAPITestUpdate {
         boolean hasShallowSubmoduleSupport =
                 w.git instanceof CliGitAPIImpl && w.cgit().isAtLeastVersion(1, 8, 4, 0);
 
-        String shallow = Paths.get(".git", "modules", "submodule", "shallow").toString();
+        String shallow = Path.of(".git", "modules", "submodule", "shallow").toString();
         assertEquals("shallow file existence: " + shallow, hasShallowSubmoduleSupport, w.exists(shallow));
 
         int localSubmoduleCommits =
@@ -1060,7 +1063,7 @@ public abstract class GitAPITestUpdate {
         boolean hasShallowSubmoduleSupport =
                 w.git instanceof CliGitAPIImpl && w.cgit().isAtLeastVersion(1, 8, 4, 0);
 
-        String shallow = Paths.get(".git", "modules", "submodule", "shallow").toString();
+        String shallow = Path.of(".git", "modules", "submodule", "shallow").toString();
         assertEquals("shallow file existence: " + shallow, hasShallowSubmoduleSupport, w.exists(shallow));
 
         int localSubmoduleCommits =
@@ -2063,9 +2066,9 @@ public abstract class GitAPITestUpdate {
         WorkingArea submoduleWorkingArea = new WorkingArea(submoduleDir).init();
 
         for (int commit = 1; commit <= 5; commit++) {
-            submoduleWorkingArea.touch("file", String.format("submodule content-%d", commit));
+            submoduleWorkingArea.touch("file", "submodule content-%d".formatted(commit));
             submoduleWorkingArea.cgit().add("file");
-            submoduleWorkingArea.cgit().commit(String.format("submodule commit-%d", commit));
+            submoduleWorkingArea.cgit().commit("submodule commit-%d".formatted(commit));
         }
 
         WorkingArea repositoryWorkingArea = new WorkingArea(repositoryDir).init();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdateCliGit.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.fail;
 
 import hudson.plugins.git.GitException;
 import java.io.File;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
@@ -38,7 +38,7 @@ public abstract class GitAPITestUpdateCliGit extends GitAPITestUpdate {
         }
         assertFixSubmoduleUrlsThrows();
 
-        String shallow = Paths.get(".git", "modules", "module", "1", "shallow").toString();
+        String shallow = Path.of(".git", "modules", "module", "1", "shallow").toString();
         assertFalse("shallow file existence: " + shallow, w.exists(shallow));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientMaintenanceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientMaintenanceTest.java
@@ -168,8 +168,7 @@ public class GitClientMaintenanceTest {
                 "Vojtěch GitClientMaintenanceTest Zweibrücken-Šafařík",
                 "email.from.git.client.maintenance@example.com");
 
-        if (gitClient instanceof CliGitAPIImpl) {
-            CliGitAPIImpl cliGitClient = (CliGitAPIImpl) gitClient;
+        if (gitClient instanceof CliGitAPIImpl cliGitClient) {
             if (!cliGitClient.isAtLeastVersion(1, 8, 0, 0)) {
                 incrementalRepackSupported = false;
                 commitGraphSupported = false;
@@ -218,7 +217,7 @@ public class GitClientMaintenanceTest {
     }
 
     private ObjectId commitOneFile(final String commitMessage) throws Exception {
-        final String content = String.format("A random maintenance UUID: %s\n", UUID.randomUUID());
+        final String content = "A random maintenance UUID: %s\n".formatted(UUID.randomUUID());
         return commitFile("One-Maintenance-File.txt", content, commitMessage);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientSecurityTest.java
@@ -108,11 +108,11 @@ public class GitClientSecurityTest {
 
     @Parameterized.Parameters(name = "{1},{0}")
     public static Collection testConfiguration() {
-        markerFileName = String.format(markerFileName, CONFIG_RANDOM.nextInt()); // Unique enough file name
+        markerFileName = markerFileName.formatted(CONFIG_RANDOM.nextInt()); // Unique enough file name
         List<Object[]> arguments = new ArrayList<>();
         for (String prefix : BAD_REMOTE_URL_PREFIXES) {
             /* insert markerFileName into test data */
-            String formattedPrefix = String.format(prefix, markerFileName);
+            String formattedPrefix = prefix.formatted(markerFileName);
 
             /* Random remote URL with prefix */
             String firstChar = CONFIG_RANDOM.nextBoolean() ? " " : "";

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -39,7 +39,6 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -125,8 +124,8 @@ public class GitClientTest {
                 .getClient();
 
         CliGitAPIImpl cliGitClient;
-        if (this.srcGitClient instanceof CliGitAPIImpl) {
-            cliGitClient = (CliGitAPIImpl) this.srcGitClient;
+        if (this.srcGitClient instanceof CliGitAPIImpl impl) {
+            cliGitClient = impl;
         } else {
             cliGitClient = (CliGitAPIImpl) Git.with(TaskListener.NULL, new EnvVars())
                     .in(srcRepoDir)
@@ -314,8 +313,7 @@ public class GitClientTest {
      * not a threat to these tests.
      */
     private void allowFileProtocol(GitClient client) throws Exception {
-        if (client instanceof CliGitAPIImpl) {
-            CliGitAPIImpl cliGit = (CliGitAPIImpl) client;
+        if (client instanceof CliGitAPIImpl cliGit) {
             cliGit.allowFileProtocol();
         }
     }
@@ -327,7 +325,7 @@ public class GitClientTest {
     }
 
     private ObjectId commitOneFile(final String commitMessage) throws Exception {
-        final String content = String.format("A random UUID: %s\n", UUID.randomUUID());
+        final String content = "A random UUID: %s\n".formatted(UUID.randomUUID());
         return commitFile("One-File.txt", content, commitMessage);
     }
 
@@ -388,18 +386,21 @@ public class GitClientTest {
     public void testChangelogVeryLong() throws Exception {
 
         final String gitMessage =
-                "Uno Dos Tres Cuatro Cinco Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut "
-                        + "posuere tellus eu efficitur tristique. In iaculis neque in dolor vulputate"
-                        + "sollicitudin eget a quam. Donec finibus sapien quis lectus euismod facilisis. Integer"
-                        + "massa purus, scelerisque id iaculis ut, blandit vitae velit. Pellentesque lobortis"
-                        + "aliquet felis, vel laoreet ipsum tincidunt at. Mauris tellus est, cursus vitae ex"
-                        + "eget, venenatis auctor eros. Sed sagittis porta odio. Donec ut interdum massa. Aliquam"
-                        + "sagittis, mi sit amet sollicitudin elementum, velit quam eleifend nisl, in rhoncus"
-                        + "felis nibh eu nibh. Class aptent taciti sociosqu ad litora torquent per conubia "
-                        + "nostra, per inceptos himenaeos."
-                        + "\nseis\n"
-                        + "\nasfasfasfasf\n";
-        final String content = String.format("A random UUID: %s\n", UUID.randomUUID());
+                """
+                Uno Dos Tres Cuatro Cinco Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut \
+                posuere tellus eu efficitur tristique. In iaculis neque in dolor vulputate\
+                sollicitudin eget a quam. Donec finibus sapien quis lectus euismod facilisis. Integer\
+                massa purus, scelerisque id iaculis ut, blandit vitae velit. Pellentesque lobortis\
+                aliquet felis, vel laoreet ipsum tincidunt at. Mauris tellus est, cursus vitae ex\
+                eget, venenatis auctor eros. Sed sagittis porta odio. Donec ut interdum massa. Aliquam\
+                sagittis, mi sit amet sollicitudin elementum, velit quam eleifend nisl, in rhoncus\
+                felis nibh eu nibh. Class aptent taciti sociosqu ad litora torquent per conubia \
+                nostra, per inceptos himenaeos.
+                seis
+
+                asfasfasfasf
+                """;
+        final String content = "A random UUID: %s\n".formatted(UUID.randomUUID());
         ObjectId message = commitFile("One-File.txt", content, gitMessage);
 
         ChangelogCommand changelog = gitClient.changelog();
@@ -1776,9 +1777,12 @@ public class GitClientTest {
         File uuidFile = new File(repoRoot, "uuid.txt");
         String fileContent =
                 Files.readString(uuidFile.toPath(), StandardCharsets.UTF_8).trim();
-        String expectedContent = "version https://git-lfs.github.com/spec/v1\n"
-                + "oid sha256:75d122e4160dc91480257ff72403e77ef276e24d7416ed2be56d4e726482d86e\n"
-                + "size 33";
+        String expectedContent =
+                """
+                version https://git-lfs.github.com/spec/v1
+                oid sha256:75d122e4160dc91480257ff72403e77ef276e24d7416ed2be56d4e726482d86e
+                size 33\
+                """;
         assertEquals("Incorrect non-LFS file contents in " + uuidFile, expectedContent, fileContent);
     }
 
@@ -2452,12 +2456,12 @@ public class GitClientTest {
      */
     private void enableLongPaths(GitClient gitClient) throws Exception {
         CliGitAPIImpl cliGitClient;
-        if (gitClient instanceof CliGitAPIImpl && isWindows()) {
+        if (gitClient instanceof CliGitAPIImpl impl && isWindows()) {
             /* Enable core.longpaths prior to fetch on Windows -
              * testSubmodulesUsedFromOtherBranches submodule test will
              * fail with default Windows location otherwise
              */
-            cliGitClient = (CliGitAPIImpl) gitClient;
+            cliGitClient = impl;
             cliGitClient.launchCommand("config", "core.longpaths", "true");
         }
     }
@@ -2562,7 +2566,7 @@ public class GitClientTest {
         gitCmd.initializeRepository("Vojtěch GitClientTest Zweibrücken-Šafařík", "email.from.git.client@example.com");
         File readme = new File(urlRepoDir, "readme");
         String readmeText = "This repo includes .url in its directory name (" + random.nextInt() + ")";
-        Files.write(Paths.get(readme.getAbsolutePath()), readmeText.getBytes());
+        Files.write(Path.of(readme.getAbsolutePath()), readmeText.getBytes());
         urlRepoClient.add("readme");
         urlRepoClient.commit("Added README to repo used as a submodule");
         /* Enable long paths to prevent checkout failure on default Windows workspace with MSI installer */
@@ -2585,7 +2589,7 @@ public class GitClientTest {
         File hasSubmoduleReadme = new File(repoHasSubmodule, "readme");
         String hasSubmoduleReadmeText =
                 "Repo has a submodule that includes .url in its directory name (" + random.nextInt() + ")";
-        Files.write(Paths.get(hasSubmoduleReadme.getAbsolutePath()), hasSubmoduleReadmeText.getBytes());
+        Files.write(Path.of(hasSubmoduleReadme.getAbsolutePath()), hasSubmoduleReadmeText.getBytes());
         repoHasSubmoduleClient.add("readme");
         repoHasSubmoduleClient.commit("Added README to repo that will include a submodule whose URL ends in '.url'");
         String moduleDirBaseName = "module.named.url";
@@ -3324,6 +3328,7 @@ public class GitClientTest {
         if (!gitImplName.equals("git")) {
             return;
         }
+        // Embedded \r (carriage return) must be retained in the gitBranchOutput
         String gitBranchOutput =
                 "* (HEAD detached at b297853)  b297853e667d5989801937beea30fcec7d1d2595 Commit message with line breaks\r very-long-string-with-more-than-44-characters\n"
                         + "  remotes/origin/master       e0d3f46c4fdb8acd068b6b127356931411d16e23 Commit message with line breaks\r very-long-string-with-more-than-44-characters and some more text\n"

--- a/src/test/java/org/jenkinsci/plugins/gitclient/NetrcTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/NetrcTest.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -80,15 +80,15 @@ public class NetrcTest {
     }
 
     private void copyFileContents(String source, String destination) throws IOException {
-        try (InputStream sourceStream = Files.newInputStream(Paths.get(source));
-                OutputStream out = Files.newOutputStream(Paths.get(destination))) {
+        try (InputStream sourceStream = Files.newInputStream(Path.of(source));
+                OutputStream out = Files.newOutputStream(Path.of(destination))) {
             IOUtils.copy(sourceStream, out);
         }
     }
 
     private void copyResourceContents(String resource, String destination) throws IOException {
         try (InputStream sourceStream = this.getClass().getClassLoader().getResourceAsStream(resource);
-                OutputStream out = Files.newOutputStream(Paths.get(destination))) {
+                OutputStream out = Files.newOutputStream(Path.of(destination))) {
             IOUtils.copy(sourceStream, out);
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/jgit/AuthzTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/jgit/AuthzTest.java
@@ -104,19 +104,15 @@ public class AuthzTest {
     protected void testRepo(StandardCredentials standardCredentials, GenericContainer<?> containerUnderTest)
             throws Exception {
         String repoUrl = null;
-        if (containerUnderTest instanceof GitServerContainer) {
-            repoUrl = ((GitServerContainer) containerUnderTest)
-                    .getGitRepoURIAsSSH()
-                    .toString();
+        if (containerUnderTest instanceof GitServerContainer container) {
+            repoUrl = container.getGitRepoURIAsSSH().toString();
             // ssh://git@localhost:33011/srv/git/someRepo.git
             // we don't want the user part of the uri or jgit will use this user
             // and we want to be sure to test our implementation with dynamic user
             repoUrl = StringUtils.remove(repoUrl, "git@");
         }
-        if (containerUnderTest instanceof GitHttpServerContainer) {
-            repoUrl = ((GitHttpServerContainer) containerUnderTest)
-                    .getGitRepoURIAsHttp()
-                    .toString();
+        if (containerUnderTest instanceof GitHttpServerContainer container) {
+            repoUrl = container.getGitRepoURIAsHttp().toString();
         }
 
         Path testRepo = testFolder.newFolder().toPath();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifierTest.java
@@ -25,14 +25,19 @@ import org.junit.rules.TemporaryFolder;
 
 public class AcceptFirstConnectionVerifierTest {
 
-    private static final String FILE_CONTENT = "|1|4MiAohNAs5mYhPnYkpnOUWXmMTA=|iKR8xF3kCEdmSch/QtdXfdjWMCo="
-            + " ssh-ed25519"
-            + " AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";
+    private static final String FILE_CONTENT =
+            """
+            |1|4MiAohNAs5mYhPnYkpnOUWXmMTA=|iKR8xF3kCEdmSch/QtdXfdjWMCo=\
+             ssh-ed25519\
+             AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl\
+            """;
 
     private static final String KEY_ecdsa_sha2_nistp256 =
-            "|1|owDOW+8aankl2aFSPKPIXsIf31E=|lGZ9BEWUfa9HoQteyYE5wIqHJdo=,|1|eGv/ezgtZ9YMw7OHcykKKOvAINk=|3lpkF7XiveRl/D7XvTOMc3ra2kU="
-                    + " ecdsa-sha2-nistp256"
-                    + " AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=";
+            """
+            |1|owDOW+8aankl2aFSPKPIXsIf31E=|lGZ9BEWUfa9HoQteyYE5wIqHJdo=,|1|eGv/ezgtZ9YMw7OHcykKKOvAINk=|3lpkF7XiveRl/D7XvTOMc3ra2kU=\
+             ecdsa-sha2-nistp256\
+             AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=\
+            """;
 
     @Rule
     public TemporaryFolder testFolder =
@@ -136,9 +141,12 @@ public class AcceptFirstConnectionVerifierTest {
         if (isKubernetesCI()) {
             return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
         }
-        String fileContent = "github.com,140.82.121.4"
-                + " ecdsa-sha2-nistp256"
-                + " AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=";
+        String fileContent =
+                """
+                github.com,140.82.121.4\
+                 ecdsa-sha2-nistp256\
+                 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=\
+                """;
         File mockedKnownHosts = knownHostsTestUtil.createFakeKnownHosts(fileContent);
         AcceptFirstConnectionVerifier acceptFirstConnectionVerifier = spy(new AcceptFirstConnectionVerifier());
         when(acceptFirstConnectionVerifier.getKnownHostsFile()).thenReturn(mockedKnownHosts);
@@ -163,9 +171,12 @@ public class AcceptFirstConnectionVerifierTest {
     @Test
     @Ignore("FIXME not sure what is the test here")
     public void testVerifyServerHostKeyWhenSecondConnectionWithNonEqualKeys() throws Exception {
-        String fileContent = "|1|f7esvmtaiBk+EMHjPzWbRYRpBPY=|T7Qe4QAksYPZPwYEx5QxQykSjfc=" // github.com:22
-                + " ssh-ed25519"
-                + " AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9OOOO";
+        String fileContent =
+                """
+                |1|f7esvmtaiBk+EMHjPzWbRYRpBPY=|T7Qe4QAksYPZPwYEx5QxQykSjfc=\
+                 ssh-ed25519\
+                 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9OOOO\
+                """;
         File mockedKnownHosts =
                 knownHostsTestUtil.createFakeKnownHosts(fileContent); // file was created during first connection
         AcceptFirstConnectionVerifier acceptFirstConnectionVerifier = spy(new AcceptFirstConnectionVerifier());
@@ -193,9 +204,12 @@ public class AcceptFirstConnectionVerifierTest {
         if (isKubernetesCI()) {
             return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
         }
-        String bitbucketFileContent = "|1|HnmPCP38pBhCY0NUtBXSraOg9pM=|L6YZ9asEeb2xplTDEThGOxRq7ZY="
-                + " ssh-rsa"
-                + " AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==";
+        String bitbucketFileContent =
+                """
+                |1|HnmPCP38pBhCY0NUtBXSraOg9pM=|L6YZ9asEeb2xplTDEThGOxRq7ZY=\
+                 ssh-rsa\
+                 AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==\
+                """;
 
         File fakeKnownHosts = knownHostsTestUtil.createFakeKnownHosts(bitbucketFileContent);
         AcceptFirstConnectionVerifier acceptFirstConnectionVerifier = spy(new AcceptFirstConnectionVerifier());
@@ -225,9 +239,12 @@ public class AcceptFirstConnectionVerifierTest {
         if (isKubernetesCI()) {
             return; // Test fails with connection timeout on ci.jenkins.io kubernetes agents
         }
-        String fileContent = "|1|6uMj3M7sLgZpn54vQbGqgPNTCVM=|OkV9Lu9REJZR5QCVrITAIY34I1M=" // github.com:59666
-                + " ssh-ed25519"
-                + " AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";
+        String fileContent =
+                """
+                |1|6uMj3M7sLgZpn54vQbGqgPNTCVM=|OkV9Lu9REJZR5QCVrITAIY34I1M=\
+                 ssh-ed25519\
+                 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl\
+                """;
         File mockedKnownHosts = knownHostsTestUtil.createFakeKnownHosts(fileContent);
         AcceptFirstConnectionVerifier acceptFirstConnectionVerifier = spy(new AcceptFirstConnectionVerifier());
         when(acceptFirstConnectionVerifier.getKnownHostsFile()).thenReturn(mockedKnownHosts);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
@@ -22,9 +22,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class KnownHostsFileVerifierTest {
 
-    private static final String FILE_CONTENT = "github.com"
-            + " ecdsa-sha2-nistp256"
-            + " AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=";
+    private static final String FILE_CONTENT =
+            """
+            github.com\
+             ecdsa-sha2-nistp256\
+             AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=\
+            """;
 
     // Create a temporary folder and assert folder deletion at end of tests
     @Rule

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsTestUtil.java
@@ -11,7 +11,7 @@ import java.lang.reflect.Method;
 import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.security.PublicKey;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -81,7 +81,7 @@ public class KnownHostsTestUtil {
 
         try (SshClient client = ClientBuilder.builder()
                 .factory(JGitSshClient::new)
-                .hostConfigEntryResolver(new ConfigFileHostEntryResolver(Paths.get("src/test/resources/ssh_config")))
+                .hostConfigEntryResolver(new ConfigFileHostEntryResolver(Path.of("src/test/resources/ssh_config")))
                 .serverKeyVerifier(new JGitServerKeyVerifier(verifier.getServerKeyDatabase()))
                 .compressionFactories(new ArrayList<>(BuiltinCompressions.VALUES))
                 .build()) {
@@ -118,14 +118,13 @@ public class KnownHostsTestUtil {
         }
 
         boolean verified = false;
-        if (serverKey instanceof OpenSshCertificate) {
+        if (serverKey instanceof OpenSshCertificate certificate) {
             // check if we trust the CA
-            verified =
-                    serverKeyVerifier.verifyServerKey(s, remoteAddress, ((OpenSshCertificate) serverKey).getCaPubKey());
+            verified = serverKeyVerifier.verifyServerKey(s, remoteAddress, certificate.getCaPubKey());
 
             if (!verified) {
                 // fallback to actual public host key
-                serverKey = ((OpenSshCertificate) serverKey).getCertPubKey();
+                serverKey = certificate.getCertPubKey();
             }
         }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
@@ -7,7 +7,7 @@ import static org.jenkinsci.plugins.gitclient.verifier.KnownHostsTestUtil.isKube
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.Before;
@@ -48,7 +48,7 @@ public class NoHostKeyVerifierTest {
     @Test
     public void testVerifyHostKeyOption() throws IOException {
         assertThat(
-                verifier.forCliGit(TaskListener.NULL).getVerifyHostKeyOption(Paths.get("")),
+                verifier.forCliGit(TaskListener.NULL).getVerifyHostKeyOption(Path.of("")),
                 is("-o StrictHostKeyChecking=no"));
     }
 }


### PR DESCRIPTION
## Use Java 17 features in source code

[Open Rewrite migrate to Java 17](https://docs.openrewrite.org/running-recipes/popular-recipe-guides/migrate-to-java-17) provided the transformations and they all pass automated tests.

Several nice readability improvements are provided by Java 17.

I would like to include these changes in the 6.0.0 git client plugin release, since it will require Java 17.  @olamy or @rsandell could you review and approve?

### Testing done

Automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
