### PR TITLE
Run GitClientTest.testSparseCheckoutWithCliGitLFS when credentials available

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
@@ -1373,18 +1375,23 @@ public class GitClientTest {
         assertFileContent("uuid.txt", "5e7733d8acc94636850cb466aec524e4");
     }
 
+    private static final File HOME_DIR = new File(System.getProperty("user.home"));
+    private static final File SSH_DIR = new File(HOME_DIR, ".ssh");
+    private static final Path LFS_TOKEN_PATH = (new File(SSH_DIR, "jenkins-pipeline-utils-lfs-access-token").toPath());
+
     @Issue("JENKINS-43427") // Git LFS sparse checkout support
     @Test
     public void testSparseCheckoutWithCliGitLFS() throws Exception {
-        String JENKINS_URL = System.getenv("JENKINS_URL") != null ? System.getenv("JENKINS_URL") : "";
-        if (JENKINS_URL.contains("ci.jenkins.io")
-                || !gitImplName.equals("git")
-                || !CLI_GIT_HAS_GIT_LFS
-                || isWindows()) {
-            /* Test fails sporadically on ci.jenkins.io with GitHub error 'bad credentials' */
-            /* Slow test that does not tell us much more on Windows than Linux */
+        if (!gitImplName.equals("git") || !LFS_TOKEN_PATH.toFile().exists()) {
+            /* Git LFS not implemented in JGitAPIImpl */
+            /* Test requires an LFS credential for checkout, otherwise fails with GitHub error 'bad credentials' */
             return;
         }
+        String password = Files.readAllLines(LFS_TOKEN_PATH).get(0).trim();
+        String username = "MarkEWaite";
+        String id = "mwaite-lfs-credential-id";
+        String desc = "Mark Waite's LFS credential for a public repository";
+        var credential = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, id, desc, username, password);
 
         String branch = "tests/largeFileSupport";
 
@@ -1418,6 +1425,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths)
                     .execute();
 
@@ -1443,6 +1451,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths)
                     .execute();
 
@@ -1469,6 +1478,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths)
                     .execute();
 
@@ -1494,6 +1504,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths)
                     .execute();
 
@@ -1519,6 +1530,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths)
                     .execute();
 
@@ -1544,6 +1556,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths)
                     .execute();
 
@@ -1569,6 +1582,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths)
                     .execute();
 
@@ -1594,6 +1608,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths)
                     .execute();
 
@@ -1619,6 +1634,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths1)
                     .execute();
 
@@ -1676,6 +1692,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths)
                     .execute();
 
@@ -1701,6 +1718,7 @@ public class GitClientTest {
                     .checkout()
                     .ref(remote + "/" + branch)
                     .lfsRemote(remote)
+                    .lfsCredentials(credential)
                     .sparseCheckoutPaths(sparsePaths)
                     .execute();
 


### PR DESCRIPTION
## Run GitClientTest.testSparseCheckoutWithCliGitLFS when credentials available

The test fails in nearly 100% of cases when credentials are not provided, even though the repository is a public repository.  When credentials are provided, the test only fails in about 20% of the cases.  The credentials I use for the test are narrowly scoped to exactly one repository and to only allow access to repository content.  Since the repository content is already publicly readable, the credential does not grant any additional permissions.

The ci.jenkins.io agents do not have the credential, so they will not run the test.

### Testing done

Confirmed that test fails consistently without credentials.

Confirmed that test fails in approximately 20% of cases when I use a range of agents including:

* Debian 11
* Debian 12
* Debian Testing
* openSUSE 15.6
* Red Hat Enterprise Linux 8
* Rocky Linux 9
* Ubuntu 22
* Ubuntu 24
* Windows

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
