### PR TITLE
Use try with resources in JGit

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1620,8 +1620,6 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public void execute() throws GitException {
-                Repository repository = null;
-
                 try {
                     // the directory needs to be clean or else JGit complains
                     if (workspace.exists()) {
@@ -1647,41 +1645,43 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         builder.addAlternateObjectDirectory(new File(reference));
                     }
 
-                    repository = builder.build();
-                    repository.create();
+                    try (Repository repository = builder.build()) {
+                        repository.create();
 
-                    // the repository builder does not create the alternates file
-                    if (reference != null && !reference.isEmpty()) {
-                        File referencePath = new File(reference);
-                        if (!referencePath.exists()) {
-                            listener.getLogger().println("[WARNING] Reference path does not exist: " + reference);
-                        } else if (!referencePath.isDirectory()) {
-                            listener.getLogger().println("[WARNING] Reference path is not a directory: " + reference);
-                        } else {
-                            // reference path can either be a normal or a base repository
-                            File objectsPath = new File(referencePath, ".git/objects");
-                            if (!objectsPath.isDirectory()) {
-                                // reference path is bare repo
-                                objectsPath = new File(referencePath, "objects");
-                            }
-                            if (!objectsPath.isDirectory()) {
+                        // the repository builder does not create the alternates file
+                        if (reference != null && !reference.isEmpty()) {
+                            File referencePath = new File(reference);
+                            if (!referencePath.exists()) {
+                                listener.getLogger().println("[WARNING] Reference path does not exist: " + reference);
+                            } else if (!referencePath.isDirectory()) {
                                 listener.getLogger()
-                                        .println(
-                                                "[WARNING] Reference path does not contain an objects directory (no git repo?): "
-                                                        + objectsPath);
+                                        .println("[WARNING] Reference path is not a directory: " + reference);
                             } else {
-                                try {
-                                    File alternates = new File(workspace, ".git/objects/info/alternates");
-                                    String absoluteReference =
-                                            objectsPath.getAbsolutePath().replace('\\', '/');
-                                    listener.getLogger().println("Using reference repository: " + reference);
-                                    // git implementations on windows also use
-                                    try (PrintWriter w = new PrintWriter(alternates, StandardCharsets.UTF_8)) {
+                                // reference path can either be a normal or a base repository
+                                File objectsPath = new File(referencePath, ".git/objects");
+                                if (!objectsPath.isDirectory()) {
+                                    // reference path is bare repo
+                                    objectsPath = new File(referencePath, "objects");
+                                }
+                                if (!objectsPath.isDirectory()) {
+                                    listener.getLogger()
+                                            .println(
+                                                    "[WARNING] Reference path does not contain an objects directory (no git repo?): "
+                                                            + objectsPath);
+                                } else {
+                                    try {
+                                        File alternates = new File(workspace, ".git/objects/info/alternates");
+                                        String absoluteReference =
+                                                objectsPath.getAbsolutePath().replace('\\', '/');
+                                        listener.getLogger().println("Using reference repository: " + reference);
                                         // git implementations on windows also use
-                                        w.print(absoluteReference);
+                                        try (PrintWriter w = new PrintWriter(alternates, StandardCharsets.UTF_8)) {
+                                            // git implementations on windows also use
+                                            w.print(absoluteReference);
+                                        }
+                                    } catch (FileNotFoundException e) {
+                                        listener.error("Failed to setup reference");
                                     }
-                                } catch (FileNotFoundException e) {
-                                    listener.error("Failed to setup reference");
                                 }
                             }
                         }
@@ -1689,45 +1689,39 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                     // Jgit repository has alternates directory set, but seems to ignore them
                     // Workaround: close this repo and create a new one
-                    repository.close();
-                    repository = getRepository();
-
-                    if (refspecs == null) {
-                        refspecs =
-                                Collections.singletonList(new RefSpec("+refs/heads/*:refs/remotes/" + remote + "/*"));
-                    }
-                    FetchCommand fetch = new Git(repository)
-                            .fetch()
-                            .setProgressMonitor(new JGitProgressMonitor(listener))
-                            .setRemote(url)
-                            .setCredentialsProvider(getProvider())
-                            .setTransportConfigCallback(getTransportConfigCallback())
-                            .setTagOpt(tags ? TagOpt.FETCH_TAGS : TagOpt.NO_TAGS)
-                            .setRefSpecs(refspecs);
-                    setTransportTimeout(fetch, "fetch", timeout);
-                    if (shallow) {
-                        if (depth == null) {
-                            depth = 1;
+                    try (Repository repository = getRepository()) {
+                        if (refspecs == null) {
+                            refspecs = Collections.singletonList(
+                                    new RefSpec("+refs/heads/*:refs/remotes/" + remote + "/*"));
                         }
-                        fetch.setDepth(depth);
+                        FetchCommand fetch = new Git(repository)
+                                .fetch()
+                                .setProgressMonitor(new JGitProgressMonitor(listener))
+                                .setRemote(url)
+                                .setCredentialsProvider(getProvider())
+                                .setTransportConfigCallback(getTransportConfigCallback())
+                                .setTagOpt(tags ? TagOpt.FETCH_TAGS : TagOpt.NO_TAGS)
+                                .setRefSpecs(refspecs);
+                        setTransportTimeout(fetch, "fetch", timeout);
+                        if (shallow) {
+                            if (depth == null) {
+                                depth = 1;
+                            }
+                            fetch.setDepth(depth);
+                        }
+                        fetch.call();
+
+                        StoredConfig config = repository.getConfig();
+                        config.setString("remote", remote, "url", url);
+                        config.setStringList(
+                                "remote",
+                                remote,
+                                "fetch",
+                                refspecs.stream().map(Object::toString).collect(Collectors.toList()));
+                        config.save();
                     }
-                    fetch.call();
-
-                    StoredConfig config = repository.getConfig();
-                    config.setString("remote", remote, "url", url);
-                    config.setStringList(
-                            "remote",
-                            remote,
-                            "fetch",
-                            refspecs.stream().map(Object::toString).collect(Collectors.toList()));
-                    config.save();
-
                 } catch (GitAPIException | IOException e) {
                     throw new GitException(e);
-                } finally {
-                    if (repository != null) {
-                        repository.close();
-                    }
                 }
             }
         };

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -3097,7 +3097,6 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     @Deprecated
     @Override
     public boolean isBareRepository(String GIT_DIR) throws GitException, InterruptedException {
-        Repository repo = null;
         boolean isBare = false;
         if (GIT_DIR == null) {
             throw new GitException("Not a git repository"); // Compatible with CliGitAPIImpl
@@ -3105,20 +3104,23 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         try {
             if (isBlank(GIT_DIR) || !(new File(GIT_DIR)).isAbsolute()) {
                 if ((new File(workspace, ".git")).exists()) {
-                    repo = getRepository();
+                    try (Repository repo = getRepository()) {
+                        isBare = repo.isBare();
+                    }
                 } else {
-                    repo = new RepositoryBuilder().setGitDir(workspace).build();
+                    try (Repository repo =
+                            new RepositoryBuilder().setGitDir(workspace).build()) {
+                        isBare = repo.isBare();
+                    }
                 }
             } else {
-                repo = new RepositoryBuilder().setGitDir(new File(GIT_DIR)).build();
+                try (Repository repo =
+                        new RepositoryBuilder().setGitDir(new File(GIT_DIR)).build()) {
+                    isBare = repo.isBare();
+                }
             }
-            isBare = repo.isBare();
         } catch (IOException ioe) {
             throw new GitException(ioe);
-        } finally {
-            if (repo != null) {
-                repo.close();
-            }
         }
         return isBare;
     }


### PR DESCRIPTION
## Use try with resources in JGit

While evaluating an open file leak in JGit 7.2.0, I found several places in the JGitAPIImpl repository operations that could be simplified by using the Java try with resources facility instead of managing the repository closing inside JGitAPIImpl.  These changes do not resolve the open file leak in JGit 7.2.0, but they make it easier to reason about the open repositories in JGitAPIImpl.  It is intended that this changes no behavior, since the previous implementation was also believed to be cleanly and correctly closing file descriptors.

This pull request is extracted from:

* https://github.com/jenkinsci/git-client-plugin/pull/1262

Best reviewed with [whitespace differences suppressed](https://github.com/jenkinsci/git-client-plugin/pull/1269/files?w=1) by adding the `?w=1` argument on the GitHub review page or by using `git diff -w master`.

I'd appreciate a review from @olamy or @rsandell to confirm that the change is behavior preserving.

### JGit doCheckoutWithResetAndRetry

The JGit implementation for doCheckoutWithResetAndRetry needs to remove conflicting files that might have been created during a checkout.  The conflicting file removal was previously done by closing the repository and opening the repository again for the cleanup.

Rather than use such complicated logic with the risk that files won't be closed on exceptions, let's switch to try with resources so that Java will close the repository on exit from the block.

### JGit clone_()

The CloneCommand implementation configures the Git alternates and then closes and reopens the repository so that JGit recognizes the updated alternates configuration.  Use try with resources in the code that adds the alternates and in the code that reopens the repository after the Git alternates are configured.

### Use try with resources in JGit isBareRepository()

Reduce the visibility of the repository variable to only the context where isBare() is called.  Simplifies repository closing to reduce chance of leaking an open file in error cases.

### Testing done

Automated tests pass.  Interactive tests detected no issue while testing:

* https://github.com/jenkinsci/git-client-plugin/pull/1262

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
