### PR TITLE
Support command line git 2.51.0

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -88,4 +88,4 @@ Run the benchmarks with the command:
 
 * `mvn -P jmh-benchmark -Dbenchmark.run=true test`
 
-The results can be reviewed visiually by pasting the resulting `jmh-report.json` file into the link:https://jmh.morethan.io/[online JMH visualizer].
+The results can be reviewed visually by pasting the resulting `jmh-report.json` file into the link:https://jmh.morethan.io/[online JMH visualizer].

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,12 @@
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  forkCount: '1C', // Run a JVM per core in tests
+  // we use Docker for containerized tests
+  useContainerAgent: false,
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -8,7 +8,7 @@ import org.eclipse.jgit.lib.ObjectId;
  * Command builder for generating changelog in the format {@code GitSCM} expects.
  *
  * <p>
- * The output format is that of <code>git log --raw</code>, which looks something like this:
+ * The output format is that of <code>git log --raw --no-merges</code>, which looks something like this:
  *
  * <pre>
  * commit dadaf808d99c4c23c53476b0c48e25a181016300

--- a/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/ChangelogCommand.java
@@ -8,7 +8,7 @@ import org.eclipse.jgit.lib.ObjectId;
  * Command builder for generating changelog in the format {@code GitSCM} expects.
  *
  * <p>
- * The output format is that of <code>git-whatchanged</code>, which looks something like this:
+ * The output format is that of <code>git log --raw</code>, which looks something like this:
  *
  * <pre>
  * commit dadaf808d99c4c23c53476b0c48e25a181016300

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1297,7 +1297,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public void execute() throws GitException, InterruptedException {
-                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "log", "--raw", "--no-abbrev", "-M");
+                ArgumentListBuilder args =
+                        new ArgumentListBuilder(gitExe, "log", "--raw", "--no-merges", "--no-abbrev", "-M");
                 if (isAtLeastVersion(1, 8, 3, 0)) {
                     args.add("--format=" + RAW);
                 } else {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1297,7 +1297,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public void execute() throws GitException, InterruptedException {
-                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "whatchanged", "--no-abbrev", "-M");
+                ArgumentListBuilder args = new ArgumentListBuilder(gitExe, "log", "--raw", "--no-abbrev", "-M");
                 if (isAtLeastVersion(1, 8, 3, 0)) {
                     args.add("--format=" + RAW);
                 } else {
@@ -1315,7 +1315,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     throw new IllegalStateException();
                 }
 
-                // "git whatchanged" std output gives us byte stream of data
+                // "git log" std output gives us byte stream of data
                 // Commit messages in that byte stream are UTF-8 encoded.
                 // We want to decode bytestream to strings using UTF-8 encoding.
                 try (WriterOutputStream w = new WriterOutputStream(out, StandardCharsets.UTF_8)) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/GitClient.java
@@ -886,7 +886,7 @@ public interface GitClient {
     void addNote(String note, String namespace) throws GitException, InterruptedException;
 
     /**
-     * Given a Revision, show it as if it were an entry from git whatchanged, so that it
+     * Given a Revision, show it as if it were an entry from git log --raw, so that it
      * can be parsed by GitChangeLogParser.
      *
      * <p>
@@ -898,14 +898,14 @@ public interface GitClient {
      * behave differently from {@link #changelog()}.
      *
      * @param r a {@link org.eclipse.jgit.lib.ObjectId} object.
-     * @return The git whatchanged output, in <code>raw</code> format.
+     * @return The git log output, in <code>raw</code> format.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
     List<String> showRevision(ObjectId r) throws GitException, InterruptedException;
 
     /**
-     * Given a Revision, show it as if it were an entry from git whatchanged, so that it
+     * Given a Revision, show it as if it were an entry from git log --raw, so that it
      * can be parsed by GitChangeLogParser.
      *
      * <p>
@@ -918,14 +918,14 @@ public interface GitClient {
      *
      * @param from a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @param to a {@link org.eclipse.jgit.lib.ObjectId} object.
-     * @return The git whatchanged output, in <code>raw</code> format.
+     * @return The git log output, in <code>raw</code> format.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */
     List<String> showRevision(ObjectId from, ObjectId to) throws GitException, InterruptedException;
 
     /**
-     * Given a Revision, show it as if it were an entry from git whatchanged, so that it
+     * Given a Revision, show it as if it were an entry from <code>git log --raw</code>, so that it
      * can be parsed by GitChangeLogParser.
      *
      * <p>
@@ -943,7 +943,7 @@ public interface GitClient {
      * @param from a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @param to a {@link org.eclipse.jgit.lib.ObjectId} object.
      * @param useRawOutput a {java.lang.Boolean} object.
-     * @return The git whatchanged output, in <code>raw</code> format.
+     * @return The git log output, in <code>raw</code> format.
      * @throws hudson.plugins.git.GitException if underlying git operation fails.
      * @throws java.lang.InterruptedException if interrupted.
      */

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1350,7 +1350,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         this.includes("HEAD");
                     }
                     for (RevCommit commit : walk) {
-                        // git log --raw doesn't show the merge commits unless -m is given
+                        // git log --raw --no-merges doesn't show merge commits
                         if (commit.getParentCount() > 1) {
                             continue;
                         }
@@ -1358,7 +1358,8 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         formatter.format(commit, null, pw, true);
                     }
                 } catch (IOException e) {
-                    throw new GitException("Error: jgit log --raw in " + workspace + " " + e.getMessage(), e);
+                    throw new GitException(
+                            "Error: jgit log --raw --no-merges in " + workspace + " " + e.getMessage(), e);
                 } finally {
                     closeResources();
                 }
@@ -1400,7 +1401,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
          *      Commit to format.
          * @param parent
          *      Optional parent commit to produce the diff against. This only matters
-         *      for merge commits, and git-log behaves differently with respect to this.
+         *      for merge commits and git-log behaves differently with respect to this.
          */
         @SuppressFBWarnings(
                 value = "VA_FORMAT_STRING_USES_NEWLINE",

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -1350,7 +1350,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         this.includes("HEAD");
                     }
                     for (RevCommit commit : walk) {
-                        // git whatachanged doesn't show the merge commits unless -m is given
+                        // git log --raw doesn't show the merge commits unless -m is given
                         if (commit.getParentCount() > 1) {
                             continue;
                         }
@@ -1358,7 +1358,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         formatter.format(commit, null, pw, true);
                     }
                 } catch (IOException e) {
-                    throw new GitException("Error: jgit whatchanged in " + workspace + " " + e.getMessage(), e);
+                    throw new GitException("Error: jgit log --raw in " + workspace + " " + e.getMessage(), e);
                 } finally {
                     closeResources();
                 }
@@ -1400,7 +1400,7 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
          *      Commit to format.
          * @param parent
          *      Optional parent commit to produce the diff against. This only matters
-         *      for merge commits, and git-log/git-whatchanged/etc behaves differently with respect to this.
+         *      for merge commits, and git-log behaves differently with respect to this.
          */
         @SuppressFBWarnings(
                 value = "VA_FORMAT_STRING_USES_NEWLINE",

--- a/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplUnsupportedProtocolTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/JGitAPIImplUnsupportedProtocolTest.java
@@ -1,0 +1,144 @@
+package org.jenkinsci.plugins.gitclient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitException;
+import java.util.List;
+import java.util.Random;
+import org.eclipse.jgit.lib.Config;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * JGit supports the 'amazon-s3' protocol but the Jenkins git client
+ * plugin is not tested with that protocol.  Command line git does not
+ * support the 'amazon-s3' protocol.  Since command line git is the
+ * reference implementation for the git client plugin, there is no
+ * reason to support the 'amazon-s3' protocol.  Plugin releases 6.2.0
+ * and before would report a class cast exception if a user used the
+ * 'amazon-s3' protocol.  It was not usable by users.
+ */
+public class JGitAPIImplUnsupportedProtocolTest {
+
+    private JGitAPIImpl jgit = null;
+
+    private URIish url = null;
+    private String urlStr = null;
+
+    private String expectedMessage = null;
+
+    private final Random random = new Random();
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void setup() throws Exception {
+        url = new URIish("amazon-s3://@host/path-" + random.nextInt());
+        urlStr = url.toString();
+        jgit = new JGitAPIImpl(folder.getRoot(), TaskListener.NULL);
+        expectedMessage = "unsupported protocol in URL " + urlStr;
+    }
+
+    @Test
+    public void testFetchCommand() throws Exception {
+        List<RefSpec> refspecs = null;
+        var thrown = assertThrows(
+                GitException.class, () -> jgit.fetch_().from(url, refspecs).execute());
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    public void testGetRemoteReferences() throws Exception {
+        String pattern = ".*";
+        boolean headsOnly = random.nextBoolean();
+        boolean tagsOnly = random.nextBoolean();
+        var thrown =
+                assertThrows(GitException.class, () -> jgit.getRemoteReferences(urlStr, pattern, headsOnly, tagsOnly));
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    public void testGetRemoteSymbolicReferences() throws Exception {
+        String pattern = ".*";
+        var thrown = assertThrows(GitException.class, () -> jgit.getRemoteSymbolicReferences(urlStr, pattern));
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    public void testGetHeadRev() throws Exception {
+        String branchSpec = "origin/my-branch-" + random.nextInt();
+        var thrown = assertThrows(GitException.class, () -> jgit.getHeadRev(urlStr, branchSpec));
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    public void testSetRemoteUrl() throws Exception {
+        String name = "upstream-" + random.nextInt();
+        var thrown = assertThrows(GitException.class, () -> jgit.setRemoteUrl(name, urlStr));
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    public void testAddRemoteUrl() throws Exception {
+        String name = "upstream-" + random.nextInt();
+        var thrown = assertThrows(GitException.class, () -> jgit.addRemoteUrl(name, urlStr));
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    public void testCloneCommand() throws Exception {
+        var thrown =
+                assertThrows(GitException.class, () -> jgit.clone_().url(urlStr).execute());
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    public void testAddSubmodule() throws Exception {
+        var thrown = assertThrows(GitException.class, () -> jgit.addSubmodule(urlStr, "subdir"));
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    public void testPushCommand() throws Exception {
+        var thrown = assertThrows(GitException.class, () -> jgit.push().to(url).execute());
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    public void testPrune() throws Exception {
+        // Create a local git repository
+        jgit.init_().workspace(folder.getRoot().getAbsolutePath()).execute();
+        // Locally modify the remote URL inside existing local git repository
+        String remoteName = "amazons3-remote";
+        jgit.config(GitClient.ConfigLevel.LOCAL, "remote." + remoteName + ".url", urlStr);
+        // Confirm that locally modified remote URL with amazon-s3 protocol throws
+        var thrown = assertThrows(GitException.class, () -> jgit.prune(new RemoteConfig(new Config(), remoteName)));
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    @Deprecated
+    public void testSetSubmoduleUrl() throws Exception {
+        var thrown = assertThrows(GitException.class, () -> jgit.setSubmoduleUrl("submodule-name", urlStr));
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+
+    @Test
+    @Deprecated
+    public void testSetRemoteUrl3Args() throws Exception {
+        // Create a local git repository so that remote URL is not altered in working directory
+        String repoDir = folder.getRoot().getAbsolutePath();
+        jgit.init_().workspace(repoDir).execute();
+        var thrown = assertThrows(GitException.class, () -> jgit.setRemoteUrl("remote-name", urlStr, repoDir));
+        assertThat(thrown.getMessage(), is(expectedMessage));
+    }
+}


### PR DESCRIPTION
## Support command line git 2.51.0

Jenkins plugin BOM line 2.492.x needs the change that supports command line git 2.51.0.  That needs a release of the git client plugin stable-6.1 line.  Include the fix for SECURITY-3590 as well so that the vulnerability is fixed for the 2.492.x line.

Backported from pull requests:

* https://github.com/jenkinsci/git-client-plugin/pull/1326
* https://github.com/jenkinsci/git-client-plugin/pull/1327

The fix for SECURITY-3590 is cherry picked from 20090a86c3ebc72e5283c882de73e3a4459137bb

### Testing done

Confirmed that automated tests pass.

Confirmed interactively that SECURITY-3590 is visible without this change and that it is fixed with this change.

Confirmed interactively that change generation fails on command line git 2.51.0 without this change and succeeds with this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
