### PR TITLE
Use system temporary directory for known_hosts file

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2130,7 +2130,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     userName = sshUser.getUsername();
                 }
                 passphrase = createPassphraseFile(sshUser);
-                knownHostsTemp = createTempFile("known_hosts", "");
+                /* ssh.exe 9.5 on Windows does not accept spaces in path to known_hosts.
+                 * Use temp file wrapper location because known_hosts is not sensitive info.
+                 */
+                knownHostsTemp = createTempFileForWrapper("known_hosts", "");
                 if (launcher.isUnix()) {
                     ssh = createUnixGitSSH(key, userName, knownHostsTemp);
                     askpass = createUnixSshAskpass(sshUser, passphrase);


### PR DESCRIPTION
## Use system temporary directory for known_hosts file

Windows ssh.exe 9.5p1 and ssh.exe 9.5p2 will not read the known_hosts file if there is a space character in the path to the file.

Since we already use the system temporary directory for other scripts that do not contain sensitive information, we'll use it for the known_hosts file as well.  The contents of the known_hosts file is not sensitive information.

Fixes #1703

Amends 5a271e5d1d08bd45cdb3c3541856d2dc2abf0dbc

### Testing done

* Confirmed that without this change, Windows ssh.exe does not read the known_hosts file when using a manually verified known_hosts file from a workspace that has spaces in its absolute path.
* Confirmed that with this change, Windows ssh.exe reads the known_hosts file when using a manually verified known_hosts file from a workspace that has spaces in its absolute path.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~Ensure you have provided tests that demonstrate the feature works or the issue is fixed~
