### PR TITLE
Remove unknown javadoc parameters for maven javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,9 +276,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <fixTags>param,return,throws,link</fixTags>
           <author>false</author>
-          <force>true</force>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
## Remove unknown javadoc parameters for maven javadoc plugin

Removes plugin compilation warning:

```
[WARNING] Parameter 'fixTags' is unknown for plugin 'maven-javadoc-plugin:3.12.0:javadoc (default-cli)'
[WARNING] Parameter 'force' is unknown for plugin 'maven-javadoc-plugin:3.12.0:javadoc (default-cli)'
```

### Testing done

* Compared before and after and confirmed that files are consistent

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
