### PR TITLE
[JENKINS-76026] Do not show merges in changelog

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -8,7 +8,7 @@ import org.eclipse.jgit.lib.ObjectId;
  * Command builder for generating changelog in the format {@code GitSCM} expects.
  *
  * <p>
- * The output format is that of <code>git log --raw</code>, which looks something like this:
+ * The output format is that of <code>git log --raw --no-merges</code>, which looks something like this:
  *
  * <pre>
  * commit dadaf808d99c4c23c53476b0c48e25a181016300

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1300,7 +1300,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public void execute() throws GitException, InterruptedException {
-                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "log", "--raw", "--no-abbrev", "-M");
+                ArgumentListBuilder args =
+                        new ArgumentListBuilder(gitExe, "log", "--raw", "--no-merges", "--no-abbrev", "-M");
                 if (isAtLeastVersion(1, 8, 3, 0)) {
                     args.add("--format=" + RAW);
                 } else {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1394,7 +1394,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         this.includes("HEAD");
                     }
                     for (RevCommit commit : walk) {
-                        // git log --raw doesn't show the merge commits unless -m is given
+                        // git log --raw --no-merges doesn't show merge commits
                         if (commit.getParentCount() > 1) {
                             continue;
                         }
@@ -1402,7 +1402,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         formatter.format(commit, null, pw, true);
                     }
                 } catch (IOException e) {
-                    throw new GitException("Error: jgit log --raw in " + workspace + " " + e.getMessage(), e);
+                    throw new GitException(
+                            "Error: jgit log --raw --no-merges in " + workspace + " " + e.getMessage(), e);
                 } finally {
                     closeResources();
                 }
@@ -1444,7 +1445,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
          *      Commit to format.
          * @param parent
          *      Optional parent commit to produce the diff against. This only matters
-         *      for merge commits, and git-log behaves differently with respect to this.
+         *      for merge commits and git-log behaves differently with respect to this.
          */
         @SuppressFBWarnings(
                 value = "VA_FORMAT_STRING_USES_NEWLINE",


### PR DESCRIPTION
## [JENKINS-76026] Do not show merges in changelog

Git client 6.3.1 adapted the git client plugin to support command line git 2.51.0 where the "whatchanged" command has been deprecated.  However, the change introduced an inconsistency between the CLI git implementation and the JGit implementation.

Prior to git client plugin 6.3.1, the changelog skipped merge commits in all cases.

With git client 6.3.1, the CLI git changelog includes merge commits.  With git client 6.3.1, the JGit changelog does not include merge commits.

### Testing done

* Confirmed the bug with interactive testing of git client plugin 6.3.1
* Wrote an automated test that shows the inconsistency
* Confirmed that the automated test passes with git client 6.3.1 for JGit
* Confirmed that the automated test fails with git client 6.3.1 for CLI git and passes with the fix

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
