### PR TITLE
Sanitize paths for SSH data

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1982,6 +1982,18 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
 
         File workspaceTmp = new File(workspace.getAbsolutePath() + WorkspaceList.TMP_DIR_SUFFIX);
+        String absolutePath = workspaceTmp.getAbsolutePath();
+        if (absolutePath.contains("%")) {
+            // Do not create temporary file in a path that includes a '%' character because
+            // SSH attempts to expand '%' characters in its file arguments
+            // https://man.openbsd.org/ssh_config#TOKENS
+            return createTempFileInSystemDir(prefix, suffix);
+        }
+        if (isWindows() && (absolutePath.contains(" ") || absolutePath.contains("(") || absolutePath.contains(")"))) {
+            // Do not create temporary file in a Windows path that includes a known problem character.
+            // Breaks SSH argument passing through GIT_SSH and SSH_ASKPASS.
+            return createTempFileInSystemDir(prefix, suffix);
+        }
         if (!workspaceTmp.isDirectory() && !workspaceTmp.mkdirs()) {
             if (!workspaceTmp.isDirectory()) {
                 return createTempFileInSystemDir(prefix, suffix);


### PR DESCRIPTION
## Sanitize paths for SSH data

SSH has special rules related to '%' characters in its file name arguments.  Refer to the ssh_config man page for its descriptions of tokens:

https://man.openbsd.org/ssh_config#TOKENS

If the absolute path to the temporary file for the private key includes a '%' character, then use the system temporary directory instead.

Likewise if the absolute path to the Windows temporary file for the private key includes a ' ', a '(', or a ')', then use the system temporary directory.  

Windows

Makes the createTempFile() implementation match the comment.

Fixes #1704

Fixes #1710

Amends 5a271e5d1d08bd45cdb3c3541856d2dc2abf0dbc

### Testing done

* Confirmed that I can duplicate the bug with a multibranch Pipeline cloned through an SSH URL when one of the branches in the repository contains a '/' character.  In my test case, I used 'bug/git-cleint-plugin-1710' as the branch name
* Confirmed that the bug is resolved by this change

Multibranch Pipeline definition used for test:

```
pipeline {
    agent {
        label 'windows'
    }
    options {
        skipDefaultCheckout true
    }
    stages {
        stage('Checkout') {
            steps {
                ws('percent%2Fencoded') {
                    checkout scm
                }
                ws('a b') {
                    checkout scm
                }
                ws('c(') {
                    checkout scm
                }
                ws('d)') {
                    checkout scm
                }
                ws('e())') {
                    checkout scm
                }
                ws('f g') {
                    checkout scm
                }
            }
        }
    }
}
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
