### PR TITLE
Skip ssh host tests on ci.jenkins.io

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/AcceptFirstConnectionVerifierTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
+import static org.jenkinsci.plugins.gitclient.verifier.KnownHostsTestUtil.runKnownHostsTests;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -17,6 +18,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import org.awaitility.Awaitility;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +43,7 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyHostKeyOption() throws IOException {
+        Assume.assumeTrue(runKnownHostsTests());
         assertThat(
                 new AcceptFirstConnectionVerifier().forCliGit(TaskListener.NULL).getVerifyHostKeyOption(null),
                 is("-o StrictHostKeyChecking=accept-new -o HashKnownHosts=yes"));
@@ -48,6 +51,7 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenFirstConnection() throws Exception {
+        Assume.assumeTrue(runKnownHostsTests());
         File file = new File(testFolder.getRoot() + "path/to/file");
         AcceptFirstConnectionVerifier acceptFirstConnectionVerifier = spy(new AcceptFirstConnectionVerifier());
         when(acceptFirstConnectionVerifier.getKnownHostsFile()).thenReturn(file);
@@ -72,6 +76,7 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenSecondConnectionWithEqualKeys() throws Exception {
+        Assume.assumeTrue(runKnownHostsTests());
         String hostKeyEntry =
                 "|1|FJGXVAi7jMQIsl1J6uE6KnCiteM=|xlH92KQ91GuBgRxvRbU/sBo60Bo= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=";
 
@@ -100,6 +105,7 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenHostnameWithoutPort() throws Exception {
+        Assume.assumeTrue(runKnownHostsTests());
         String hostKeyEntry =
                 "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=";
         File mockedKnownHosts = knownHostsTestUtil.createFakeKnownHosts(hostKeyEntry);
@@ -123,6 +129,7 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenSecondConnectionWhenNotDefaultAlgorithm() throws Exception {
+        Assume.assumeTrue(runKnownHostsTests());
         String fileContent = "github.com,140.82.121.4"
                 + " ecdsa-sha2-nistp256"
                 + " AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=";
@@ -150,6 +157,7 @@ public class AcceptFirstConnectionVerifierTest {
     @Test
     @Ignore("FIXME not sure what is the test here")
     public void testVerifyServerHostKeyWhenSecondConnectionWithNonEqualKeys() throws Exception {
+        Assume.assumeTrue(runKnownHostsTests());
         String fileContent = "|1|f7esvmtaiBk+EMHjPzWbRYRpBPY=|T7Qe4QAksYPZPwYEx5QxQykSjfc=" // github.com:22
                 + " ssh-ed25519"
                 + " AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9OOOO";
@@ -177,6 +185,7 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenConnectionWithAnotherHost() throws Exception {
+        Assume.assumeTrue(runKnownHostsTests());
         String bitbucketFileContent = "|1|HnmPCP38pBhCY0NUtBXSraOg9pM=|L6YZ9asEeb2xplTDEThGOxRq7ZY="
                 + " ssh-rsa"
                 + " AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==";
@@ -206,6 +215,7 @@ public class AcceptFirstConnectionVerifierTest {
 
     @Test
     public void testVerifyServerHostKeyWhenHostnamePortProvided() throws Exception {
+        Assume.assumeTrue(runKnownHostsTests());
         String fileContent = "|1|6uMj3M7sLgZpn54vQbGqgPNTCVM=|OkV9Lu9REJZR5QCVrITAIY34I1M=" // github.com:59666
                 + " ssh-ed25519"
                 + " AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsFileVerifierTest.java
@@ -65,6 +65,7 @@ public class KnownHostsFileVerifierTest {
 
     @Test
     public void connectWhenHostKeyProvidedThenShouldNotFail() throws IOException {
+        Assume.assumeTrue(runKnownHostsTests());
         KnownHostsFileVerifier knownHostsFileVerifier = spy(new KnownHostsFileVerifier());
         when(knownHostsFileVerifier.getKnownHostsFile()).thenReturn(fakeKnownHosts);
 
@@ -85,6 +86,7 @@ public class KnownHostsFileVerifierTest {
 
     @Test
     public void connectWhenHostKeyInKnownHostsFileWithNotDefaultAlgorithmThenShouldNotFail() throws IOException {
+        Assume.assumeTrue(runKnownHostsTests());
         fakeKnownHosts = knownHostsTestUtil.createFakeKnownHosts(
                 "fake2.ssh",
                 "known_hosts_fake2",

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/ManuallyProvidedKeyVerifierTest.java
@@ -60,6 +60,7 @@ public class ManuallyProvidedKeyVerifierTest {
 
     @Test
     public void connectWhenHostKeyProvidedThenShouldNotFail() throws Exception {
+        Assume.assumeTrue(runKnownHostsTests());
         ManuallyProvidedKeyVerifier verifier = new ManuallyProvidedKeyVerifier(hostKey);
         ManuallyProvidedKeyVerifier.ManuallyProvidedKeyJGitHostKeyVerifier jGitHostKeyVerifier =
                 (ManuallyProvidedKeyVerifier.ManuallyProvidedKeyJGitHostKeyVerifier)
@@ -78,6 +79,7 @@ public class ManuallyProvidedKeyVerifierTest {
 
     @Test
     public void connectWhenWrongHostKeyProvidedThenShouldFail() throws Exception {
+        Assume.assumeTrue(runKnownHostsTests());
         String key = "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9OOOO";
         HostKeyVerifierFactory verifier = new ManuallyProvidedKeyVerifier(key);
 
@@ -97,6 +99,7 @@ public class ManuallyProvidedKeyVerifierTest {
 
     @Test
     public void connectWhenHostKeyProvidedWithPortThenShouldNotFail() throws Exception {
+        Assume.assumeTrue(runKnownHostsTests());
         String key =
                 "github.com:22 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=";
         HostKeyVerifierFactory verifier = new ManuallyProvidedKeyVerifier(key);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/NoHostKeyVerifierTest.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.gitclient.verifier;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.jenkinsci.plugins.gitclient.verifier.KnownHostsTestUtil.runKnownHostsTests;
 
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.time.Duration;
 import org.awaitility.Awaitility;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,6 +25,7 @@ public class NoHostKeyVerifierTest {
 
     @Test
     public void verifyServerHostKey() throws IOException {
+        Assume.assumeTrue(runKnownHostsTests());
         NoHostKeyVerifier acceptFirstConnectionVerifier = new NoHostKeyVerifier();
 
         KnownHostsTestUtil.connectToHost(


### PR DESCRIPTION
## Skip ssh host verifier tests on ci.jenkins.io

The GitHub SSH abuse prevention system rejects connections from the tests when they are run on ci.jenkins.io.  These tests should only be run as end to end acceptance tests but they are not too disruptive (for now) to continue to be included in the default tests.

Additional tests should be created that use test containers so that they can use the ssh connection on the test container instead of using the GitHub.com SSH servers.

Unfortunately, I can't prioritize that test rewrite now, so these tests are disabled on ci.jenkins.io.

### Testing done

Confirmed that automated tests pass locally where the tests are not excluded.  Final confirmation on ci.jenkins.io where the tests will fail if not excluded.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
