### PR TITLE
Revert "[JENKINS-72450] Support alternate ssh implementations on Windows"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -2626,15 +2626,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             return sshexe;
         }
 
-        // Check for ssh.exe on the system PATH (supports Microsoft OpenSSH and other alternate implementations)
-        String sshPath = getPathToExe("ssh");
-        if (sshPath != null) {
-            sshexe = new File(sshPath);
-            if (sshexe.exists()) {
-                return sshexe;
-            }
-        }
-
         // Check Program Files
         sshexe = getFileFromEnv("ProgramFiles", "\\Git\\bin\\ssh.exe");
         if (sshexe != null && sshexe.exists()) {


### PR DESCRIPTION
## Revert "[JENKINS-72450] Support alternate ssh implementations on Windows"

Windows OpenSSH hangs during `git fetch` when used from a Jenkins agent started using the "SSH launcher" to connect to the Windows OpenSSH server on Windows 10 and Windows 11.

Notes on the testing are in issue:

* https://github.com/jenkinsci/git-client-plugin/issues/1715

Reopens issue:

* https://github.com/jenkinsci/git-client-plugin/issues/1668

Reverts pull request:

* https://github.com/jenkinsci/git-client-plugin/pull/1706

### Testing done

* Confirmed that the hang during git fetch is resolved (interactive testing)
* Confirmed that automated tests pass

This reverts commit cd347714f0e2ad883def3b4389896c0192da07ea.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~Ensure you have provided tests that demonstrate the feature works or the issue is fixed~
