### PR TITLE
Replace deprecated getPassword() with getSecretPassword()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2159,7 +2159,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         String userInfo = null;
                         if (StringUtils.isNotEmpty(proxy.getUserName())) {
                             userInfo = proxy.getUserName();
-                            if (StringUtils.isNotEmpty(proxy.getPassword())) {
+                            if (!Secret.toString(proxy.getSecretPassword()).isEmpty()) {
                                 userInfo += ":" + proxy.getSecretPassword();
                             }
                         }


### PR DESCRIPTION
## Replace deprecated getPassword() with getSecretPassword()

Also replaces a StringUtils use with a Java String call.

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
