### PR TITLE
[JENKINS-65032] Add option to include merge commits in changelogs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -109,6 +109,14 @@ public interface ChangelogCommand extends GitCommand {
     ChangelogCommand max(int n);
 
     /**
+     * Include merge commits in the changelog.
+     *
+     * @param include a boolean.
+     * @return a {@link org.jenkinsci.plugins.gitclient.ChangelogCommand} object.
+     */
+    ChangelogCommand includeMergeCommits(boolean include);
+
+    /**
      * Abort this ChangelogCommand without executing it, close any
      * open resources.  The JGit implementation of changelog
      * calculation opens the git repository and will close it when the

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1243,13 +1243,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     @Override
     public ChangelogCommand changelog() {
         return new ChangelogCommand() {
-
-            /** Equivalent to the git-log raw format but using ISO 8601 date format - also prevent to depend on git CLI future changes */
-            public static final String RAW =
-                    "commit %H%ntree %T%nparent %P%nauthor %aN <%aE> %ai%ncommitter %cN <%cE> %ci%n%n%w(0,4,4)%B";
-
             private final List<String> revs = new ArrayList<>();
-
             private Integer n = null;
             private Writer out = null;
             private boolean includeMergeCommits = false;
@@ -1301,6 +1295,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public void execute() throws GitException, InterruptedException {
+<<<<<<< HEAD
                 ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "whatchanged", "--no-abbrev", "-M");
                 if (isAtLeastVersion(1, 8, 3, 0)) {
                     args.add("--format=" + RAW);
@@ -1309,6 +1304,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     args.add("--format=raw");
                 }
                 if (n != null) {
+=======
+                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "whatchanged", "--no-abbrev", "-M", "--pretty=raw");
+                if (n!=null)
+>>>>>>> parent of de49c9bf ([FIXED JENKINS-27097] use ISO-8601 in changelog)
                     args.add("-n").add(n);
                 }
                 if (includeMergeCommits) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1296,7 +1296,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @Override
             public void execute() throws GitException, InterruptedException {
                 ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "whatchanged", "--no-abbrev", "-M", "--format=raw");
-                if (n!=null)
+                if (n != null) {
                     args.add("-n").add(n);
                 }
                 if (includeMergeCommits) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1295,19 +1295,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public void execute() throws GitException, InterruptedException {
-<<<<<<< HEAD
-                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "whatchanged", "--no-abbrev", "-M");
-                if (isAtLeastVersion(1, 8, 3, 0)) {
-                    args.add("--format=" + RAW);
-                } else {
-                    /* Ancient git versions don't support the required format string, use 'raw' and hope it works */
-                    args.add("--format=raw");
-                }
-                if (n != null) {
-=======
-                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "whatchanged", "--no-abbrev", "-M", "--pretty=raw");
+                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "whatchanged", "--no-abbrev", "-M", "--format=raw");
                 if (n!=null)
->>>>>>> parent of de49c9bf ([FIXED JENKINS-27097] use ISO-8601 in changelog)
                     args.add("-n").add(n);
                 }
                 if (includeMergeCommits) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1252,6 +1252,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             private Integer n = null;
             private Writer out = null;
+            private boolean includeMergeCommits = false;
 
             @Override
             public ChangelogCommand excludes(String rev) {
@@ -1288,6 +1289,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
+            public ChangelogCommand includeMergeCommits(boolean include) {
+                this.includeMergeCommits = include;
+                return this;
+            }
+
+            @Override
             public void abort() {
                 /* No cleanup needed to abort the CliGitAPIImpl ChangelogCommand */
             }
@@ -1303,6 +1310,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 }
                 if (n != null) {
                     args.add("-n").add(n);
+                }
+                if (includeMergeCommits) {
+                    args.add("-m");
                 }
                 for (String rev : this.revs) {
                     args.add(rev);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -62,8 +62,10 @@ import java.util.stream.Collectors;
 import jenkins.util.SystemProperties;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.SystemUtils;
-import org.apache.commons.lang.time.FastDateFormat;
 import org.apache.sshd.common.util.security.SecurityUtils;
+
+import javax.annotation.Nullable;
+
 import org.eclipse.jgit.api.AddNoteCommand;
 import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.CreateBranchCommand.SetupUpstreamMode;
@@ -1419,8 +1421,6 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
         }
 
-        public static final String ISO_8601 = "yyyy-MM-dd'T'HH:mm:ssZ";
-
         /**
          * Formats a commit into the raw format.
          *
@@ -1442,14 +1442,10 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             pw.printf("tree %s\n", commit.getTree().name());
-            for (RevCommit p : commit.getParents()) {
-                pw.printf("parent %s\n", p.name());
-            }
-            FastDateFormat iso = FastDateFormat.getInstance(ISO_8601);
-            PersonIdent a = commit.getAuthorIdent();
-            pw.printf("author %s <%s> %s\n", a.getName(), a.getEmailAddress(), iso.format(a.getWhen()));
-            PersonIdent c = commit.getCommitterIdent();
-            pw.printf("committer %s <%s> %s\n", c.getName(), c.getEmailAddress(), iso.format(c.getWhen()));
+            for (RevCommit p : commit.getParents())
+                pw.printf("parent %s\n",p.name());
+            pw.printf("author %s\n", commit.getAuthorIdent().toExternalString());
+            pw.printf("committer %s\n", commit.getCommitterIdent().toExternalString());
 
             // indent commit messages by 4 chars
             String msg = commit.getFullMessage();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1263,6 +1263,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private RevWalk walk = new RevWalk(or);
             private Writer out;
             private boolean hasIncludedRev = false;
+            private boolean includeMergeCommits = false;
 
             @Override
             public ChangelogCommand excludes(String rev) throws GitException {
@@ -1317,6 +1318,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return this;
             }
 
+            @Override
+            public ChangelogCommand includeMergeCommits(boolean include) {
+                this.includeMergeCommits = include;
+                return this;
+            }
+
             private void closeResources() {
                 walk.close();
                 or.close();
@@ -1348,7 +1355,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     }
                     for (RevCommit commit : walk) {
                         // git whatachanged doesn't show the merge commits unless -m is given
-                        if (commit.getParentCount() > 1) {
+                        if (!includeMergeCommits && commit.getParentCount() > 1) {
                             continue;
                         }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestUpdate.java
@@ -2038,11 +2038,8 @@ public abstract class GitAPITestUpdate {
                 .setRevisionToMerge(w.git.getHeadRev(w.repoPath(), "branch-1"))
                 .execute();
 
-        /* JGit handles merge commits in changelog differently than CLI git.  See JENKINS-40023. */
-        int maxlimit = w.git instanceof CliGitAPIImpl ? 1 : 2;
-
         StringWriter writer = new StringWriter();
-        w.git.changelog().max(maxlimit).to(writer).execute();
+        w.git.changelog().max(1).to(writer).execute();
         assertThat(writer.toString(), is(not("")));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -3134,7 +3134,8 @@ public class GitClientTest {
         String changelog = writer.toString();
 
         assertThat(changelog, containsString("commit " + mergeCommit.name()));
-        assertThat(changelog, containsString("parent " + branch1FinalCommit.name() + " " + branch2Commit.name()));
+        assertThat(changelog, containsString("parent " + branch1FinalCommit.name()));
+        assertThat(changelog, containsString("parent " + branch2Commit.name()));
         assertThat(changelog, containsString(mergeMessage));
 
         // Get changelog with merge commits excluded


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Added features
* Option to Include merge commits in the changelog

### Changes
* CliGit implementation changelog format was reverted from custom format to `--format=raw`.
* Since CliGit implementation was reverted to use `raw` format the date format has changed to default (unix time).

In the past, changelog format for CliGit implementation was changed to custom format because of the `git-plugin` date parsing issue (https://issues.jenkins.io/browse/JENKINS-27097). Since then `git-plugin` date parsing has been updated: https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/GitChangeSet.java#L282-L300

Currently following custom changelog format is used:
```
/** Equivalent to the git-log raw format but using ISO 8601 date format - also prevent to depend on git CLI future changes */
public static final String RAW =
    "commit %H%ntree %T%nparent %P%nauthor %aN <%aE> %ai%ncommitter %cN <%cE> %ci%n%n%w(0,4,4)%B";
```
The above custom format is not equivalent to git-log `raw` format since all parent commits are placed on a single line:
```
parent sha1 sha2 ...
```
Although expected output is:
```
parent sha1
parent sha2
```
Existing JGit implementation places each parent commit on a separate line so there was inconsistency between CliGit and JGit implementations.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
