### PR TITLE
Annotate deprecated methods

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/AbstractGitAPIImpl.java
@@ -30,6 +30,7 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void commit(String message, PersonIdent author, PersonIdent committer)
             throws GitException, InterruptedException {
@@ -55,6 +56,7 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void changelog(String revFrom, String revTo, OutputStream outputStream)
             throws GitException, InterruptedException {
@@ -79,12 +81,14 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void checkout(String commit) throws GitException, InterruptedException {
         checkout().ref(commit).execute();
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void checkout(String ref, String branch) throws GitException, InterruptedException {
         checkout().ref(ref).branch(branch).execute();
@@ -97,6 +101,7 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void merge(ObjectId rev) throws GitException, InterruptedException {
         merge().setRevisionToMerge(rev).execute();
@@ -142,21 +147,25 @@ abstract class AbstractGitAPIImpl implements GitClient, Serializable {
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void submoduleUpdate(boolean recursive) throws GitException, InterruptedException {
         submoduleUpdate().recursive(recursive).execute();
     }
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void submoduleUpdate(boolean recursive, String reference) throws GitException, InterruptedException {
         submoduleUpdate().recursive(recursive).ref(reference).execute();
     }
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void submoduleUpdate(boolean recursive, boolean remoteTracking) throws GitException, InterruptedException {
         submoduleUpdate().recursive(recursive).remoteTracking(remoteTracking).execute();
     }
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void submoduleUpdate(boolean recursive, boolean remoteTracking, String reference)
             throws GitException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -533,6 +533,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public FetchCommand prune() {
                 return prune(true);
@@ -637,12 +638,14 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
         fetch_().from(url, refspecs).execute();
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void fetch(String remoteName, RefSpec... refspec) throws GitException, InterruptedException {
         listener.getLogger().println("Fetching upstream changes" + (remoteName != null ? " from " + remoteName : ""));
@@ -679,6 +682,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public void fetch(String remoteName, RefSpec refspec) throws GitException, InterruptedException {
         fetch(remoteName, new RefSpec[] {refspec});
@@ -733,6 +737,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public CloneCommand shared() {
                 return shared(true);
@@ -744,6 +749,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public CloneCommand shallow() {
                 return shallow(true);
@@ -755,6 +761,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public CloneCommand noCheckout() {
                 // this.noCheckout = true; Since the "clone" command has been replaced with init + fetch, the
@@ -2884,6 +2891,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public PushCommand force() {
                 return force(true);
@@ -3361,6 +3369,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private String refspec;
             private List<ObjectId> out;
 
+            @Deprecated
             @Override
             public RevListCommand all() {
                 return all(true);
@@ -3381,6 +3390,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public RevListCommand firstParent() {
                 return firstParent(true);
@@ -3582,6 +3592,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "JGit interaction with spotbugs")
     @NonNull
+    @Deprecated
     @Override
     public Repository getRepository() throws GitException {
         try {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -743,6 +743,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public org.jenkinsci.plugins.gitclient.FetchCommand prune() {
                 return prune(true);
@@ -832,14 +833,17 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      * @param refspecs a {@link java.util.List} object.
      * @throws hudson.plugins.git.GitException if any.
      * @throws java.lang.InterruptedException if any.
+     * @deprecated
      */
     @Override
+    @Deprecated
     public void fetch(URIish url, List<RefSpec> refspecs) throws GitException, InterruptedException {
         fetch_().from(url, refspecs).execute();
     }
 
     /** {@inheritDoc} */
     @Override
+    @Deprecated
     public void fetch(String remoteName, RefSpec... refspec) throws GitException {
         try (Repository repo = getRepository()) {
             FetchCommand fetch = git(repo).fetch().setTagOpt(TagOpt.FETCH_TAGS);
@@ -866,6 +870,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
     /** {@inheritDoc} */
     @Override
+    @Deprecated
     public void fetch(String remoteName, RefSpec refspec) throws GitException {
         fetch(remoteName, new RefSpec[] {refspec});
     }
@@ -876,7 +881,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         refName = refName.replace(' ', '_');
         try (Repository repo = getRepository()) {
             RefUpdate refUpdate = repo.updateRef(refName);
-            refUpdate.setNewObjectId(repo.exactRef(Constants.HEAD).getObjectId());
+            refUpdate.setNewObjectId(repo.exactRef(HEAD).getObjectId());
             switch (refUpdate.forceUpdate()) {
                 case NOT_ATTEMPTED:
                 case LOCK_FAILURE:
@@ -1127,9 +1132,11 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      *
      * @return a {@link org.eclipse.jgit.lib.Repository} object.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
+     * @deprecated
      */
     @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "JGit interaction with spotbugs")
     @NonNull
+    @Deprecated
     @Override
     public Repository getRepository() throws GitException {
         try {
@@ -1541,6 +1548,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public CloneCommand shallow() {
                 return shallow(true);
@@ -1552,6 +1560,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public CloneCommand shared() {
                 return shared(true);
@@ -1587,6 +1596,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public CloneCommand noCheckout() {
                 // this.noCheckout = true; ignored, we never do a checkout
@@ -2141,6 +2151,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public PushCommand force() {
                 return force(true);
@@ -2276,6 +2287,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private String refspec;
             private List<ObjectId> out;
 
+            @Deprecated
             @Override
             public RevListCommand all() {
                 return all(true);
@@ -2293,6 +2305,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Deprecated
             @Override
             public RevListCommand firstParent() {
                 return firstParent(true);
@@ -2619,6 +2632,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public List<Branch> getBranchesContaining(String revspec) throws GitException, InterruptedException {
         // For the reasons of backward compatibility - we do not query remote branches here.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/LegacyCompatibleGitAPIImpl.java
@@ -217,6 +217,7 @@ abstract class LegacyCompatibleGitAPIImpl extends AbstractGitAPIImpl implements 
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override
     public final List<IndexEntry> lsTree(String treeIsh) throws GitException, InterruptedException {
         return lsTree(treeIsh, false);


### PR DESCRIPTION
## Annotate deprecated methods

Reduce compiler warnings about deprecations and declare them consistently.

### Testing done

Opened the generated javadoc in a web browser and navigated briefly.  Deprecated items are shown correctly.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
