### PR TITLE
[JENKINS-70094] Add support for partial clone

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -599,10 +599,36 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     args.add("--depth=" + depth);
                 }
 
-                if (filterSpec != null && isAtLeastVersion(2, 22, 0, 0)) {
-                    // in the future, we could add --refetch if we detect a change in the filter configuration to
-                    // trigger maintenance
-                    args.add("--filter=" + filterSpec);
+                if (filterSpec != null) {
+                    // try to get the current filterspec
+                    String currentFilterSpec = null;
+                    String defaultRemote = null;
+                    try {
+                        defaultRemote = getDefaultRemote();
+                        if (defaultRemote != null && !defaultRemote.isEmpty()) {
+                            currentFilterSpec = launchCommand(
+                                "config", "remote." + defaultRemote + ".partialclonefilter");
+                        }
+                        // We might fail if we have no modules, so catch this
+                        // exception and just return.
+                    } catch (GitException e) {
+                        // leave currentFilterSpec null
+                    }
+
+                    if (isAtLeastVersion(2, 22, 0, 0)) {
+                        args.add("--filter=" + filterSpec);
+                    }
+
+                    // if the filterspec has changed
+                    if (defaultRemote != null && !filterSpec.equals(currentFilterSpec)) {
+                        launchCommand("config", "--add", "remote." + defaultRemote + ".promisor", "true");
+                        launchCommand("config", "--add", "remote." + defaultRemote + ".partialclonefilter", filterSpec);
+
+                        if (isAtLeastVersion(2, 36, 0, 0)) {
+                            // reapply filter and trigger maintenance
+                            args.add("--refetch");
+                        }
+                    }
                 }
 
                 warnIfWindowsTemporaryDirNameHasSpaces();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1786,6 +1786,15 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return new File(workspace, pathJoin(".git", "shallow")).exists();
     }
 
+    /** Returns true if the remote has a promisor configured for missing blobs. */
+    public boolean hasPromisor(String name) throws GitException, InterruptedException {
+        try {
+            return launchCommand("config", "remote." + name + ".promisor").contains("true");
+        } catch (GitException ge) {
+            return false;
+        }
+    }
+
     private String pathJoin(String a, String b) {
         return new File(a, b).toString();
     }
@@ -2115,6 +2124,17 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @NonNull URIish url,
             Integer timeout)
             throws GitException, InterruptedException {
+        return launchCommandWithCredentials(args, workDir, environment, credentials, url, timeout);
+    }
+
+    private String launchCommandWithCredentials(
+            ArgumentListBuilder args,
+            File workDir,
+            EnvVars env,
+            StandardCredentials credentials,
+            @NonNull URIish url,
+            Integer timeout)
+            throws GitException, InterruptedException {
 
         Path key = null;
         Path ssh = null;
@@ -2123,7 +2143,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         Path passwordFile = null;
         Path passphrase = null;
         Path knownHostsTemp = null;
-        EnvVars env = environment;
         if (!PROMPT_FOR_AUTHENTICATION && isAtLeastVersion(2, 3, 0, 0)) {
             env = new EnvVars(env);
             env.put("GIT_TERMINAL_PROMPT", "false"); // Don't prompt for auth from command line git
@@ -3204,7 +3223,32 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         args.add("-f");
                     }
                     args.add(ref);
-                    launchCommandIn(args, workspace, checkoutEnv, timeout);
+
+                    String repoUrl = null;
+                    try {
+                        String defaultRemote = getDefaultRemote();
+                        if (defaultRemote != null && !defaultRemote.isEmpty() && hasPromisor(defaultRemote)) {
+                            repoUrl = getRemoteUrl(defaultRemote);
+                        }
+                    } catch (GitException e) {
+                        /* Nothing to do, just keeping repoUrl = null */
+                    }
+
+                    if (repoUrl != null) {
+                        StandardCredentials cred = credentials.get(repoUrl);
+                        if (cred == null) {
+                            cred = defaultCredentials;
+                        }
+
+                        try {
+                            launchCommandWithCredentials(
+                                    args, workspace, checkoutEnv, cred, new URIish(repoUrl), timeout);
+                        } catch (URISyntaxException e) {
+                            throw new GitException("Invalid URL " + repoUrl, e);
+                        }
+                    } else {
+                        launchCommandIn(args, workspace, checkoutEnv, timeout);
+                    }
 
                     if (lfsRemote != null) {
                         final String url = getRemoteUrl(lfsRemote);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -606,8 +606,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                     try {
                         defaultRemote = getDefaultRemote();
                         if (defaultRemote != null && !defaultRemote.isEmpty()) {
-                            currentFilterSpec = launchCommand(
-                                "config", "remote." + defaultRemote + ".partialclonefilter");
+                            currentFilterSpec =
+                                    launchCommand("config", "remote." + defaultRemote + ".partialclonefilter");
                         }
                         // We might fail if we have no modules, so catch this
                         // exception and just return.

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -522,6 +522,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private Integer timeout;
             private boolean tags = true;
             private Integer depth = 1;
+            private String filterSpec = null;
 
             @Override
             public FetchCommand from(URIish remote, List<RefSpec> refspecs) {
@@ -567,6 +568,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
+            public FetchCommand filter(String filterSpec) {
+                this.filterSpec = filterSpec;
+                return this;
+            }
+
+            @Override
             public void execute() throws GitException, InterruptedException {
                 listener.getLogger().println("Fetching upstream changes from " + url);
 
@@ -590,6 +597,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         depth = 1;
                     }
                     args.add("--depth=" + depth);
+                }
+
+                if (filterSpec != null && isAtLeastVersion(2, 22, 0, 0)) {
+                    // in the future, we could add --refetch if we detect a change in the filter configuration to
+                    // trigger maintenance
+                    args.add("--filter=" + filterSpec);
                 }
 
                 warnIfWindowsTemporaryDirNameHasSpaces();
@@ -727,6 +740,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             private boolean tags = true;
             private List<RefSpec> refspecs;
             private Integer depth = 1;
+            private String filterSpec = null;
 
             @Override
             public CloneCommand url(String url) {
@@ -803,6 +817,12 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
+            public CloneCommand filter(String filterSpec) {
+                this.filterSpec = filterSpec;
+                return this;
+            }
+
+            @Override
             public void execute() throws GitException, InterruptedException {
 
                 URIish urIish = null;
@@ -872,9 +892,14 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 if (refspecs == null) {
                     refspecs = Collections.singletonList(new RefSpec("+refs/heads/*:refs/remotes/" + origin + "/*"));
                 }
+                if (filterSpec != null) {
+                    launchCommand("config", "--add", "remote." + origin + ".promisor", "true");
+                    launchCommand("config", "--add", "remote." + origin + ".partialclonefilter", filterSpec);
+                }
                 fetch_().from(urIish, refspecs)
                         .shallow(shallow)
                         .depth(depth)
+                        .filter(filterSpec)
                         .timeout(timeout)
                         .tags(tags)
                         .execute();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -609,8 +609,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                             currentFilterSpec =
                                     launchCommand("config", "remote." + defaultRemote + ".partialclonefilter");
                         }
-                        // We might fail if we have no modules, so catch this
-                        // exception and just return.
+                        // we might fail if we have no promisor configured, catch the exception and just continue
                     } catch (GitException e) {
                         // leave currentFilterSpec null
                     }
@@ -1813,7 +1812,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /** Returns true if the remote has a promisor configured for missing blobs. */
-    public boolean hasPromisor(String name) throws GitException, InterruptedException {
+    boolean hasPromisor(String name) throws GitException, InterruptedException {
         try {
             return launchCommand("config", "remote." + name + ".promisor").contains("true");
         } catch (GitException ge) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -621,8 +621,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                     // if the filterspec has changed
                     if (defaultRemote != null && !filterSpec.equals(currentFilterSpec)) {
-                        launchCommand("config", "--add", "remote." + defaultRemote + ".promisor", "true");
-                        launchCommand("config", "--add", "remote." + defaultRemote + ".partialclonefilter", filterSpec);
+                        launchCommand("config", "remote." + defaultRemote + ".promisor", "true");
+                        launchCommand("config", "remote." + defaultRemote + ".partialclonefilter", filterSpec);
 
                         if (isAtLeastVersion(2, 36, 0, 0)) {
                             // reapply filter and trigger maintenance

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
@@ -114,4 +114,12 @@ public interface CloneCommand extends GitCommand {
      * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
      */
     CloneCommand depth(Integer depth);
+
+    /**
+     * Apply an object filter to a partial clone. If unset, a full clone is performed.
+     *
+     * @param filterSpec filter of objects to be sent by the server
+     * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
+     */
+    CloneCommand filter(String filterSpec);
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
@@ -120,6 +120,7 @@ public interface CloneCommand extends GitCommand {
      *
      * @param filterSpec filter of objects to be sent by the server
      * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
+     * @since 6.7.0
      */
     CloneCommand filter(String filterSpec);
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
@@ -64,4 +64,12 @@ public interface FetchCommand extends GitCommand {
      * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
      */
     FetchCommand depth(Integer depth);
+
+    /**
+     * Apply an object filter to a partial clone. If unset, a full clone is performed.
+     *
+     * @param filterSpec filter of objects to be sent by the server
+     * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
+     */
+    FetchCommand filter(String filterSpec);
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
@@ -70,6 +70,7 @@ public interface FetchCommand extends GitCommand {
      *
      * @param filterSpec filter of objects to be sent by the server
      * @return a {@link org.jenkinsci.plugins.gitclient.CloneCommand} object.
+     * @since 6.7.0
      */
     FetchCommand filter(String filterSpec);
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -788,7 +788,10 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public org.jenkinsci.plugins.gitclient.FetchCommand filter(String filterSpec) {
-                // unsupported, revert to full clone for backward compatibility
+                if (filterSpec != null) {
+                    listener.getLogger()
+                            .println("[WARNING] JGit does not support partial clone filters; reverting to full clone");
+                }
                 return this;
             }
 
@@ -1646,7 +1649,10 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
             @Override
             public CloneCommand filter(String filterSpec) {
-                // unsupported, revert to full clone for backward compatibility
+                if (filterSpec != null) {
+                    listener.getLogger()
+                            .println("[WARNING] JGit does not support partial clone filters; reverting to full clone");
+                }
                 return this;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -787,6 +787,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             @Override
+            public org.jenkinsci.plugins.gitclient.FetchCommand filter(String filterSpec) {
+                // unsupported, revert to full clone for backward compatibility
+                return this;
+            }
+
+            @Override
             public void execute() throws GitException {
                 try (Repository repo = getRepository()) {
                     Git git = git(repo);
@@ -1635,6 +1641,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             @Override
             public CloneCommand depth(Integer depth) {
                 this.depth = depth;
+                return this;
+            }
+
+            @Override
+            public CloneCommand filter(String filterSpec) {
+                // unsupported, revert to full clone for backward compatibility
                 return this;
             }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -516,6 +516,38 @@ class CredentialsTest {
                 "Fast-forward merge failed. master and modified_lfs should be the same.");
     }
 
+    @Test
+    @Issue("JENKINS-70094")
+    void testCheckoutPartialCloneWithCredentials() throws Exception {
+        if (testPeriodExpired() || lfsSpecificTest) {
+            return;
+        }
+        File clonedFile = new File(repo, fileToCheck);
+        git.init_().workspace(repo.getAbsolutePath()).execute();
+        assertFalse(clonedFile.exists(), "file " + fileToCheck + " in " + repo + ", has " + listDir(repo));
+        addCredential();
+        // clone with remote url
+        git.clone_()
+                .url(gitRepoURL)
+                .repositoryName("origin")
+                .filter("blob:none")
+                .execute();
+        ObjectId master = git.getHeadRev(gitRepoURL, "master");
+        git.checkout()
+                .branch("master")
+                .ref(master.getName())
+                .deleteBranchIfExist(true)
+                .execute();
+        assertTrue(git.isCommitInRepo(master), "master: " + master + " not in repo");
+        assertEquals(
+                master,
+                git.withRepository(
+                        (gitRepo, unusedChannel) -> gitRepo.findRef("master").getObjectId()),
+                "Master != HEAD");
+        assertEquals("master", git.withRepository((gitRepo, unusedChanel) -> gitRepo.getBranch()), "Wrong branch");
+        assertTrue(clonedFile.exists(), "No file " + fileToCheck + ", has " + listDir(repo));
+    }
+
     private static boolean isWindows() {
         return File.pathSeparatorChar == ';';
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -432,22 +432,23 @@ class GitClientCloneTest {
     @Test
     @Issue("JENKINS-70094")
     public void test_clone_filter() throws Exception {
-        CloneCommand cmd = testGitClient
+        WorkspaceWithRepo anotherWorkspace = new WorkspaceWithRepo(secondRepo.getRoot(), "git", listener);
+        GitClient anotherGitClient = anotherWorkspace.getGitClient();
+        CloneCommand cmd = anotherGitClient
                 .clone_()
-                .url(workspace.localMirror())
+                .url(anotherWorkspace.localMirror())
                 .repositoryName("origin")
                 .filter("blob:none");
         cmd.execute();
-        testGitClient.checkout().ref("origin/master").branch("master").execute();
-        check_remote_url(workspace, testGitClient, "origin");
-        assertBranchesExist(testGitClient.getBranches(), "master");
+        anotherGitClient.checkout().ref("origin/master").branch("master").execute();
+        check_remote_url(anotherWorkspace, anotherGitClient, "origin");
+        assertBranchesExist(anotherGitClient.getBranches(), "master");
         assertAlternatesFileNotFound();
-        boolean expectedPromisorValue = gitImplName.equals("git");
-        assertThat("hasPromisor?", workspace.cgit().hasPromisor("origin"), is(expectedPromisorValue));
         if (gitImplName.equals("git")) {
-            String filterSpec = workspace.launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter").trim();
+            assertThat("hasPromisor?", anotherWorkspace.cgit().hasPromisor("origin"), is(true));
+            String filterSpec = anotherWorkspace.launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter").trim();
             assertThat("filterSpec", filterSpec, is("blob:none"));
-            //assertPromisorFilesExist();
+            assertPromisorFilesExist(anotherWorkspace.getGitFileDir());
         }
     }
 
@@ -457,8 +458,8 @@ class GitClientCloneTest {
         assertThat(new File(testGitDir, alternates), is(anExistingFile()));
     }
 
-    private void assertPromisorFilesExist() {
-        File pack = new File(".git" + File.separator + "objects" + File.separator + "pack");
+    private void assertPromisorFilesExist(File anotherTestGitDir) {
+        File pack = new File(anotherTestGitDir, ".git" + File.separator + "objects" + File.separator + "pack");
         File[] promisors = pack.listFiles(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -17,6 +17,8 @@ import hudson.plugins.git.GitException;
 import hudson.remoting.VirtualChannel;
 import hudson.util.StreamTaskListener;
 import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -427,10 +429,43 @@ class GitClientCloneTest {
         assertTimeout(testGitClient, "fetch", expectedValue);
     }
 
+    @Test
+    @Issue("JENKINS-70094")
+    public void test_clone_filter() throws Exception {
+        CloneCommand cmd = testGitClient
+                .clone_()
+                .url(workspace.localMirror())
+                .repositoryName("origin")
+                .filter("blob:none");
+        cmd.execute();
+        testGitClient.checkout().ref("origin/master").branch("master").execute();
+        check_remote_url(workspace, testGitClient, "origin");
+        assertBranchesExist(testGitClient.getBranches(), "master");
+        assertAlternatesFileNotFound();
+        boolean expectedPromisorValue = gitImplName.equals("git");
+        assertThat("hasPromisor?", workspace.cgit().hasPromisor("origin"), is(expectedPromisorValue));
+        if (gitImplName.equals("git")) {
+            String filterSpec = workspace.launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter").trim();
+            assertThat("filterSpec", filterSpec, is("blob:none"));
+            //assertPromisorFilesExist();
+        }
+    }
+
     private void assertAlternatesFileExists() {
         final String alternates =
                 ".git" + File.separator + "objects" + File.separator + "info" + File.separator + "alternates";
         assertThat(new File(testGitDir, alternates), is(anExistingFile()));
+    }
+
+    private void assertPromisorFilesExist() {
+        File pack = new File(".git" + File.separator + "objects" + File.separator + "pack");
+        File[] promisors = pack.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith(".promisor");
+            }
+        });
+        assertThat(promisors, is(not(emptyArray())));
     }
 
     private void assertAlternatesFileNotFound() {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -18,7 +18,6 @@ import hudson.remoting.VirtualChannel;
 import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.io.FilenameFilter;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -42,6 +41,7 @@ import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.jvnet.hudson.test.Issue;
 
 @ParameterizedClass(name = "{0}")
 @MethodSource("gitObjects")
@@ -446,7 +446,9 @@ class GitClientCloneTest {
         assertAlternatesFileNotFound();
         if (gitImplName.equals("git")) {
             assertThat("hasPromisor?", anotherWorkspace.cgit().hasPromisor("origin"), is(true));
-            String filterSpec = anotherWorkspace.launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter").trim();
+            String filterSpec = anotherWorkspace
+                    .launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter")
+                    .trim();
             assertThat("filterSpec", filterSpec, is("blob:none"));
             assertPromisorFilesExist(anotherWorkspace.getGitFileDir());
         }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientCloneTest.java
@@ -17,7 +17,6 @@ import hudson.plugins.git.GitException;
 import hudson.remoting.VirtualChannel;
 import hudson.util.StreamTaskListener;
 import java.io.File;
-import java.io.FilenameFilter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -431,7 +430,7 @@ class GitClientCloneTest {
 
     @Test
     @Issue("JENKINS-70094")
-    public void test_clone_filter() throws Exception {
+    void test_clone_filter() throws Exception {
         WorkspaceWithRepo anotherWorkspace = new WorkspaceWithRepo(secondRepo.getRoot(), "git", listener);
         GitClient anotherGitClient = anotherWorkspace.getGitClient();
         CloneCommand cmd = anotherGitClient
@@ -443,7 +442,6 @@ class GitClientCloneTest {
         anotherGitClient.checkout().ref("origin/master").branch("master").execute();
         check_remote_url(anotherWorkspace, anotherGitClient, "origin");
         assertBranchesExist(anotherGitClient.getBranches(), "master");
-        assertAlternatesFileNotFound();
         if (gitImplName.equals("git")) {
             assertThat("hasPromisor?", anotherWorkspace.cgit().hasPromisor("origin"), is(true));
             String filterSpec = anotherWorkspace
@@ -462,12 +460,7 @@ class GitClientCloneTest {
 
     private void assertPromisorFilesExist(File anotherTestGitDir) {
         File pack = new File(anotherTestGitDir, ".git" + File.separator + "objects" + File.separator + "pack");
-        File[] promisors = pack.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(File dir, String name) {
-                return name.endsWith(".promisor");
-            }
-        });
+        File[] promisors = pack.listFiles((dir, name) -> name.endsWith(".promisor"));
         assertThat(promisors, is(not(emptyArray())));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -630,11 +630,17 @@ class GitClientFetchTest {
                 .filter("blob:none")
                 .execute();
         checkoutRandomBranch();
-        testGitClient.fetch_().from(new URIish("origin"), null).filter("blob:limit=1k").execute();
+        testGitClient
+                .fetch_()
+                .from(new URIish("origin"), null)
+                .filter("blob:limit=1k")
+                .execute();
         boolean expectedPromisorValue = gitImplName.equals("git");
         assertThat("hasPromisor?", workspace.cgit().hasPromisor("origin"), is(expectedPromisorValue));
         if (gitImplName.equals("git")) {
-            String filterSpec = workspace.launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter").trim();
+            String filterSpec = workspace
+                    .launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter")
+                    .trim();
             assertThat("filterSpec", filterSpec, is("blob:limit=1k"));
         }
     }
@@ -653,15 +659,23 @@ class GitClientFetchTest {
         boolean expectedPromisorValue = gitImplName.equals("git");
         assertThat("hasPromisor?", workspace.cgit().hasPromisor("origin"), is(expectedPromisorValue));
         if (gitImplName.equals("git")) {
-            String filterSpec = workspace.launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter").trim();
+            String filterSpec = workspace
+                    .launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter")
+                    .trim();
             assertThat("filterSpec", filterSpec, is("tree:0"));
         }
-        testGitClient.fetch_().from(new URIish("origin"), null).filter("blob:limit=1k").execute();
+        testGitClient
+                .fetch_()
+                .from(new URIish("origin"), null)
+                .filter("blob:limit=1k")
+                .execute();
         if (gitImplName.equals("git")) {
-                String filterSpec = workspace.launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter").trim();
-                assertThat("filterSpec", filterSpec, is("blob:limit=1k"));
-            }
+            String filterSpec = workspace
+                    .launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter")
+                    .trim();
+            assertThat("filterSpec", filterSpec, is("blob:limit=1k"));
         }
+    }
 
     private void check_remote_url(WorkspaceWithRepo workspace, GitClient gitClient, final String repositoryName)
             throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -622,7 +622,7 @@ class GitClientFetchTest {
 
     @Test
     @Issue("JENKINS-70094")
-    public void test_fetch_filter() throws Exception {
+    void test_fetch_filter() throws Exception {
         testGitClient
                 .clone_()
                 .url(workspace.localMirror())
@@ -647,7 +647,7 @@ class GitClientFetchTest {
 
     @Test
     @Issue("JENKINS-70094")
-    public void test_fetch_filter_changed() throws Exception {
+    void test_fetch_filter_changed() throws Exception {
         testGitClient
                 .clone_()
                 .url(workspace.localMirror())

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -620,6 +620,25 @@ class GitClientFetchTest {
         assertRevParseNotCalled(testGitClient, randomBranchName);
     }
 
+    @Test
+    @Issue("JENKINS-70094")
+    public void test_fetch_filter() throws Exception {
+        testGitClient
+                .clone_()
+                .url(workspace.localMirror())
+                .repositoryName("origin")
+                .filter("blob:none")
+                .execute();
+        checkoutRandomBranch();
+        testGitClient.fetch_().from(new URIish("origin"), null).filter("blob:limit=1k").execute();
+        boolean expectedPromisorValue = gitImplName.equals("git");
+        assertThat("hasPromisor?", workspace.cgit().hasPromisor("origin"), is(expectedPromisorValue));
+        if (gitImplName.equals("git")) {
+            String filterSpec = workspace.launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter").trim();
+            assertThat("filterSpec", filterSpec, is("blob:limit=1k"));
+        }
+    }
+
     private void check_remote_url(WorkspaceWithRepo workspace, GitClient gitClient, final String repositoryName)
             throws Exception {
         assertThat("Wrong remote URL", gitClient.getRemoteUrl(repositoryName), is(workspace.localMirror()));

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitClientFetchTest.java
@@ -639,6 +639,30 @@ class GitClientFetchTest {
         }
     }
 
+    @Test
+    @Issue("JENKINS-70094")
+    public void test_fetch_filter_changed() throws Exception {
+        testGitClient
+                .clone_()
+                .url(workspace.localMirror())
+                .repositoryName("origin")
+                .filter("blob:none")
+                .execute();
+        checkoutRandomBranch();
+        testGitClient.fetch_().from(new URIish("origin"), null).filter("tree:0").execute();
+        boolean expectedPromisorValue = gitImplName.equals("git");
+        assertThat("hasPromisor?", workspace.cgit().hasPromisor("origin"), is(expectedPromisorValue));
+        if (gitImplName.equals("git")) {
+            String filterSpec = workspace.launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter").trim();
+            assertThat("filterSpec", filterSpec, is("tree:0"));
+        }
+        testGitClient.fetch_().from(new URIish("origin"), null).filter("blob:limit=1k").execute();
+        if (gitImplName.equals("git")) {
+                String filterSpec = workspace.launchCommand("git", "config", "remote." + "origin" + ".partialclonefilter").trim();
+                assertThat("filterSpec", filterSpec, is("blob:limit=1k"));
+            }
+        }
+
     private void check_remote_url(WorkspaceWithRepo workspace, GitClient gitClient, final String repositoryName)
             throws Exception {
         assertThat("Wrong remote URL", gitClient.getRemoteUrl(repositoryName), is(workspace.localMirror()));


### PR DESCRIPTION
Closes [#3771](https://github.com/jenkinsci/git-plugin/issues/3771)
Adds support of partial clone by providing a filterspec to a repository configuration
- performed by setting remote.<origin>.promisor and remote.<origin>.partialCloneFilter in the clone configuration
- detect changes requested of the filterspec and perform --refetch as needed
- revert to full clone if unsupported by the git implementation
- automatically detect during checkout if the repository is a partial clone and provides credentials if needed

This PR is I think more complete than [#1131](https://github.com/jenkinsci/git-client-plugin/pull/1131).

### Testing done

Added functional tests
- test with a filter spec (on jgit, will revert to a test with a full clone)
- test with credentials
- test with changed filterspec

Currently being tested in a production server with a GB-sized repository

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
