### PR TITLE
Fix JVM crash in plugin BOM testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,27 +271,12 @@
   <build>
     <plugins>
       <plugin>
-        <!-- Needed by the mockito-core properties reference in surefire -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>properties</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
             <org.jenkinsci.plugins.gitclient.verifier.SshHostKeyVerificationStrategy.jgit_known_hosts_file>${project.build.directory}/ssh/know_hosts</org.jenkinsci.plugins.gitclient.verifier.SshHostKeyVerificationStrategy.jgit_known_hosts_file>
           </systemPropertyVariables>
-          <!-- Add mockito javaagent for the MockitoJUnitRunner in Java 21 and beyond -->
-          <!-- https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3 -->
-          <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## Revert "Add mockito-core javaagent for future Java compatibility"

Causes plugin BOM tests to fail with a JVM crash.  Compatibility with a future condition is much less important than having tests that run successfully now.

This reverts commit bfde394bae9900335e4e61efab057d9c5cbc5d55.

### Testing done

Confirmed that the JVM crash in the plugin BOM is resolved by this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
