### PR TITLE
Use non-deprecated JGit methods to get references

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -3008,10 +3008,15 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     @Override
     public Set<Branch> getRemoteBranches() throws GitException, InterruptedException {
         try (Repository db = getRepository()) {
-            Map<String, Ref> refs = db.getAllRefs();
+            List<Ref> refs;
+            try {
+                refs = db.getRefDatabase().getRefs();
+            } catch (IOException ioe) {
+                throw new GitException(ioe);
+            }
             Set<Branch> branches = new HashSet<>();
 
-            for (Ref candidate : refs.values()) {
+            for (Ref candidate : refs) {
                 if (candidate.getName().startsWith(Constants.R_REMOTES)) {
                     Branch buildBranch = new Branch(candidate);
                     if (!GitClient.quietRemoteBranches) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2080,7 +2080,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             Set<String> branches = listRemoteBranches(remote);
 
-            for (Ref r : new ArrayList<>(gitRepo.getAllRefs().values())) {
+            for (Ref r : new ArrayList<>(gitRepo.getRefDatabase().getRefs())) {
                 if (r.getName().startsWith(prefix) && !branches.contains(r.getName())) {
                     // delete this ref
                     RefUpdate update = gitRepo.updateRef(r.getName());
@@ -2334,7 +2334,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         out.add(c.copy());
 
                         if (all) {
-                            for (Ref r : repo.getAllRefs().values()) {
+                            for (Ref r : repo.getRefDatabase().getRefs()) {
                                 c = walk.parseCommit(r.getObjectId());
                                 out.add(c.copy());
                             }
@@ -2716,7 +2716,13 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     private List<Ref> getAllBranchRefs(boolean originBranches) throws GitException {
         List<Ref> branches = new ArrayList<>();
         try (Repository repo = getRepository()) {
-            for (Ref r : repo.getAllRefs().values()) {
+            List<Ref> refs;
+            try {
+                refs = repo.getRefDatabase().getRefs();
+            } catch (IOException ioe) {
+                throw new GitException(ioe);
+            }
+            for (Ref r : refs) {
                 final String branchName = r.getName();
                 if (branchName.startsWith(R_HEADS) || (originBranches && branchName.startsWith(R_REMOTES))) {
                     branches.add(r);
@@ -2785,7 +2791,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
      */
     private void markRefs(RevWalk walk, Predicate<Ref> filter) throws GitException, IOException {
         try (Repository repo = getRepository()) {
-            for (Ref r : repo.getAllRefs().values()) {
+            for (Ref r : repo.getRefDatabase().getRefs()) {
                 if (filter.test(r)) {
                     RevCommit c = walk.parseCommit(r.getObjectId());
                     walk.markStart(c);
@@ -2905,7 +2911,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             w.setRetainBody(false);
 
             Map<ObjectId, Ref> tags = new HashMap<>();
-            for (Ref r : repo.getTags().values()) {
+            for (Ref r : repo.getRefDatabase().getRefsByPrefix(R_TAGS)) {
                 ObjectId key = repo.getRefDatabase().peel(r).getPeeledObjectId();
                 if (key == null) {
                     key = r.getObjectId();


### PR DESCRIPTION
## Use non-deprecated JGit methods to get references

The JGit 7.0.0 upgrade reminded me that it is unwise to depend on deprecated methods from JGit because they will eventually be removed.  Better to stop using the deprecated methods now and avoid problems in the future.

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
