### PR TITLE
Add ssh.dev.azure.com as remote hosts test candidate

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/verifier/KnownHostsTestUtil.java
@@ -142,7 +142,7 @@ public class KnownHostsTestUtil {
     private static String[] nonGitHubHosts = {
         // bitbucket.org blocks requests from ci.jenkins.io agents
         // "bitbucket.org",
-        "git.assembla.com", "gitea.com", "gitlab.com", "vs-ssh.visualstudio.com",
+        "git.assembla.com", "gitea.com", "gitlab.com", "vs-ssh.visualstudio.com", "ssh.dev.azure.com"
     };
 
     /* Return hostname of a non-GitHub ssh provider */


### PR DESCRIPTION
## Add ssh.dev.azure.com as remote hosts test candidate

Microsoft Azure DevOps has transitioned from visualstudio.com as their base URL to dev.azure.com as base URL.  Include that base URL in the SSH known hosts test.

### Testing done

* Ran tests multiple times and confirmed that the URL was included in the test output

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
