### PR TITLE
[CVE-2025-4049] XXE vulnerability in Eclipse JGit (non-impacting)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <jgit.version>7.0.0.202409031743-r</jgit.version>
+    <jgit.version>7.0.1.202505221510-r</jgit.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>


### PR DESCRIPTION
## [CVE-2025-4049] XXE vulnerability in Eclipse JGit (non-impacting)

[JGit 7.0.1](https://projects.eclipse.org/projects/technology.jgit/releases/7.0.1) reports that CVE-2025-4049 is fixed in JGit 7.0.1.

[CVE-2025-4049](https://www.cve.org/CVERecord?id=CVE-2025-4949) describes the issue as :

> the ManifestParser class used by the repo command and the AmazonS3 class used to implement the experimental amazons3 git transport protocol allowing to store git pack files in an Amazon S3 bucket, are vulnerable to XML External Entity (XXE) attacks when parsing XML files. This vulnerability can lead to information disclosure, denial of service, and other security issues.  

This upgrade is a safeguard against scanner reports of a vulnerability that does not actually affect the git client plugin.  The vulnerability does not apply to the git client plugin because the git client plugin does not use the ManifestParser class or the RepoCommand class that depends on ManifestParser.

A GitHub search showed no use of RepoCommand in any of the jenkinsci organization.

### Testing done

Automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
