### PR TITLE
[JENKINS-76004] Use git log instead of git whatchanged for changelog

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -88,4 +88,4 @@ Run the benchmarks with the command:
 
 * `mvn -P jmh-benchmark -Dbenchmark.run=true test`
 
-The results can be reviewed visiually by pasting the resulting `jmh-report.json` file into the link:https://jmh.morethan.io/[online JMH visualizer].
+The results can be reviewed visually by pasting the resulting `jmh-report.json` file into the link:https://jmh.morethan.io/[online JMH visualizer].

--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -8,7 +8,7 @@ import org.eclipse.jgit.lib.ObjectId;
  * Command builder for generating changelog in the format {@code GitSCM} expects.
  *
  * <p>
- * The output format is that of <code>git-whatchanged</code>, which looks something like this:
+ * The output format is that of <code>git log --raw</code>, which looks something like this:
  *
  * <pre>
  * commit dadaf808d99c4c23c53476b0c48e25a181016300

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1300,7 +1300,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public void execute() throws GitException, InterruptedException {
-                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "whatchanged", "--no-abbrev", "-M");
+                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "log", "--raw", "--no-abbrev", "-M");
                 if (isAtLeastVersion(1, 8, 3, 0)) {
                     args.add("--format=" + RAW);
                 } else {
@@ -1318,7 +1318,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     throw new IllegalStateException();
                 }
 
-                // "git whatchanged" std output gives us byte stream of data
+                // "git log" std output gives us byte stream of data
                 // Commit messages in that byte stream are UTF-8 encoded.
                 // We want to decode bytestream to strings using UTF-8 encoding.
                 try (WriterOutputStream w = new WriterOutputStream(out, StandardCharsets.UTF_8)) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -886,7 +886,7 @@ public interface GitClient {
     void addNote(String note, String namespace) throws GitException, InterruptedException;
 
     /**
-     * Given a Revision, show it as if it were an entry from git whatchanged, so that it
+     * Given a Revision, show it as if it were an entry from git log --raw, so that it
      * can be parsed by GitChangeLogParser.
      *
      * <p>
@@ -898,14 +898,14 @@ public interface GitClient {
      * behave differently from {@link #changelog()}.
      *
      * @param r a {@link org.eclipse.jgit.lib.ObjectId} object.
-     * @return The git whatchanged output, in <code>raw</code> format.
+     * @return The git log output, in <code>raw</code> format.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
     List<String> showRevision(ObjectId r) throws GitException, InterruptedException;
 
     /**
-     * Given a Revision, show it as if it were an entry from git whatchanged, so that it
+     * Given a Revision, show it as if it were an entry from git log --raw, so that it
      * can be parsed by GitChangeLogParser.
      *
      * <p>
@@ -918,14 +918,14 @@ public interface GitClient {
      *
      * @param from a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @param to a {@link org.eclipse.jgit.lib.ObjectId} object.
-     * @return The git whatchanged output, in <code>raw</code> format.
+     * @return The git log output, in <code>raw</code> format.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
     List<String> showRevision(ObjectId from, ObjectId to) throws GitException, InterruptedException;
 
     /**
-     * Given a Revision, show it as if it were an entry from git whatchanged, so that it
+     * Given a Revision, show it as if it were an entry from <code>git log --raw</code>, so that it
      * can be parsed by GitChangeLogParser.
      *
      * <p>
@@ -943,7 +943,7 @@ public interface GitClient {
      * @param from a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @param to a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @param useRawOutput a {java.lang.Boolean} object.
-     * @return The git whatchanged output, in <code>raw</code> format.
+     * @return The git log output, in <code>raw</code> format.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1394,7 +1394,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         this.includes("HEAD");
                     }
                     for (RevCommit commit : walk) {
-                        // git whatachanged doesn't show the merge commits unless -m is given
+                        // git log --raw doesn't show the merge commits unless -m is given
                         if (commit.getParentCount() > 1) {
                             continue;
                         }
@@ -1402,7 +1402,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         formatter.format(commit, null, pw, true);
                     }
                 } catch (IOException e) {
-                    throw new GitException("Error: jgit whatchanged in " + workspace + " " + e.getMessage(), e);
+                    throw new GitException("Error: jgit log --raw in " + workspace + " " + e.getMessage(), e);
                 } finally {
                     closeResources();
                 }
@@ -1444,7 +1444,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
          *      Commit to format.
          * @param parent
          *      Optional parent commit to produce the diff against. This only matters
-         *      for merge commits, and git-log/git-whatchanged/etc behaves differently with respect to this.
+         *      for merge commits, and git-log behaves differently with respect to this.
          */
         @SuppressFBWarnings(
                 value = "VA_FORMAT_STRING_USES_NEWLINE",


### PR DESCRIPTION
## [JENKINS-76004] Use git log instead of git whatchanged for changelog

Command line git 2.51.0 has deprecated the "git whatchanged" command and recommends that it be replaced with "git log --raw".  Refer to the [blog post](https://github.blog/open-source/git/highlights-from-git-2-51/)

### Testing done

Interactive testing confirmed that without this change, the changelog that is usually displayed on a freestyle project will silently remain empty when using command line git 2.51.0.

With this change, the changelog displays as expected.

Automated tests pass on:

* Debian 11 (Git 2.30)
* Debian 12 (Git 2.39)
* FreeBSD 14 (Git 2.50)
* Red Hat 8 (Git 2.51, built from source code)
* Ubuntu 22 (Git 2.34)
* Ubuntu 24 (Git 2.43)
* Windows 11 (Git 2.50.1)

Those test combinations are a wide range of versions of command line git.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
