### PR TITLE
`HttpTransport` ≠ `TransportHttp`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -125,7 +125,6 @@ import org.eclipse.jgit.storage.file.WindowCacheConfig;
 import org.eclipse.jgit.submodule.SubmoduleWalk;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.FetchConnection;
-import org.eclipse.jgit.transport.HttpTransport;
 import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteConfig;
@@ -993,7 +992,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             if (transport instanceof SshTransport sshTransport) {
                 sshTransport.setSshSessionFactory(buildSshdSessionFactory(this.hostKeyVerifierFactory));
             }
-            if (transport instanceof HttpTransport) {
+            if (transport instanceof TransportHttp) {
                 ((TransportHttp) transport)
                         .setHttpConnectionFactory(new PreemptiveAuthHttpClientConnectionFactory(getProvider()));
             }
@@ -1004,7 +1003,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         if (tn instanceof SshTransport transport) {
             transport.setSshSessionFactory(buildSshdSessionFactory(getHostKeyFactory()));
         }
-        if (tn instanceof HttpTransport) {
+        if (tn instanceof TransportHttp) {
             ((TransportHttp) tn).setHttpConnectionFactory(new PreemptiveAuthHttpClientConnectionFactory(getProvider()));
         }
     }


### PR DESCRIPTION
This looked wrong. Any non-`TransportHttp` `HttpTransport` would run into a `ClassCastException`.

### Testing done

None

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
