### PR TITLE
Add option to suppress merge commits diff in showRevision

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1342,12 +1342,23 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return showRevision(from, to, true);
     }
 
-    /** {@inheritDoc} */
     @Override
     public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput)
             throws GitException, InterruptedException {
+        return showRevision(from, to, useRawOutput, false);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean suppressMergeCommitDiff)
+            throws GitException, InterruptedException {
         ArgumentListBuilder args =
-                new ArgumentListBuilder("log", "--full-history", "--no-abbrev", "--format=raw", "-M", "-m");
+                new ArgumentListBuilder("log", "--full-history", "--no-abbrev", "--format=raw", "-M");
+
+        if (!suppressMergeCommitDiff) {
+            args.add("-m");
+        }
+
         if (useRawOutput) {
             args.add("--raw");
         }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -951,6 +951,31 @@ public interface GitClient {
             throws GitException, InterruptedException;
 
     /**
+     * Given a Revision, show it as if it were an entry from git whatchanged, so that it
+     * can be parsed by GitChangeLogParser.
+     *
+     * <p>
+     * If useRawOutput is true, the '--raw' option will include commit file information to be passed to the
+     * GitChangeLogParser.
+     *
+     * <p>
+     * Changes are computed on the [from..to] range. If {@code from} is null, this prints
+     * just one commit that {@code to} represents.
+     *
+     * <p>
+     * If suppressMergeCommitDiff is false, for merge commit this method reports one diff per each parent.
+     *
+     * @param from a {@link org.eclipse.jgit.lib.ObjectId} object.
+     * @param to a {@link org.eclipse.jgit.lib.ObjectId} object.
+     * @param useRawOutput a {java.lang.Boolean} object.
+     * @param suppressMergeCommitDiff a {java.lang.Boolean} object.
+     * @return The git whatchanged output, in <code>raw</code> format.
+     * @throws hudson.plugins.git.GitException if underlying git operation fails.
+     * @throws java.lang.InterruptedException if interrupted.
+     */
+    List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean suppressMergeCommitDiff)
+            throws GitException, InterruptedException;
+    /**
      * Equivalent of "git-describe --tags".
      *
      * Find a nearby tag (including unannotated ones) and come up with a short identifier to describe the tag.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -2438,6 +2438,13 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     /** {@inheritDoc} */
     @Override
     public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput) throws GitException {
+        return showRevision(from, to, useRawOutput, false);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean suppressMergeCommitDiff)
+            throws GitException {
         try (Repository repo = getRepository();
                 ObjectReader or = repo.newObjectReader();
                 RevWalk w = new RevWalk(or)) {
@@ -2457,9 +2464,10 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     if (c.getParentCount() <= 1 || !useRawOutput) {
                         f.format(c, null, pw, useRawOutput);
                     } else {
-                        // the effect of the -m option, which makes the diff produce for each parent of a merge commit
-                        for (RevCommit p : c.getParents()) {
-                            f.format(c, p, pw, useRawOutput);
+                        if (!suppressMergeCommitDiff) {
+                            for (RevCommit p : c.getParents()) {
+                                f.format(c, p, pw, useRawOutput);
+                            }
                         }
                     }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/RemoteGitImpl.java
@@ -852,6 +852,12 @@ class RemoteGitImpl implements GitClient, hudson.plugins.git.IGitAPI, Serializab
         return proxy.showRevision(from, to, useRawOutput);
     }
 
+    @Override
+    public List<String> showRevision(ObjectId from, ObjectId to, Boolean useRawOutput, Boolean suppressMergeCommitDiff)
+            throws GitException, InterruptedException {
+        return proxy.showRevision(from, to, useRawOutput);
+    }
+
     /** {@inheritDoc} */
     @Override
     public boolean hasGitModules(String treeIsh) throws GitException, InterruptedException {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
I create this PR to fix the issues mentioned in the [PR#750](https://github.com/jenkinsci/git-client-plugin/pull/750).
The code changes are basically the same that in the closed PR but adding tests (thanks @anatoly-spb).

The issues are 
- https://issues.jenkins.io/browse/JENKINS-20389
- https://issues.jenkins.io/browse/JENKINS-23606
- https://issues.jenkins.io/browse/JENKINS-36180
- https://issues.jenkins.io/browse/JENKINS-65932

The goal of this pull request is to add the option to suppress merge commits diff in the `showRevision` methods, the feature is disabled by default to maintain backward compatibility.

I plan to create a pull request in the git plugin too to add the option to use this configuration in the `Polling ignores commits in certain paths` extension once this is merged.


### Testing done

I've ran all the unit test and the steps specified in the Contributing document.
I've also tested it in Jenkins with git plugin installed too.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
