### PR TITLE
Revert "Bump jgit.version from 7.0.0.202409031743-r to 7.1.0.202411261347-r"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
-    <jgit.version>7.1.0.202411261347-r</jgit.version>
+    <jgit.version>7.0.0.202409031743-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitLightweightTagTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitLightweightTagTest.java
@@ -14,6 +14,7 @@ import hudson.EnvVars;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitObject;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -80,17 +81,21 @@ public class JGitLightweightTagTest {
         }
     }
 
-    private void packRefs() throws Exception {
-        try (org.eclipse.jgit.api.Git jgit = new org.eclipse.jgit.api.Git(new FileRepository(repoRootGitDir))) {
-            jgit.packRefs().setAll(true).call();
+    private void packRefs() throws IOException {
+        try (FileRepository repo = new FileRepository(repoRootGitDir)) {
+            org.eclipse.jgit.internal.storage.file.GC gc;
+            gc = new org.eclipse.jgit.internal.storage.file.GC(repo);
+            gc.packRefs();
         }
     }
 
     // No flavor of GitClient has a tag(String) API, only tag(String,String).
     // But sometimes we want a lightweight a.k.a. non-annotated tag.
     private void lightweightTag(String tagName) throws Exception {
-        try (org.eclipse.jgit.api.Git jgit = new org.eclipse.jgit.api.Git(new FileRepository(repoRootGitDir))) {
-            jgit.tag().setName(tagName).setAnnotated(false).call();
+        try (FileRepository repo = new FileRepository(repoRootGitDir)) {
+            // Collides with implicit org.jenkinsci.plugins.gitclient.Git.
+            org.eclipse.jgit.api.Git jgitAPI = org.eclipse.jgit.api.Git.wrap(repo);
+            jgitAPI.tag().setName(tagName).setAnnotated(false).call();
         }
     }
 


### PR DESCRIPTION
Reverts jenkinsci/git-client-plugin#1220

Null pointer exception is reported from JGit 7.1.0 API change in DiffFormatter. See the test failure with the command:

```
LINE=weekly PLUGINS=warnings-ng TEST=GitForensicsITest bash local-test.sh
```

Reverting the change so that the master branch continues to pass BOM tests.