### PR TITLE
Make PushTest more reliable

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
@@ -136,7 +136,7 @@ class PushTest {
     void createWorkingRepository() throws Exception {
         hudson.EnvVars env = new hudson.EnvVars();
         TaskListener listener = StreamTaskListener.fromStderr();
-        workingRepo = newFolder(temporaryFolder, "junit-" + System.nanoTime());
+        workingRepo = newFolder(temporaryFolder, "PushTest-" + System.nanoTime());
         workingGitClient =
                 Git.with(listener, env).in(workingRepo).using(gitImpl).getClient();
         workingGitClient
@@ -165,8 +165,7 @@ class PushTest {
     @AfterEach
     void verifyPushResultAndDeleteDirectory(TestInfo info) throws Exception {
         /* Confirm push reached bare repo */
-        if (expectedException == null
-                && !info.getTestMethod().orElseThrow().getName().contains("Throws")) {
+        if (expectedException == null) {
             ObjectId latestBareHead = bareGitClient.getHeadRev(bareRepo.getAbsolutePath(), branchName);
             assertEquals(workingCommit, latestBareHead, branchName + " commit not pushed to " + refSpec);
             assertNotEquals(previousCommit, workingCommit);
@@ -176,23 +175,18 @@ class PushTest {
 
     @BeforeAll
     static void createBareRepository() throws Exception {
-        /* Randomly choose git implementation to create bare repository */
-        final String[] gitImplementations = {"git", "jgit"};
-        Random random = new Random();
-        String gitImpl = gitImplementations[random.nextInt(gitImplementations.length)];
-
         /* Create the bare repository */
-        bareRepo = newFolder(staticTemporaryFolder, "junit-" + System.nanoTime());
+        bareRepo = newFolder(staticTemporaryFolder, "PushTest-" + System.nanoTime());
         bareURI = new URIish(bareRepo.getAbsolutePath());
         hudson.EnvVars env = new hudson.EnvVars();
         TaskListener listener = StreamTaskListener.fromStderr();
-        bareGitClient = Git.with(listener, env).in(bareRepo).using(gitImpl).getClient();
+        bareGitClient = Git.with(listener, env).in(bareRepo).using("git").getClient();
         bareGitClient.init_().workspace(bareRepo.getAbsolutePath()).bare(true).execute();
 
         /* Clone the bare repository into a working copy */
-        File cloneRepo = newFolder(staticTemporaryFolder, "junit-" + System.nanoTime());
+        File cloneRepo = newFolder(staticTemporaryFolder, "PushTest-" + System.nanoTime());
         GitClient cloneGitClient =
-                Git.with(listener, env).in(cloneRepo).using(gitImpl).getClient();
+                Git.with(listener, env).in(cloneRepo).using("git").getClient();
         cloneGitClient
                 .clone_()
                 .url(bareRepo.getAbsolutePath())

--- a/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/PushTest.java
@@ -111,7 +111,8 @@ class PushTest {
             "this/ref/does/not/exist", "src/ref/does/not/exist:dest/ref/does/not/exist"
         };
 
-        shuffleArray(implementations);
+        // Run command line git tests first, no shuffling
+        // shuffleArray(implementations);
         shuffleArray(goodRefSpecs);
         shuffleArray(badRefSpecs);
 


### PR DESCRIPTION
## Make PushTest more reliable

CLI git tests first in PushTest

JGit 7.7.0 and 7.7.1 occasionally fail test cleanup in PushTest.  This change, combined with the preceding commit to create the bare repository with command line git reduced the failure rate to 1 failure in 25 runs across my 6 Windows agents.

Create bare repository with command line git in PushTest

Reduce the risk of a JGit file leak in the test.  JGit 7.7.0 and 7.7.1 have occasional failures in the cleanup from PushTest.  This change reduces the failure rate.

### Testing done

* Confirmed that failure rate dropped significantly with this change

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
